### PR TITLE
feat: (payments) Add hclog logger adapter for use in connector plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/invopop/jsonschema v0.12.0
 	github.com/jackc/pgx/v5 v5.7.1

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a h1:yDWHCSQ40h88yih2JAcL6Ls/kVkSE8GFACTGVnMPruw=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -268,8 +269,12 @@ github.com/lufia/plan9stats v0.0.0-20240909124753-873cd0166683 h1:7UMa6KCCMjZEMD
 github.com/lufia/plan9stats v0.0.0-20240909124753-873cd0166683/go.mod h1:ilwx/Dta8jXAgpFYFvSWEMwxmbWXyiUHkd5FwyKhb5k=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
@@ -367,6 +372,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
@@ -536,6 +542,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -544,7 +552,10 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/logging/adapter_hclog.go
+++ b/logging/adapter_hclog.go
@@ -14,13 +14,11 @@ type HcLogLoggerAdapter struct {
 	backend hclog.Logger
 
 	hooks []string
-	opts  *hclog.LoggerOptions
 }
 
 // NewLogger returns new logging.Logger using passed *hclog.Logger as backend.
-func NewHcLogLoggerAdapter(opts *hclog.LoggerOptions, hookKeys []string) Logger {
-	z := hclog.New(opts)
-	return &HcLogLoggerAdapter{backend: z, opts: opts, hooks: hookKeys}
+func NewHcLogLoggerAdapter(z hclog.Logger, hookKeys []string) Logger {
+	return &HcLogLoggerAdapter{backend: z, hooks: hookKeys}
 }
 
 func (l *HcLogLoggerAdapter) parseArgs(args []any) (msg string, ret []any) {
@@ -74,7 +72,6 @@ func (l *HcLogLoggerAdapter) WithFields(fields map[string]any) Logger {
 		ctx:     l.ctx,
 		backend: l.backend.With(args...),
 		hooks:   l.hooks,
-		opts:    l.opts,
 	}
 }
 
@@ -83,7 +80,6 @@ func (l *HcLogLoggerAdapter) WithField(key string, val any) Logger {
 		ctx:     l.ctx,
 		backend: l.backend.With(key, val),
 		hooks:   l.hooks,
-		opts:    l.opts,
 	}
 }
 
@@ -92,7 +88,6 @@ func (l *HcLogLoggerAdapter) WithContext(ctx context.Context) Logger {
 		ctx:     ctx,
 		backend: l.backend,
 		hooks:   l.hooks,
-		opts:    l.opts,
 	}
 }
 
@@ -114,5 +109,5 @@ func (l *HcLogLoggerAdapter) fireHooks() hclog.Logger {
 }
 
 func (l *HcLogLoggerAdapter) Writer() io.Writer {
-	return l.opts.Output
+	return l.backend.StandardWriter(&hclog.StandardLoggerOptions{})
 }

