### PR TITLE
feat(currency): Add currency package from payments repo to go-libs

### DIFF
--- a/currency/amount.go
+++ b/currency/amount.go
@@ -1,0 +1,120 @@
+package currency
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// This package provides a way to convert a string amount to a big.Int
+// with a given precision. The precision is the number of decimals that
+// the amount has. For example, if the amount is 123.45 and the precision is 2,
+// the amount will be 12345.
+// We also provide a way to convert a big.Int to a string amount with a given
+// precision.
+// We developed this package because we need to convert amounts from strings,
+// and apply the precision to them to have minor units. If we do that with
+// the big package using floats and divisions/multiplcations, we will
+// sometimes loose precision, which is unacceptable.
+// Here is an example of loosing precision with the big package:
+
+var (
+	// ErrInvalidAmount is returned when the amount is invalid
+	ErrInvalidAmount = fmt.Errorf("invalid amount")
+	// ErrInvalidPrecision is returned when the precision is inferior to the
+	// number of decimals in the amount or negative
+	ErrInvalidPrecision = fmt.Errorf("invalid precision")
+)
+
+func GetAmountWithPrecisionFromString(amountString string, precision int) (*big.Int, error) {
+	if precision < 0 {
+		return nil, errors.Wrap(ErrInvalidPrecision, fmt.Sprintf("precision is negative: %d", precision))
+	}
+
+	parts := strings.Split(amountString, ".")
+
+	lengthParts := len(parts)
+
+	if lengthParts > 2 || lengthParts == 0 {
+		// More than one dot, invalid amount
+		return nil, errors.Wrap(ErrInvalidAmount, fmt.Sprintf("got multiple dots in amount: %s", amountString))
+	}
+
+	if lengthParts == 1 {
+		// No dot, which means it's an integer
+		for p := 0; p < precision; p++ {
+			amountString += "0"
+		}
+		res, ok := new(big.Int).SetString(amountString, 10)
+		if !ok {
+			return nil, errors.Wrap(ErrInvalidAmount, fmt.Sprintf("invalid amount: %s", amountString))
+		}
+		return res, nil
+	}
+
+	// Here we are in the case where we have one dot, which means we have a
+	// decimal amount
+	decimalPart := parts[1]
+	lengthDecimalPart := len(decimalPart)
+	switch {
+	case lengthDecimalPart == precision:
+		// The decimal part has the same length as the precision, we can
+		// concatenate the two parts and return the result
+		res, ok := new(big.Int).SetString(parts[0]+decimalPart, 10)
+		if !ok {
+			return nil, errors.Wrap(ErrInvalidAmount, fmt.Sprintf("invalid amount computed: %s from amount %s", parts[0]+decimalPart, amountString))
+		}
+		return res, nil
+
+	case lengthDecimalPart < precision:
+		// The decimal part is shorter than the precision, we need to add
+		// some zeros at the end of the decimal part
+		for p := 0; p < precision-lengthDecimalPart; p++ {
+			decimalPart += "0"
+		}
+		res, ok := new(big.Int).SetString(parts[0]+decimalPart, 10)
+		if !ok {
+			return nil, errors.Wrap(ErrInvalidAmount, fmt.Sprintf("invalid amount computed: %s from amount %s", parts[0]+decimalPart, amountString))
+		}
+		return res, nil
+
+	default:
+		// The decimal part is longer than the precision, we have to send an
+		// error because we don't want to loose the precision
+		return nil, ErrInvalidPrecision
+	}
+}
+
+func GetStringAmountFromBigIntWithPrecision(amount *big.Int, precision int) (string, error) {
+	if precision < 0 {
+		return "", errors.Wrap(ErrInvalidPrecision, fmt.Sprintf("precision is negative: %d", precision))
+	}
+
+	amountString := amount.String()
+	amountStringLength := len(amountString)
+
+	if precision == 0 {
+		// Nothing to do
+		return amountString, nil
+	}
+
+	decimalPart := bytes.NewBufferString("")
+	for p := precision; p > 0; p-- {
+		if amountStringLength < p {
+			decimalPart.WriteByte('0')
+			continue
+		}
+		decimalPart.WriteByte(amountString[amountStringLength-p])
+	}
+
+	if amountStringLength < precision || amountStringLength == precision {
+		return "0." + decimalPart.String(), nil
+	}
+
+	// Here we are in the case where the amount has more digits than the
+	// precision, we need to add a dot at the right place
+	return amountString[:amountStringLength-precision] + "." + decimalPart.String(), nil
+}

