### PR TITLE
fix: make localstack respect DOCKER_HOST for rootless setups

### DIFF
--- a/queue/localstack_integration_test.go
+++ b/queue/localstack_integration_test.go
@@ -31,11 +31,11 @@ func TestListener(t *testing.T) {
 
 func initClient() (client *sqsservice.Client, queueURL string, ch <-chan *message.Message, err error) {
 	ctx := logging.TestingContext()
-	from_env_opt, err := localstack.WithClientFromEnv()
+	fromEnvOpt, err := localstack.WithClientFromEnv()
 	if err != nil {
 		return nil, "", ch, fmt.Errorf("Could not connect to Docker %w", err)
 	}
-	l, err := localstack.NewInstance(from_env_opt)
+	l, err := localstack.NewInstance(fromEnvOpt)
 	if err != nil {
 		return nil, "", ch, fmt.Errorf("Could not connect to Docker %w", err)
 	}

--- a/queue/localstack_integration_test.go
+++ b/queue/localstack_integration_test.go
@@ -31,7 +31,11 @@ func TestListener(t *testing.T) {
 
 func initClient() (client *sqsservice.Client, queueURL string, ch <-chan *message.Message, err error) {
 	ctx := logging.TestingContext()
-	l, err := localstack.NewInstance()
+	from_env_opt, err := localstack.WithClientFromEnv()
+	if err != nil {
+		return nil, "", ch, fmt.Errorf("Could not connect to Docker %w", err)
+	}
+	l, err := localstack.NewInstance(from_env_opt)
 	if err != nil {
 		return nil, "", ch, fmt.Errorf("Could not connect to Docker %w", err)
 	}


### PR DESCRIPTION
Without it the tests fail to run on my machine (with rootless docker), since it looks for it at `unix:///var/run/docker.sock` instead of checking `DOCKER_HOST`