--- a/logging/adapter_hclog.go
+++ b/logging/adapter_hclog.go
@@ -1,0 +1,118 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+// Logger implements logging.Logger with *hclog.Logger.
+type HcLogLoggerAdapter struct {
+	ctx     context.Context
+	backend hclog.Logger
+
+	hooks []string
+	opts  *hclog.LoggerOptions
+}
+
+// NewLogger returns new logging.Logger using passed *hclog.Logger as backend.
+func NewHcLogLoggerAdapter(opts *hclog.LoggerOptions, hookKeys []string) Logger {
+	z := hclog.New(opts)
+	return &HcLogLoggerAdapter{backend: z, opts: opts, hooks: hookKeys}
+}
+
+func (l *HcLogLoggerAdapter) parseArgs(args []any) (msg string, ret []any) {
+	start := 0
+	if len(args) > 0 {
+		if str, ok := args[0].(string); ok {
+			msg = str
+			start++ // remove first argument
+		}
+	}
+	return msg, args[start:]
+}
+
+func (l *HcLogLoggerAdapter) Error(args ...any) {
+	msg, fields := l.parseArgs(args)
+	l.Errorf(msg, fields...)
+}
+
+func (l *HcLogLoggerAdapter) Errorf(msg string, args ...any) {
+	backend := l.fireHooks()
+	backend.Error(fmt.Sprintf(msg, args...))
+}
+
+func (l *HcLogLoggerAdapter) Info(args ...any) {
+	msg, fields := l.parseArgs(args)
+	l.Infof(msg, fields...)
+}
+
+func (l *HcLogLoggerAdapter) Infof(msg string, args ...any) {
+	backend := l.fireHooks()
+	backend.Info(fmt.Sprintf(msg, args...))
+}
+
+func (l *HcLogLoggerAdapter) Debug(args ...any) {
+	msg, fields := l.parseArgs(args)
+	l.Debugf(msg, fields...)
+}
+
+func (l *HcLogLoggerAdapter) Debugf(msg string, args ...any) {
+	backend := l.fireHooks()
+	backend.Debug(fmt.Sprintf(msg, args...))
+}
+
+func (l *HcLogLoggerAdapter) WithFields(fields map[string]any) Logger {
+	args := make([]any, 0, len(fields)*2)
+	for key, val := range fields {
+		args = append(args, key)
+		args = append(args, val)
+	}
+	return &HcLogLoggerAdapter{
+		ctx:     l.ctx,
+		backend: l.backend.With(args...),
+		hooks:   l.hooks,
+		opts:    l.opts,
+	}
+}
+
+func (l *HcLogLoggerAdapter) WithField(key string, val any) Logger {
+	return &HcLogLoggerAdapter{
+		ctx:     l.ctx,
+		backend: l.backend.With(key, val),
+		hooks:   l.hooks,
+		opts:    l.opts,
+	}
+}
+
+func (l *HcLogLoggerAdapter) WithContext(ctx context.Context) Logger {
+	return &HcLogLoggerAdapter{
+		ctx:     ctx,
+		backend: l.backend,
+		hooks:   l.hooks,
+		opts:    l.opts,
+	}
+}
+
+// fireHooks emulates logrus' hook feature
+func (l *HcLogLoggerAdapter) fireHooks() hclog.Logger {
+	if l.ctx == nil {
+		return l.backend
+	}
+	var args []any
+	for _, key := range l.hooks {
+		val := l.ctx.Value(key)
+		if val == nil {
+			continue
+		}
+		args = append(args, key)
+		args = append(args, val)
+	}
+	return l.backend.With(args...)
+}
+
+func (l *HcLogLoggerAdapter) Writer() io.Writer {
+	return l.opts.Output
+}

--- a/logging/adapter_hclog_test.go
+++ b/logging/adapter_hclog_test.go
@@ -19,7 +19,8 @@ func TestHcLogAdapterHook(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), hookKey, hookVal)
 	opts := &hclog.LoggerOptions{Level: hclog.Debug, Output: &buf}
-	logger := logging.NewHcLogLoggerAdapter(opts, []string{hookKey})
+	hl := hclog.New(opts)
+	logger := logging.NewHcLogLoggerAdapter(hl, []string{hookKey})
 	logger = logger.WithContext(ctx)
 
 	logger.Error("this is the message")

--- a/logging/adapter_hclog_test.go
+++ b/logging/adapter_hclog_test.go
@@ -1,0 +1,27 @@
+package logging_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/formancehq/go-libs/v2/logging"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHcLogAdapterHook(t *testing.T) {
+	var buf bytes.Buffer
+
+	hookKey := "hookKey"
+	hookVal := "hookVal"
+
+	ctx := context.WithValue(context.Background(), hookKey, hookVal)
+	opts := &hclog.LoggerOptions{Level: hclog.Debug, Output: &buf}
+	logger := logging.NewHcLogLoggerAdapter(opts, []string{hookKey})
+	logger = logger.WithContext(ctx)
+
+	logger.Error("this is the message")
+	assert.Regexp(t, fmt.Sprintf("%s=%s", hookKey, hookVal), buf.String())
+}