--- a/currency/amount.go
+++ b/currency/amount.go
@@ -18,8 +18,7 @@ import (
 // We developed this package because we need to convert amounts from strings,
 // and apply the precision to them to have minor units. If we do that with
 // the big package using floats and divisions/multiplcations, we will
-// sometimes loose precision, which is unacceptable.
-// Here is an example of loosing precision with the big package:
+// sometimes lose precision, which is unacceptable.
 
 var (
 	// ErrInvalidAmount is returned when the amount is invalid
@@ -83,7 +82,7 @@ func GetAmountWithPrecisionFromString(amountString string, precision int) (*big.
 
 	default:
 		// The decimal part is longer than the precision, we have to send an
-		// error because we don't want to loose the precision
+		// error because we don't want to lose the precision
 		return nil, ErrInvalidPrecision
 	}
 }

--- a/currency/amount.go
+++ b/currency/amount.go
@@ -33,8 +33,11 @@ func GetAmountWithPrecisionFromString(amountString string, precision int) (*big.
 		return nil, errors.Wrap(ErrInvalidPrecision, fmt.Sprintf("precision is negative: %d", precision))
 	}
 
-	parts := strings.Split(amountString, ".")
+	if amountString == "" {
+		return nil, errors.Wrap(ErrInvalidAmount, "amount string is empty")
+	}
 
+	parts := strings.Split(amountString, ".")
 	lengthParts := len(parts)
 
 	if lengthParts > 2 || lengthParts == 0 {

--- a/currency/amount_test.go
+++ b/currency/amount_test.go
@@ -1,0 +1,251 @@
+package currency
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAmountWithPrecisionFromString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name         string
+		amountString string
+		precision    int
+		expected     *big.Int
+		expecterErr  error
+	}
+
+	testCases := []testCase{
+		{
+			name:         "nominal float string with precision 2",
+			amountString: "123.45",
+			precision:    2,
+			expected:     big.NewInt(12345),
+			expecterErr:  nil,
+		},
+		{
+			name:         "nominal float string with precision 2 (2)",
+			amountString: "0.00",
+			precision:    2,
+			expected:     big.NewInt(0),
+			expecterErr:  nil,
+		},
+		{
+			name:         "nominal float string with precision 0",
+			amountString: "123.",
+			precision:    0,
+			expected:     big.NewInt(123),
+			expecterErr:  nil,
+		},
+		{
+			name:         "nominal float string with precision 0 and decimals = precision",
+			amountString: "123.",
+			precision:    0,
+			expected:     big.NewInt(123),
+			expecterErr:  nil,
+		},
+		{
+			name:         "nominal float string with precision 0 and decimals = precision",
+			amountString: "123.4567",
+			precision:    4,
+			expected:     big.NewInt(1234567),
+			expecterErr:  nil,
+		},
+		{
+			name:         "nominal float string with precision 2 and decimals < precision",
+			amountString: "123.",
+			precision:    2,
+			expected:     big.NewInt(12300),
+			expecterErr:  nil,
+		},
+		{
+			name:         "nominal float string with precision 2 and decimals < precision (2)",
+			amountString: "123.1",
+			precision:    2,
+			expected:     big.NewInt(12310),
+			expecterErr:  nil,
+		},
+		{
+			name:         "nominal integer string with precision 2",
+			amountString: "123",
+			precision:    2,
+			expected:     big.NewInt(12300),
+			expecterErr:  nil,
+		},
+		{
+			name:         "nominal integer string with precision 0",
+			amountString: "123",
+			precision:    0,
+			expected:     big.NewInt(123),
+			expecterErr:  nil,
+		},
+
+		// Error cases
+		{
+			name:        "negative precision",
+			precision:   -1,
+			expected:    nil,
+			expecterErr: ErrInvalidPrecision,
+		},
+		{
+			name:         "invalid amount multiple dots",
+			amountString: "123.45.67",
+			precision:    2,
+			expected:     nil,
+			expecterErr:  ErrInvalidAmount,
+		},
+		{
+			name:         "invalid float amount",
+			amountString: "123.4a",
+			precision:    2,
+			expected:     nil,
+			expecterErr:  ErrInvalidAmount,
+		},
+		{
+			name:         "invalid float amount (2)",
+			amountString: "12a3.4",
+			precision:    2,
+			expected:     nil,
+			expecterErr:  ErrInvalidAmount,
+		},
+		{
+			name:         "invalid integer amount",
+			amountString: "123a",
+			precision:    2,
+			expected:     nil,
+			expecterErr:  ErrInvalidAmount,
+		},
+		{
+			name:         "float number with decimal part > precision",
+			amountString: "123.456",
+			precision:    2,
+			expected:     nil,
+			expecterErr:  ErrInvalidPrecision,
+		},
+		{
+			name:         "float number with decimal part > precision (2)",
+			amountString: "123.456",
+			precision:    0,
+			expected:     nil,
+			expecterErr:  ErrInvalidPrecision,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			amount, err := GetAmountWithPrecisionFromString(tc.amountString, tc.precision)
+			if tc.expecterErr != nil {
+				require.True(t, errors.Is(err, tc.expecterErr), "expected error %v, got %v", tc.expecterErr, err)
+				return
+			}
+
+			if amount.Cmp(tc.expected) != 0 {
+				t.Errorf("expected %v, got %v", tc.expected, amount)
+			}
+		})
+	}
+}
+
+func TestGetStringAmountFromBigIntWithPrecision(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name           string
+		amount         *big.Int
+		precision      int
+		expectedAmount string
+		expectedError  error
+	}
+
+	testCases := []testCase{
+		{
+			name:           "precision 0",
+			amount:         big.NewInt(12345),
+			precision:      0,
+			expectedAmount: "12345",
+			expectedError:  nil,
+		},
+		{
+			name:           "precision 0 (2)",
+			amount:         big.NewInt(0),
+			precision:      0,
+			expectedAmount: "0",
+			expectedError:  nil,
+		},
+		{
+			name:           "precision 0 (3)",
+			amount:         big.NewInt(123),
+			precision:      0,
+			expectedAmount: "123",
+			expectedError:  nil,
+		},
+		{
+			name:           "precision 2",
+			amount:         big.NewInt(12345),
+			precision:      2,
+			expectedAmount: "123.45",
+			expectedError:  nil,
+		},
+		{
+			name:           "precision 2 (2)",
+			amount:         big.NewInt(123),
+			precision:      2,
+			expectedAmount: "1.23",
+			expectedError:  nil,
+		},
+		{
+			name:           "precision 2 (3)",
+			amount:         big.NewInt(12),
+			precision:      2,
+			expectedAmount: "0.12",
+			expectedError:  nil,
+		},
+		{
+			name:           "precision 2 (4)",
+			amount:         big.NewInt(0),
+			precision:      2,
+			expectedAmount: "0.00",
+			expectedError:  nil,
+		},
+		{
+			name:           "precision > length of amount",
+			amount:         big.NewInt(123),
+			precision:      6,
+			expectedAmount: "0.000123",
+			expectedError:  nil,
+		},
+
+		// Error cases
+		{
+			name:           "negative precision",
+			amount:         big.NewInt(123),
+			precision:      -1,
+			expectedAmount: "",
+			expectedError:  ErrInvalidPrecision,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			amount, err := GetStringAmountFromBigIntWithPrecision(tc.amount, tc.precision)
+			if tc.expectedError != nil {
+				require.True(t, errors.Is(err, tc.expectedError), "expected error %v, got %v", tc.expectedError, err)
+				return
+			}
+
+			if amount != tc.expectedAmount {
+				t.Errorf("expected %v, got %v", tc.expectedAmount, amount)
+			}
+		})
+	}
+}

