### PR TITLE
feat(postgres): add support for SetConnMaxLifetime

### DIFF
--- a/bun/bunconnect/connect.go
+++ b/bun/bunconnect/connect.go
@@ -20,12 +20,13 @@ type ConnectionOptions struct {
 	MaxIdleConns       int
 	MaxOpenConns       int
 	ConnMaxIdleTime    time.Duration
+	ConnMaxLifetime    time.Duration
 	Connector          func(dsn string) (driver.Connector, error) `json:",omitempty"`
 }
 
 func (opts ConnectionOptions) String() string {
-	return fmt.Sprintf("dsn=%s, max-idle-conns=%d, max-open-conns=%d, conn-max-idle-time=%s",
-		opts.DatabaseSourceName, opts.MaxIdleConns, opts.MaxOpenConns, opts.ConnMaxIdleTime)
+	return fmt.Sprintf("dsn=%s, max-idle-conns=%d, max-open-conns=%d, conn-max-idle-time=%s, conn-max-lifetime=%s",
+		opts.DatabaseSourceName, opts.MaxIdleConns, opts.MaxOpenConns, opts.ConnMaxIdleTime, opts.ConnMaxLifetime)
 }
 
 func OpenSQLDB(ctx context.Context, options ConnectionOptions, hooks ...bun.QueryHook) (*bun.DB, error) {
@@ -50,6 +51,9 @@ func OpenSQLDB(ctx context.Context, options ConnectionOptions, hooks ...bun.Quer
 	sqldb.SetMaxIdleConns(options.MaxIdleConns)
 	if options.ConnMaxIdleTime != 0 {
 		sqldb.SetConnMaxIdleTime(options.ConnMaxIdleTime)
+	}
+	if options.ConnMaxLifetime != 0 {
+		sqldb.SetConnMaxLifetime(options.ConnMaxLifetime)
 	}
 	if options.MaxOpenConns != 0 {
 		sqldb.SetMaxOpenConns(options.MaxOpenConns)

--- a/bun/bunconnect/flags.go
+++ b/bun/bunconnect/flags.go
@@ -24,6 +24,7 @@ const (
 	PostgresMaxIdleConnsFlag    = "postgres-max-idle-conns"
 	PostgresMaxOpenConnsFlag    = "postgres-max-open-conns"
 	PostgresConnMaxIdleTimeFlag = "postgres-conn-max-idle-time"
+	PostgresConnMaxLifetimeFlag = "postgres-conn-max-lifetime"
 )
 
 func AddFlags(flags *pflag.FlagSet) {
@@ -31,6 +32,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.Bool(PostgresAWSEnableIAMFlag, false, "Enable AWS IAM authentication")
 	flags.Int(PostgresMaxIdleConnsFlag, 0, "Max Idle connections")
 	flags.Duration(PostgresConnMaxIdleTimeFlag, time.Minute, "Max Idle time for connections")
+	flags.Duration(PostgresConnMaxLifetimeFlag, 0, "Max lifetime for connections")
 	flags.Int(PostgresMaxOpenConnsFlag, 20, "Max opened connections")
 }
 
@@ -87,12 +89,14 @@ func ConnectionOptionsFromFlags(cmd *cobra.Command, opts ...Option) (*Connection
 	}
 	maxIdleConns, _ := cmd.Flags().GetInt(PostgresMaxIdleConnsFlag)
 	connMaxIdleConns, _ := cmd.Flags().GetDuration(PostgresConnMaxIdleTimeFlag)
+	connMaxLifetime, _ := cmd.Flags().GetDuration(PostgresConnMaxLifetimeFlag)
 	maxOpenConns, _ := cmd.Flags().GetInt(PostgresMaxOpenConnsFlag)
 
 	return &ConnectionOptions{
 		DatabaseSourceName: postgresUri,
 		MaxIdleConns:       maxIdleConns,
 		ConnMaxIdleTime:    connMaxIdleConns,
+		ConnMaxLifetime:    connMaxLifetime,
 		MaxOpenConns:       maxOpenConns,
 		Connector:          connector,
 	}, nil

--- a/bun/bunconnect/module.go
+++ b/bun/bunconnect/module.go
@@ -23,6 +23,7 @@ func Module(connectionOptions ConnectionOptions, debug bool) fx.Option {
 					"max-idle-conns":         connectionOptions.MaxIdleConns,
 					"max-open-conns":         connectionOptions.MaxOpenConns,
 					"max-conn-max-idle-time": connectionOptions.ConnMaxIdleTime,
+					"conn-max-lifetime":      connectionOptions.ConnMaxLifetime,
 				}).
 				Infof("opening database connection")
 


### PR DESCRIPTION
## Summary

This PR adds support for configuring database connection max lifetime using `SetConnMaxLifetime`.

## Changes

- Added `ConnMaxLifetime` field to `ConnectionOptions` struct (bun/bunconnect/connect.go:23)
- Added `--postgres-conn-max-lifetime` CLI flag with default value of 0 (disabled)
- Added `SetConnMaxLifetime()` call in `OpenSQLDB()` when value is non-zero (bun/bunconnect/connect.go:55-57)
- Updated connection logging to include `conn-max-lifetime` parameter

## Benefits

According to [database/sql documentation](https://pkg.go.dev/database/sql#DB.SetConnMaxLifetime), `SetConnMaxLifetime` sets the maximum amount of time a connection may be reused. This helps:
- Prevent stale or degraded connections from lingering in the pool
- Accommodate databases that disconnect idle sessions after extended periods
- Ensure connections are periodically refreshed rather than held indefinitely

## Usage

```bash
# Set connection lifetime to 10 minutes
--postgres-conn-max-lifetime=10m

# Set connection lifetime to 1 hour
--postgres-conn-max-lifetime=1h

# Disable (default)
--postgres-conn-max-lifetime=0
```

## Test plan

- [ ] Verify the new `--postgres-conn-max-lifetime` flag is available
- [ ] Test with different lifetime values (e.g., 10m, 1h)
- [ ] Verify connections are properly closed and replaced after the specified lifetime
- [ ] Check that logging includes the new connection configuration parameter