--- a/logging/adapter_logrus.go
+++ b/logging/adapter_logrus.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/uptrace/opentelemetry-go-extra/otellogrus"
 )
 
 type LogrusLogger struct {
@@ -89,7 +90,12 @@ func Testing() *LogrusLogger {
 	return NewLogrus(logger)
 }
 
-func NewDefaultLogger(w io.Writer, debug, formatJSON bool, hooks ...logrus.Hook) *LogrusLogger {
+func NewDefaultLogger(
+	w io.Writer,
+	debug,
+	formatJSON bool,
+	otelTraces string,
+) *LogrusLogger {
 	l := logrus.New()
 	l.SetOutput(w)
 	if debug {
@@ -107,10 +113,24 @@ func NewDefaultLogger(w io.Writer, debug, formatJSON bool, hooks ...logrus.Hook)
 	}
 
 	l.SetFormatter(formatter)
+	SetHooks(l, otelTraces)
 
+	return NewLogrus(l)
+}
+
+func SetHooks(l *logrus.Logger, otelTraces string) {
+	if otelTraces == "" {
+		return
+	}
+
+	hooks := make([]logrus.Hook, 0)
+	hooks = append(hooks, otellogrus.NewHook(otellogrus.WithLevels(
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+		logrus.WarnLevel,
+	)))
 	for _, hook := range hooks {
 		l.AddHook(hook)
 	}
-
-	return NewLogrus(l)
 }

--- a/logging/adapter_logrus.go
+++ b/logging/adapter_logrus.go
@@ -94,7 +94,7 @@ func NewDefaultLogger(
 	w io.Writer,
 	debug,
 	formatJSON bool,
-	otelTraces string,
+	otelTraces bool,
 ) *LogrusLogger {
 	l := logrus.New()
 	l.SetOutput(w)
@@ -118,8 +118,8 @@ func NewDefaultLogger(
 	return NewLogrus(l)
 }
 
-func SetHooks(l *logrus.Logger, otelTraces string) {
-	if otelTraces == "" {
+func SetHooks(l *logrus.Logger, otelTraces bool) {
+	if !otelTraces {
 		return
 	}
 

--- a/logging/context.go
+++ b/logging/context.go
@@ -12,7 +12,9 @@ var loggerKey contextKey = "_logger"
 func FromContext(ctx context.Context) Logger {
 	l := ctx.Value(loggerKey)
 	if l == nil {
-		return NewDefaultLogger(os.Stderr, false, false)
+		// if a logger is not set in the context we initialize a new one without tracing hooks configured
+		// this is mostly expected to happen in testing contexts as the app root should be propagating the logger when creating contexts
+		return NewDefaultLogger(os.Stderr, false, false, "")
 	}
 	return l.(Logger)
 }

--- a/logging/context.go
+++ b/logging/context.go
@@ -14,7 +14,7 @@ func FromContext(ctx context.Context) Logger {
 	if l == nil {
 		// if a logger is not set in the context we initialize a new one without tracing hooks configured
 		// this is mostly expected to happen in testing contexts as the app root should be propagating the logger when creating contexts
-		return NewDefaultLogger(os.Stderr, false, false, "")
+		return NewDefaultLogger(os.Stderr, false, false, false)
 	}
 	return l.(Logger)
 }

--- a/service/app.go
+++ b/service/app.go
@@ -10,8 +10,6 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/formancehq/go-libs/v2/otlp/otlptraces"
-	"github.com/sirupsen/logrus"
-	"github.com/uptrace/opentelemetry-go-extra/otellogrus"
 
 	"github.com/formancehq/go-libs/v2/errorsutils"
 	"github.com/formancehq/go-libs/v2/logging"
@@ -34,23 +32,14 @@ type App struct {
 
 func (a *App) Run(cmd *cobra.Command) error {
 	if a.logger == nil {
-		loggerHooks := make([]logrus.Hook, 0)
 		otelTraces, _ := cmd.Flags().GetString(otlptraces.OtelTracesExporterFlag)
-		if otelTraces != "" {
-			loggerHooks = append(loggerHooks, otellogrus.NewHook(otellogrus.WithLevels(
-				logrus.PanicLevel,
-				logrus.FatalLevel,
-				logrus.ErrorLevel,
-				logrus.WarnLevel,
-			)))
-		}
 
 		jsonFormatting, _ := cmd.Flags().GetBool(logging.JsonFormattingLoggerFlag)
 		a.logger = logging.NewDefaultLogger(
 			a.output,
 			IsDebug(cmd),
 			jsonFormatting,
-			loggerHooks...,
+			otelTraces,
 		)
 	}
 	a.logger.Infof("Starting application")

--- a/service/app.go
+++ b/service/app.go
@@ -39,7 +39,7 @@ func (a *App) Run(cmd *cobra.Command) error {
 			a.output,
 			IsDebug(cmd),
 			jsonFormatting,
-			otelTraces,
+			otelTraces != "",
 		)
 	}
 	a.logger.Infof("Starting application")


### PR DESCRIPTION
In payments we need to use the [hclog Logger](https://github.com/hashicorp/go-hclog) which is compatible with [go plugin](https://github.com/hashicorp/go-plugin) inside the connectors

This adds the ability to initialise a service with the non-default logger