--- a/currency/amount_test.go
+++ b/currency/amount_test.go
@@ -120,6 +120,20 @@ func TestGetAmountWithPrecisionFromString(t *testing.T) {
 			expecterErr:  ErrInvalidAmount,
 		},
 		{
+			name:         "amount string is empty with zero precision",
+			amountString: "",
+			precision:    0,
+			expected:     nil,
+			expecterErr:  ErrInvalidAmount,
+		},
+		{
+			name:         "amount string is empty with non-zero precision",
+			amountString: "",
+			precision:    2,
+			expected:     nil,
+			expecterErr:  ErrInvalidAmount,
+		},
+		{
 			name:         "float number with decimal part > precision",
 			amountString: "123.456",
 			precision:    2,
@@ -146,6 +160,7 @@ func TestGetAmountWithPrecisionFromString(t *testing.T) {
 				return
 			}
 
+			require.NotNil(t, amount)
 			if amount.Cmp(tc.expected) != 0 {
 				t.Errorf("expected %v, got %v", tc.expected, amount)
 			}

--- a/currency/currency.go
+++ b/currency/currency.go
@@ -1,0 +1,232 @@
+package currency
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrMissingCurrencies = errors.New("missing currencies")
+
+	UnsupportedCurrencies = map[string]struct{}{
+		"HUF": {},
+		"ISK": {},
+		"TWD": {},
+	}
+
+	ISO4217Currencies = map[string]int{
+		"AFN": 2, //  Afghan afghani
+		"EUR": 2, //  Euro
+		"ALL": 2, //  Albanian lek
+		"DZD": 2, //  Algerian dinar
+		"USD": 2, //  United States dollar
+		"AOA": 2, //  Angolan kwanza
+		"XCD": 2, //  East Caribbean dollar
+		"ARS": 2, //  Argentine peso
+		"AMD": 2, //  Armenian dram
+		"AWG": 2, //  Aruban florin
+		"AUD": 2, //  Australian dollar
+		"AZN": 2, //  Azerbaijani manat
+		"BSD": 2, //  Bahamian dollar
+		"BHD": 3, //  Bahraini dinar
+		"BDT": 2, //  Bangladeshi taka
+		"BBD": 2, //  Barbados dollar
+		"BYN": 2, //  Belarusian ruble
+		"BZD": 2, //  Belize dollar
+		"XOF": 0, //  West African CFA franc
+		"BMD": 2, //  Bermudian dollar
+		"INR": 2, //  Indian rupee
+		"BTN": 2, //  Bhutanese ngultrum
+		"BOB": 2, //  Bolivian boliviano
+		"BOV": 2, //  Bolivian Mvdol (funds code)
+		"BAM": 2, //  Bosnia and Herzegovina convertible mark
+		"BWP": 2, //  Botswana pula
+		"NOK": 2, //  Norwegian krone
+		"BRL": 2, //  Brazilian real
+		"BND": 2, //  Brunei dollar
+		"BGN": 2, //  Bulgarian lev
+		"BIF": 0, //  Burundian franc
+		"CVE": 2, //  Cape Verdean escudo
+		"KHR": 2, //  Cambodian riel
+		"XAF": 0, //  Central African CFA franc
+		"CAD": 2, //  Canadian dollar
+		"KYD": 2, //  Cayman Islands dollar
+		"CLP": 0, //  Chilean peso
+		"CLF": 4, //  Unidad de Fomento (funds code)
+		"CNY": 2, //  Chinese yuan
+		"COP": 2, //  Colombian peso
+		"COU": 2, //  Unidad de Valor Real (UVR) (funds code)[7]
+		"KMF": 0, //  Comoro franc
+		"CDF": 2, //  Congolese franc
+		"NZD": 2, //  New Zealand dollar
+		"CRC": 2, //  Costa Rican colon
+		"HRK": 2, //  Croatian kuna
+		"CUP": 2, //  Cuban peso
+		"CUC": 2, //  Cuban convertible peso
+		"ANG": 2, //  Netherlands Antillean guilder
+		"CZK": 2, //  Czech koruna
+		"DKK": 2, //  Danish krone
+		"DJF": 0, //  Djiboutian franc
+		"DOP": 2, //  Dominican peso
+		"EGP": 2, //  Egyptian pound
+		"SVC": 2, //  Salvadoran colón
+		"ERN": 2, //  Eritrean nakfa
+		"SZL": 2, //  Swazi lilangeni
+		"ETB": 2, //  Ethiopian birr
+		"FKP": 2, //  Falkland Islands pound
+		"FJD": 2, //  Fiji dollar
+		"XPF": 0, //  CFP franc
+		"GMD": 2, //  Gambian dalasi
+		"GEL": 2, //  Georgian lari
+		"GHS": 2, //  Ghanaian cedi
+		"GIP": 2, //  Gibraltar pound
+		"GTQ": 2, //  Guatemalan quetzal
+		"GBP": 2, //  Pound sterling
+		"GNF": 0, //  Guinean franc
+		"GYD": 2, //  Guyanese dollar
+		"HTG": 2, //  Haitian gourde
+		"HNL": 2, //  Honduran lempira
+		"HKD": 2, //  Hong Kong dollar
+		"HUF": 2, //  Hungarian forint
+		"ISK": 0, //  Icelandic króna
+		"IDR": 2, //  Indonesian rupiah
+		"IRR": 2, //  Iranian rial
+		"IQD": 3, //  Iraqi dinar
+		"ILS": 2, //  Israeli new shekel
+		"JMD": 2, //  Jamaican dollar
+		"JPY": 0, //  Japanese yen
+		"JOD": 3, //  Jordanian dinar
+		"KZT": 2, //  Kazakhstani tenge
+		"KES": 2, //  Kenyan shilling
+		"KPW": 2, //  North Korean won
+		"KRW": 0, //  South Korean won
+		"KWD": 3, //  Kuwaiti dinar
+		"KGS": 2, //  Kyrgyzstani som
+		"LAK": 2, //  Lao kip
+		"LBP": 2, //  Lebanese pound
+		"LSL": 2, //  Lesotho loti
+		"ZAR": 2, //  South African rand
+		"LRD": 2, //  Liberian dollar
+		"LYD": 3, //  Libyan dinar
+		"CHF": 2, //  Swiss franc
+		"MOP": 2, //  Macanese pataca
+		"MKD": 2, //  Macedonian denar
+		"MGA": 2, //  Malagasy ariary
+		"MWK": 2, //  Malawian kwacha
+		"MYR": 2, //  Malaysian ringgit
+		"MVR": 2, //  Maldivian rufiyaa
+		"MRU": 2, //  Mauritanian ouguiya
+		"MUR": 2, //  Mauritian rupee
+		"MXN": 2, //  Mexican peso
+		"MXV": 2, //  Mexican Unidad de Inversion (UDI) (funds code)
+		"MDL": 2, //  Moldovan leu
+		"MNT": 2, //  Mongolian tögrög
+		"MAD": 2, //  Moroccan dirham
+		"MZN": 2, //  Mozambican metical
+		"MMK": 2, //  Burmese kyat
+		"NAD": 2, //  Namibian dollar
+		"NPR": 2, //  Nepalese rupee
+		"NIO": 2, //  Nicaraguan córdoba
+		"NGN": 2, //  Nigerian naira
+		"OMR": 3, //  Omani rial
+		"PKR": 2, //  Pakistani rupee
+		"PAB": 2, //  Panamanian balboa
+		"PGK": 2, //  Papua New Guinean kina
+		"PYG": 0, //  Paraguayan guaraní
+		"PEN": 2, //  Peruvian sol
+		"PHP": 2, //  Philippine peso
+		"PLN": 2, //  Polish złoty
+		"QAR": 2, //  Qatari riyal
+		"RON": 2, //  Romanian leu
+		"RUB": 2, //  Russian ruble
+		"RWF": 0, //  Rwandan franc
+		"SHP": 2, //  Saint Helena pound
+		"WST": 2, //  Samoan tala
+		"STN": 2, //  São Tomé and Príncipe dobra
+		"SAR": 2, //  Saudi riyal
+		"RSD": 2, //  Serbian dinar
+		"SCR": 2, //  Seychelles rupee
+		"SLL": 2, //  Sierra Leonean leone
+		"SGD": 2, //  Singapore dollar
+		"SBD": 2, //  Solomon Islands dollar
+		"SOS": 2, //  Somali shilling
+		"SSP": 2, //  South Sudanese pound
+		"LKR": 2, //  Sri Lankan rupee
+		"SDG": 2, //  Sudanese pound
+		"SRD": 2, //  Surinamese dollar
+		"SEK": 2, //  Swedish krona/kronor
+		"CHE": 2, //  WIR Euro (complementary currency)
+		"CHW": 2, //  WIR Franc (complementary currency)
+		"SYP": 2, //  Syrian pound
+		"TWD": 2, //  New Taiwan dollar
+		"TJS": 2, //  Tajikistani somoni
+		"TZS": 2, //  Tanzanian shilling
+		"THB": 2, //  Thai baht
+		"TOP": 2, //  Tongan paʻanga
+		"TTD": 2, //  Trinidad and Tobago dollar
+		"TND": 3, //  Tunisian dinar
+		"TRY": 2, //  Turkish lira
+		"TMT": 2, //  Turkmenistan manat
+		"UGX": 0, //  Ugandan shilling
+		"UAH": 2, //  Ukrainian hryvnia
+		"AED": 2, //  United Arab Emirates dirham
+		"USN": 2, //  United States dollar (next day) (funds code)
+		"UYU": 2, //  Uruguayan peso
+		"UYI": 0, //  Uruguay Peso en Unidades Indexadas (URUIURUI) (funds code)
+		"UYW": 4, //  Unidad previsional[9]
+		"UZS": 2, //  Uzbekistan som
+		"VUV": 0, //  Vanuatu vatu
+		"VES": 2, //  Venezuelan bolívar soberano
+		"VND": 0, //  Vietnamese đồng
+		"YER": 2, //  Yemeni rial
+		"ZMW": 2, //  Zambian kwacha
+		"ZWL": 2, //  Zimbabwean dollar A/10
+	}
+)
+
+func FormatAsset(currencies map[string]int, cur string) string {
+	asset := strings.ToUpper(string(cur))
+
+	def, ok := currencies[asset]
+	if !ok {
+		return asset
+	}
+
+	if def == 0 {
+		return asset
+	}
+
+	return fmt.Sprintf("%s/%d", asset, def)
+}
+
+func FormatAssetWithPrecision(cur string, precision int) string {
+	asset := strings.ToUpper(string(cur))
+	return fmt.Sprintf("%s/%d", asset, precision)
+}
+
+func GetPrecision(currencies map[string]int, cur string) (int, error) {
+	asset := strings.ToUpper(string(cur))
+
+	def, ok := currencies[asset]
+	if !ok {
+		return 0, fmt.Errorf("%s: %w", asset, ErrMissingCurrencies)
+	}
+
+	return def, nil
+}
+
+func GetCurrencyAndPrecisionFromAsset(currencies map[string]int, asset string) (string, int, error) {
+	parts := strings.Split(asset, "/")
+	if len(parts) != 2 {
+		return "", 0, fmt.Errorf("invalid asset: %s", asset)
+	}
+
+	currency := parts[0]
+	precision, err := GetPrecision(currencies, currency)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return currency, precision, nil
+}

