### PR TITLE
feat: refactor migration system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-.idea
-vendor
-coverage.*

--- a/bun/bunconnect/module.go
+++ b/bun/bunconnect/module.go
@@ -27,9 +27,10 @@ func Module(connectionOptions ConnectionOptions, debug bool) fx.Option {
 
 			return OpenSQLDB(logging.ContextWithLogger(context.Background(), logger), connectionOptions, hooks...)
 		}),
-		fx.Invoke(func(lc fx.Lifecycle, db *bun.DB) {
+		fx.Invoke(func(lc fx.Lifecycle, db *bun.DB, logger logging.Logger) {
 			lc.Append(fx.Hook{
 				OnStop: func(ctx context.Context) error {
+					logger.Info("closing database connection...")
 					return db.Close()
 				},
 			})

--- a/migrations/collect.go
+++ b/migrations/collect.go
@@ -54,8 +54,8 @@ func CollectMigrationFiles(fs MigrationFileSystem, rootDir string) ([]Migration,
 
 		ret[i] = Migration{
 			Name: entry,
-			UpWithContext: func(ctx context.Context, tx bun.Tx) error {
-				_, err := tx.ExecContext(ctx, string(fileContent))
+			Up: func(ctx context.Context, db bun.IDB) error {
+				_, err := db.ExecContext(ctx, string(fileContent))
 				return err
 			},
 		}

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -7,7 +7,6 @@ import (
 )
 
 type Migration struct {
-	Name          string
-	Up            func(tx bun.Tx) error
-	UpWithContext func(ctx context.Context, tx bun.Tx) error
+	Name string
+	Up   func(ctx context.Context, db bun.IDB) error
 }

--- a/migrations/migrator.go
+++ b/migrations/migrator.go
@@ -2,15 +2,14 @@ package migrations
 
 import (
 	"context"
-	"database/sql"
-	"embed"
+	"errors"
 	"fmt"
 	"math"
 
+	"github.com/formancehq/go-libs/v2/logging"
+	"github.com/formancehq/go-libs/v2/platform/postgres"
 	"github.com/formancehq/go-libs/v2/time"
-	"github.com/jackc/pgx/v5/pgconn"
 
-	"github.com/pkg/errors"
 	"github.com/uptrace/bun"
 )
 
@@ -21,6 +20,7 @@ const (
 
 var (
 	ErrMissingVersionTable = errors.New("missing version table")
+	ErrAlreadyUpToDate     = errors.New("already up to date")
 )
 
 type Info struct {
@@ -37,6 +37,227 @@ type Migrator struct {
 	tableName    string
 }
 
+func (m *Migrator) RegisterMigrations(migrations ...Migration) *Migrator {
+	m.migrations = append(m.migrations, migrations...)
+	return m
+}
+
+func (m *Migrator) getVersionsTable() string {
+	if m.schema != "" {
+		return fmt.Sprintf(`"%s"."%s"`, m.schema, m.tableName)
+	}
+	return fmt.Sprintf(`"%s"`, m.tableName)
+}
+
+func (m *Migrator) createVersionTableIfNeeded(ctx context.Context, db bun.IDB) error {
+	_, err := db.NewCreateTable().
+		Model(&VersionTable{}).
+		ModelTableExpr(m.getVersionsTable()).
+		IfNotExists().
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create version table: %w", postgres.ResolveError(err))
+	}
+
+	lastVersion, err := m.GetLastVersion(ctx, db)
+	if err != nil {
+		return fmt.Errorf("failed to get last version: %w", err)
+	}
+
+	if lastVersion == -1 {
+		if err := m.insertVersion(ctx, db, 0); err != nil {
+			return fmt.Errorf("failed to insert version: %w", err)
+		}
+	}
+
+	return err
+}
+
+func (m *Migrator) GetLastVersion(ctx context.Context, db bun.IDB) (int, error) {
+	version := &VersionTable{}
+	if err := db.NewSelect().
+		Model(version).
+		ModelTableExpr(m.getVersionsTable()).
+		Order("version_id DESC").
+		Limit(1).
+		ColumnExpr("*").
+		Scan(ctx); err != nil {
+		err = postgres.ResolveError(err)
+		switch {
+		case errors.Is(err, postgres.ErrMissingTable):
+			return -1, ErrMissingVersionTable
+		case errors.Is(err, postgres.ErrNotFound):
+			return -1, nil
+		default:
+			return -1, err
+		}
+	}
+
+	return version.VersionID, nil
+}
+
+func (m *Migrator) insertVersion(ctx context.Context, db bun.IDB, version int) error {
+	_, err := db.NewInsert().
+		Model(&VersionTable{
+			VersionID: version,
+			IsApplied: true,
+			Timestamp: time.Now(),
+		}).
+		ModelTableExpr(m.getVersionsTable()).
+		Exec(ctx)
+	return err
+}
+
+func (m *Migrator) Up(ctx context.Context, db bun.IDB) error {
+	for {
+		err := m.UpByOne(ctx, db)
+		if err != nil {
+			if errors.Is(err, ErrAlreadyUpToDate) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func (m *Migrator) GetMigrations(ctx context.Context, db bun.IDB) ([]Info, error) {
+	ret := make([]Info, len(m.migrations))
+
+	if err := db.NewSelect().
+		TableExpr(m.getVersionsTable()).
+		Order("version_id").
+		Where("version_id >= 1").
+		Column("version_id", "tstamp").
+		Limit(len(m.migrations)).
+		Scan(ctx, &ret); err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < int(math.Min(float64(len(ret)), float64(len(m.migrations)))); i++ {
+		ret[i].Name = m.migrations[i].Name
+		ret[i].State = "DONE"
+	}
+
+	for i := len(ret); i < len(m.migrations); i++ {
+		ret = append(ret, Info{
+			Version: fmt.Sprint(i),
+			Name:    m.migrations[i].Name,
+			State:   "TO DO",
+		})
+	}
+
+	return ret, nil
+}
+
+func (m *Migrator) IsUpToDate(ctx context.Context, db bun.IDB) (bool, error) {
+	version, err := m.GetLastVersion(ctx, db)
+	if err != nil {
+		if errors.Is(err, ErrMissingVersionTable) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return version == len(m.migrations), nil
+}
+
+func (m *Migrator) createSchemaIfNeeded(ctx context.Context, db bun.IDB) error {
+	if m.schema != "" && m.createSchema {
+		_, err := db.ExecContext(ctx, fmt.Sprintf(`create schema if not exists "%s"`, m.schema))
+		if err != nil {
+			return fmt.Errorf("failed to create schema: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Migrator) upByOne(ctx context.Context, db bun.IDB) error {
+
+	err := m.createSchemaIfNeeded(ctx, db)
+	if err != nil {
+		return fmt.Errorf("failed to create schema: %w", err)
+	}
+
+	err = m.createVersionTableIfNeeded(ctx, db)
+	if err != nil {
+		return fmt.Errorf("failed to create version table: %w", err)
+	}
+
+	// We need to lock something to prevent concurrent migration
+	// We could have started a transaction and lock and full table,
+	// but the downside is than the underlying migrations could not use "create index concurrently".
+	// So, we will use advisory locks, at session level.
+	// As advisory locks at session level need to be taken and released with the same underlying connection,
+	// we grab a connection from the pool if we are not already in a transaction (a sql transaction already keep the same connection).
+	conn := db
+	switch idb := db.(type) {
+	case *bun.DB:
+		newConn, err := idb.Conn(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get connection: %w", err)
+		}
+		defer func() {
+			if err := newConn.Close(); err != nil {
+				logging.FromContext(ctx).Errorf("unable to close connection: %v", err)
+			}
+		}()
+		conn = newConn
+	}
+
+	_, err = conn.ExecContext(ctx, "select pg_advisory_lock(hashtext(?))", m.getVersionsTable())
+	if err != nil {
+		return fmt.Errorf("failed to acquire lock: %w", err)
+	}
+
+	defer func() {
+		_, err = conn.ExecContext(ctx, "select pg_advisory_unlock(hashtext(?))", m.getVersionsTable())
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	lastVersion, err := m.GetLastVersion(ctx, db)
+	if err != nil {
+		return fmt.Errorf("failed to get last version: %w", err)
+	}
+
+	// At this point, there is no pending migration occurring
+	if len(m.migrations) == lastVersion {
+		// no more migration to play
+		return ErrAlreadyUpToDate
+	}
+
+	// notes(gfyrag): run migration using db provided and not the tx we just created.
+	// we need this tx to be able to lock the migrations table,
+	// but we want migrations has the control and start a transaction if they need to.
+	logging.FromContext(ctx).Debugf("Running migration %d: %s", lastVersion, m.migrations[lastVersion].Name)
+	if err := m.migrations[lastVersion].Up(ctx, db); err != nil {
+		return fmt.Errorf("failed to run migration '%s': %w", m.migrations[lastVersion].Name, err)
+	}
+
+	newVersion := lastVersion + 1
+	if err := m.insertVersion(ctx, db, newVersion); err != nil {
+		return fmt.Errorf("failed to insert new version: %w", err)
+	}
+
+	return nil
+}
+
+func (m *Migrator) UpByOne(ctx context.Context, db bun.IDB) error {
+	return postgres.ResolveError(m.upByOne(ctx, db))
+}
+
+func NewMigrator(opts ...Option) *Migrator {
+	ret := &Migrator{
+		tableName: migrationTable,
+	}
+	for _, opt := range opts {
+		opt(ret)
+	}
+	return ret
+}
+
 type Option func(m *Migrator)
 
 func WithSchema(schema string, create bool) Option {
@@ -50,239 +271,4 @@ func WithTableName(name string) Option {
 	return func(m *Migrator) {
 		m.tableName = name
 	}
-}
-
-func (m *Migrator) RegisterMigrations(migrations ...Migration) *Migrator {
-	m.migrations = append(m.migrations, migrations...)
-	return m
-}
-
-func (m *Migrator) RegisterMigrationsFromFileSystem(dir embed.FS, rootDir string) *Migrator {
-	migrations, err := CollectMigrationFiles(dir, rootDir)
-	if err != nil {
-		panic(err)
-	}
-	return m.RegisterMigrations(migrations...)
-}
-
-func (m *Migrator) createVersionTable(ctx context.Context, tx bun.Tx) error {
-	_, err := tx.ExecContext(ctx, fmt.Sprintf(`create table if not exists "%s" (
-		id serial primary key,
-		version_id bigint not null,
-		is_applied boolean not null,
-		tstamp timestamp default now()
-	);`, m.tableName))
-	if err != nil {
-		return errors.Wrap(err, "failed to create version table")
-	}
-
-	lastVersion, err := m.getLastVersion(ctx, tx)
-	if err != nil {
-		return errors.Wrap(err, "failed to get last version")
-	}
-
-	if lastVersion == -1 {
-		if err := m.insertVersion(ctx, tx, 0); err != nil {
-			return errors.Wrap(err, "failed to insert version")
-		}
-	}
-
-	return err
-}
-
-func (m *Migrator) getLastVersion(ctx context.Context, querier interface {
-	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
-}) (int64, error) {
-	row := querier.QueryRowContext(ctx, fmt.Sprintf(`select max(version_id) from "%s";`, m.tableName))
-	if err := row.Err(); err != nil {
-		switch {
-		case err == sql.ErrNoRows:
-			return -1, nil
-		default:
-			switch err := err.(type) {
-			case *pgconn.PgError:
-				switch err.Code {
-				case "42P01": // Table not exists
-					return -1, ErrMissingVersionTable
-				}
-			}
-		}
-
-		return -1, errors.Wrap(err, "selecting max id from version table")
-	}
-	var number sql.NullInt64
-	if err := row.Scan(&number); err != nil {
-		return 0, err
-	}
-
-	if !number.Valid {
-		return -1, nil
-	}
-
-	return number.Int64, nil
-}
-
-func (m *Migrator) insertVersion(ctx context.Context, tx bun.Tx, version int) error {
-	_, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`INSERT INTO "%s" (version_id, is_applied, tstamp) VALUES (?, ?, ?)`, m.tableName),
-		version, true, time.Now())
-	return err
-}
-
-func (m *Migrator) GetDBVersion(ctx context.Context, db bun.IDB) (int64, error) {
-	ret := int64(0)
-	if err := m.runInTX(ctx, db, func(ctx context.Context, tx bun.Tx) error {
-		var err error
-		ret, err = m.getLastVersion(ctx, tx)
-		return err
-	}); err != nil {
-		return 0, err
-	}
-
-	return ret, nil
-}
-
-func (m *Migrator) runInTX(ctx context.Context, db bun.IDB, fn func(ctx context.Context, tx bun.Tx) error) error {
-	return db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
-		if m.schema != "" {
-			_, err := tx.ExecContext(ctx, fmt.Sprintf(`set search_path = "%s"`, m.schema))
-			if err != nil {
-				return err
-			}
-		}
-		return fn(ctx, tx)
-	})
-}
-
-func (m *Migrator) Up(ctx context.Context, db bun.IDB) error {
-	return m.runInTX(ctx, db, func(ctx context.Context, tx bun.Tx) error {
-		for {
-			more, err := m.upByOne(ctx, tx)
-			if err != nil {
-				return err
-			}
-			if !more {
-				return nil
-			}
-		}
-	})
-}
-
-func (m *Migrator) GetMigrations(ctx context.Context, db bun.IDB) ([]Info, error) {
-	ret := make([]Info, len(m.migrations))
-	if err := m.runInTX(ctx, db, func(ctx context.Context, tx bun.Tx) error {
-		migrationTableName := m.tableName
-		if m.schema != "" {
-			migrationTableName = fmt.Sprintf(`"%s".%s`, m.schema, migrationTableName)
-		}
-
-		if err := tx.NewSelect().
-			TableExpr(migrationTableName).
-			Order("version_id").
-			Where("version_id >= 1").
-			Column("version_id", "tstamp").
-			Limit(len(m.migrations)).
-			Scan(ctx, &ret); err != nil {
-			return err
-		}
-
-		for i := 0; i < int(math.Min(float64(len(ret)), float64(len(m.migrations)))); i++ {
-			ret[i].Name = m.migrations[i].Name
-			ret[i].State = "DONE"
-		}
-
-		for i := len(ret); i < len(m.migrations); i++ {
-			ret = append(ret, Info{
-				Version: fmt.Sprint(i),
-				Name:    m.migrations[i].Name,
-				State:   "TO DO",
-			})
-		}
-
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-
-	return ret, nil
-}
-
-func (m *Migrator) IsUpToDate(ctx context.Context, db bun.IDB) (bool, error) {
-	ret := false
-	if err := m.runInTX(ctx, db, func(ctx context.Context, tx bun.Tx) error {
-		version, err := m.getLastVersion(ctx, tx)
-		if err != nil {
-			return err
-		}
-
-		ret = int(version) == len(m.migrations)
-		return nil
-	}); err != nil {
-		return false, err
-	}
-
-	return ret, nil
-}
-
-// upByOne returns a boolean indicating if there are more migrations to apply
-func (m *Migrator) upByOne(ctx context.Context, tx bun.Tx) (bool, error) {
-	if m.schema != "" && m.createSchema {
-		_, err := tx.ExecContext(ctx, fmt.Sprintf(`create schema if not exists "%s"`, m.schema))
-		if err != nil {
-			return false, errors.Wrap(err, "creating schema")
-		}
-	}
-
-	if err := m.createVersionTable(ctx, tx); err != nil {
-		return false, errors.Wrap(err, "creating version table")
-	}
-
-	lastMigration, err := m.getLastVersion(ctx, tx)
-	if err != nil {
-		return false, errors.Wrap(err, "getting last migration")
-	}
-
-	if len(m.migrations) > int(lastMigration) {
-		migration := m.migrations[lastMigration]
-		if migration.UpWithContext != nil {
-			if err := migration.UpWithContext(ctx, tx); err != nil {
-				return false, errors.Wrapf(err, "executing migration %d", lastMigration)
-			}
-		} else if migration.Up != nil {
-			if err := migration.Up(tx); err != nil {
-				return false, errors.Wrapf(err, "executing migration %d", lastMigration)
-			}
-		} else {
-			return false, errors.New("no code defined for migration")
-		}
-
-		if err := m.insertVersion(ctx, tx, int(lastMigration)+1); err != nil {
-			return false, errors.Wrap(err, "inserting new version")
-		}
-	}
-
-	return len(m.migrations) > int(lastMigration), nil
-}
-
-// upByOne returns a boolean indicating if there are more migrations to apply
-func (m *Migrator) UpByOne(ctx context.Context, db bun.IDB) (more bool, err error) {
-	err = m.runInTX(ctx, db, func(ctx context.Context, tx bun.Tx) error {
-		more, err = m.upByOne(ctx, tx)
-		return err
-	})
-	if err != nil {
-		return false, err
-	}
-
-	return more, nil
-}
-
-func NewMigrator(opts ...Option) *Migrator {
-	ret := &Migrator{
-		tableName: migrationTable,
-	}
-	for _, opt := range opts {
-		opt(ret)
-	}
-	return ret
 }

--- a/migrations/migrator_test.go
+++ b/migrations/migrator_test.go
@@ -3,7 +3,13 @@ package migrations
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
+	"time"
+
+	"github.com/formancehq/go-libs/v2/platform/postgres"
+	"github.com/formancehq/go-libs/v2/testing/utils"
+	"github.com/google/uuid"
 
 	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/go-libs/v2/testing/docker"
@@ -17,38 +23,144 @@ import (
 	"github.com/uptrace/bun/extra/bundebug"
 )
 
-func TestMigrations(t *testing.T) {
-	dockerPool := docker.NewPool(t, logging.Testing())
-	srv := pgtesting.CreatePostgresServer(t, dockerPool)
+var (
+	dockerPool *docker.Pool
+	srv        *pgtesting.PostgresServer
+	db         *pgtesting.Database
+	sqlDB      *sql.DB
+	bunDB      *bun.DB
+)
 
-	migrator := NewMigrator()
-	migrator.RegisterMigrations(
-		Migration{
-			Up: func(tx bun.Tx) error {
-				_, err := tx.Exec(`CREATE TABLE "foo" (id varchar)`)
-				return err
-			},
-		},
-	)
+func TestMain(m *testing.M) {
+	utils.WithTestMain(func(t *utils.TestingTForMain) int {
+		var err error
 
-	db := srv.NewDatabase(t)
-	sqlDB, err := sql.Open("pgx", db.ConnString())
-	require.NoError(t, err)
+		dockerPool = docker.NewPool(t, logging.Testing())
+		srv = pgtesting.CreatePostgresServer(t, dockerPool)
+		db = srv.NewDatabase(t)
+		sqlDB, err = sql.Open("pgx", db.ConnString())
+		require.NoError(t, err)
 
-	t.Cleanup(func() {
-		_ = sqlDB.Close()
+		t.Cleanup(func() {
+			_ = sqlDB.Close()
+		})
+
+		bunDB = bun.NewDB(sqlDB, pgdialect.New())
+		if testing.Verbose() {
+			bunDB.AddQueryHook(bundebug.NewQueryHook(
+				bundebug.WithVerbose(true),
+				bundebug.FromEnv("BUNDEBUG"),
+			))
+		}
+
+		return m.Run()
 	})
+}
 
-	bunDB := bun.NewDB(sqlDB, pgdialect.New())
-	if testing.Verbose() {
-		bunDB.AddQueryHook(bundebug.NewQueryHook(
-			bundebug.WithVerbose(true),
-			bundebug.FromEnv("BUNDEBUG"),
-		))
+func TestMigrationsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+
+	type testCase struct {
+		name        string
+		options     []Option
+		expectError error
 	}
 
-	require.NoError(t, migrator.Up(context.Background(), bunDB))
-	version, err := migrator.GetDBVersion(context.Background(), bunDB)
-	require.NoError(t, err)
-	require.EqualValues(t, 1, version)
+	testCases := []testCase{
+		{
+			name: "default",
+		},
+		{
+			name: "with schema and create",
+			options: []Option{
+				WithSchema(uuid.NewString()[:8], true),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			migrationStarted := make(chan struct{})
+			terminatedMigration := make(chan struct{})
+
+			migrator1 := NewMigrator(testCase.options...)
+			migrator1.RegisterMigrations(Migration{
+				Up: func(ctx context.Context, db bun.IDB) error {
+					close(migrationStarted)
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-terminatedMigration:
+						return nil
+					}
+				},
+			})
+
+			ctx, cancel := context.WithTimeout(ctx, time.Second)
+			t.Cleanup(cancel)
+
+			migrator1Err := make(chan error, 1)
+			go func() {
+				migrator1Err <- migrator1.UpByOne(ctx, bunDB)
+			}()
+
+			<-migrationStarted
+
+			migrator2 := NewMigrator(testCase.options...)
+			migrator2.RegisterMigrations(Migration{
+				Up: func(ctx context.Context, db bun.IDB) error {
+					return errors.New("should not have been called")
+				},
+			})
+
+			migrator2Err := make(chan error, 1)
+			go func() {
+				migrator2Err <- migrator2.UpByOne(ctx, bunDB)
+			}()
+
+			close(terminatedMigration)
+
+			select {
+			case err := <-migrator1Err:
+				if testCase.expectError != nil {
+					require.True(t, errors.Is(err, testCase.expectError))
+				} else {
+					require.NoError(t, err)
+				}
+
+				select {
+				case err := <-migrator2Err:
+					if testCase.expectError != nil {
+						require.True(t, errors.Is(err, testCase.expectError))
+					} else {
+						require.True(t, errors.Is(err, ErrAlreadyUpToDate))
+					}
+				case <-time.After(time.Second):
+					t.Fatal("migrator2 did not finish")
+				}
+			case <-time.After(time.Second):
+				t.Fatal("migrator1 did not finish")
+			}
+		})
+	}
+}
+
+func TestMigrationsMissingSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+
+	migrator1 := NewMigrator(WithSchema("foo", false))
+	migrator1.RegisterMigrations(Migration{
+		Up: func(ctx context.Context, db bun.IDB) error {
+			return nil
+		},
+	})
+
+	err := migrator1.UpByOne(ctx, bunDB)
+	require.True(t, errors.Is(err, postgres.ErrMissingSchema))
 }

--- a/migrations/versions.go
+++ b/migrations/versions.go
@@ -1,0 +1,10 @@
+package migrations
+
+import "github.com/formancehq/go-libs/v2/time"
+
+type VersionTable struct {
+	ID        int       `bun:"id,type:serial,pk,scanonly"`
+	VersionID int       `bun:"version_id,type:bigint,notnull"`
+	Timestamp time.Time `bun:"tstamp,type:timestamp,default:now()"`
+	IsApplied bool      `bun:"is_applied,type:boolean,notnull"`
+}

--- a/platform/postgres/errors.go
+++ b/platform/postgres/errors.go
@@ -4,10 +4,11 @@ import (
 	"database/sql"
 
 	"github.com/jackc/pgx/v5/pgconn"
+
 	"github.com/pkg/errors"
 )
 
-// postgresError is an helper to wrap postgres errors into storage errors
+// ResolveError is an helper to wrap postgres errors into storage errors
 func ResolveError(err error) error {
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -27,6 +28,8 @@ func ResolveError(err error) error {
 				return ErrSerialization
 			case "42P01":
 				return ErrMissingTable
+			case "3F000":
+				return ErrMissingSchema
 			}
 		}
 
@@ -41,6 +44,7 @@ var (
 	ErrDeadlockDetected = errors.New("deadlock detected")
 	ErrSerialization    = errors.New("serialization error")
 	ErrMissingTable     = errors.New("missing table")
+	ErrMissingSchema    = errors.New("missing schema")
 )
 
 func IsNotFoundError(err error) bool {

--- a/testing/api/matchers.go
+++ b/testing/api/matchers.go
@@ -9,8 +9,9 @@ import (
 )
 
 type HaveErrorCodeMatcher struct {
-	lastSeen string
-	expected string
+	lastSeen        string
+	lastSeenMessage string
+	expected        string
 }
 
 func (s *HaveErrorCodeMatcher) Match(actual interface{}) (success bool, err error) {
@@ -24,6 +25,7 @@ func (s *HaveErrorCodeMatcher) Match(actual interface{}) (success bool, err erro
 		return false, nil
 	}
 	s.lastSeen = errorResponse.ErrorCode
+	s.lastSeenMessage = errorResponse.ErrorMessage
 
 	return errorResponse.ErrorCode == s.expected, nil
 }
@@ -32,7 +34,7 @@ func (s *HaveErrorCodeMatcher) FailureMessage(actual interface{}) (message strin
 	if actual == nil {
 		return fmt.Sprintf("error should have code %s but is nil", s.expected)
 	}
-	return fmt.Sprintf("error should have code %s but have %s", s.expected, s.lastSeen)
+	return fmt.Sprintf("error should have code %s but have %s with message '%s'", s.expected, s.lastSeen, s.lastSeenMessage)
 }
 
 func (s *HaveErrorCodeMatcher) NegatedFailureMessage(actual interface{}) (message string) {

--- a/testing/migrations/testing.go
+++ b/testing/migrations/testing.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/go-libs/v2/migrations"
 	"github.com/stretchr/testify/require"
@@ -34,8 +36,10 @@ func (mt *MigrationTest) Run() {
 			}
 		}
 
-		more, err := mt.migrator.UpByOne(ctx, mt.db)
-		require.NoError(mt.t, err)
+		err := mt.migrator.UpByOne(ctx, mt.db)
+		if !errors.Is(err, migrations.ErrAlreadyUpToDate) {
+			require.NoError(mt.t, err)
+		}
 
 		for _, hook := range mt.hooks[i] {
 			if hook.After != nil {
@@ -45,7 +49,7 @@ func (mt *MigrationTest) Run() {
 
 		i++
 
-		if !more {
+		if errors.Is(err, migrations.ErrAlreadyUpToDate) {
 			break
 		}
 	}

--- a/testing/platform/pgtesting/postgres.go
+++ b/testing/platform/pgtesting/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/google/uuid"
 	"os"
 	"strconv"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"github.com/formancehq/go-libs/v2/bun/bunconnect"
 
 	"github.com/formancehq/go-libs/v2/testing/docker"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -105,6 +105,7 @@ func (s *PostgresServer) setupDatabase(t T, name string) {
 
 type createDatabaseOptions struct {
 	template string
+	name     string
 }
 
 type CreateDatabaseOption func(opts *createDatabaseOptions)
@@ -112,6 +113,12 @@ type CreateDatabaseOption func(opts *createDatabaseOptions)
 func CreateWithTemplate(template string) CreateDatabaseOption {
 	return func(opts *createDatabaseOptions) {
 		opts.template = template
+	}
+}
+
+func WithName(name string) CreateDatabaseOption {
+	return func(opts *createDatabaseOptions) {
+		opts.name = name
 	}
 }
 
@@ -127,7 +134,10 @@ func (s *PostgresServer) NewDatabase(t T, options ...CreateDatabaseOption) *Data
 		option(databaseOptions)
 	}
 
-	databaseName := uuid.NewString()[:8]
+	databaseName := databaseOptions.name
+	if databaseName == "" {
+		databaseName = uuid.NewString()[:8]
+	}
 	createDatabaseQuery := fmt.Sprintf(`create database "%s"`, databaseName)
 	if databaseOptions.template != "" {
 		createDatabaseQuery += fmt.Sprintf(` template "%s"`, databaseOptions.template)

--- a/testing/platform/pgtesting/postgres.go
+++ b/testing/platform/pgtesting/postgres.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/google/uuid"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/google/uuid"
 
 	sharedlogging "github.com/formancehq/go-libs/v2/logging"
 	"github.com/ory/dockertest/v3"


### PR DESCRIPTION
* Pass only a bun.IDB interface to migration function (caller must create a tx if they need one)
* Take a pg advisory lock to prevent concurrent migrations.
