### PR TITLE
fix: code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/testing/platform/pgtesting/postgres.go
+++ b/testing/platform/pgtesting/postgres.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"math"
 )
 
 type T interface {
@@ -63,9 +64,12 @@ type PostgresServer struct {
 }
 
 func (s *PostgresServer) GetPort() int {
-	v, err := strconv.ParseInt(s.Port, 10, 64)
+	v, err := strconv.ParseInt(s.Port, 10, 32)
 	if err != nil {
 		panic(err)
+	}
+	if v < math.MinInt32 || v > math.MaxInt32 {
+		panic(fmt.Sprintf("Port value out of range: %d", v))
 	}
 	return int(v)
 }


### PR DESCRIPTION
Fixes [https://github.com/formancehq/go-libs/security/code-scanning/1](https://github.com/formancehq/go-libs/security/code-scanning/1)

To fix the problem, we need to ensure that the conversion from a 64-bit integer to a smaller integer type is safe. This can be done by specifying the correct bit size when parsing the integer and adding bounds checking to ensure the value fits within the target type's range.

1. Use `strconv.ParseInt` with a bit size of 32 to directly parse the integer as a 32-bit value.
2. Add bounds checking to ensure the parsed value fits within the range of the `int` type.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