--- a/currency/currency.go
+++ b/currency/currency.go
@@ -9,12 +9,6 @@ import (
 var (
 	ErrMissingCurrencies = errors.New("missing currencies")
 
-	UnsupportedCurrencies = map[string]struct{}{
-		"HUF": {},
-		"ISK": {},
-		"TWD": {},
-	}
-
 	ISO4217Currencies = map[string]int{
 		"AFN": 2, //  Afghan afghani
 		"EUR": 2, //  Euro

--- a/currency/currency_test.go
+++ b/currency/currency_test.go
@@ -1,0 +1,67 @@
+package currency
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatAsset(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct{ currency, expected string }{
+		"with precision": {
+			currency: "EUR",
+			expected: "EUR/2",
+		},
+		"zero decimals": {
+			currency: "VND",
+			expected: "VND",
+		},
+		"not in list": {
+			currency: "BBB",
+			expected: "BBB",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := FormatAsset(ISO4217Currencies, tc.currency)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestGetCurrencyAndPrecisionFromAsset(t *testing.T) {
+	currencies := map[string]int{
+		"USD": 2,
+		"EUR": 2,
+		"BTC": 8,
+	}
+
+	tests := map[string]struct {
+		asset       string
+		expectedCur string
+		expectedPre int
+		expectErr   bool
+	}{
+		"typical format": {"USD/2", "USD", 2, false},
+		"different precision provided than in currency list":           {"BTC/55", "BTC", 8, false},
+		"unexpected value after slash still returns correct precision": {"EUR/JPY", "EUR", 2, false},
+		"invalid value":  {"INVALID", "", 0, true},
+		"too many parts": {"USD/4/2", "", 0, true},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cur, pre, err := GetCurrencyAndPrecisionFromAsset(currencies, tt.asset)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedCur, cur)
+				assert.Equal(t, tt.expectedPre, pre)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This just puts the functions from https://github.com/formancehq/payments/tree/main/internal/connectors/plugins/currency into go-libs so they can be used by bank-files service as well.