### PR TITLE
feat(auth): Inject organizationID claim into request header

### DIFF
--- a/auth/additional_checks.go
+++ b/auth/additional_checks.go
@@ -7,6 +7,8 @@ import (
 	"github.com/formancehq/go-libs/v3/oidc"
 )
 
+const FormanceHeaderOrganizationID = "X-Formance-OrganizationID"
+
 type AdditionalCheck func(*http.Request, *oidc.AccessTokenClaims) error
 
 // OrganizationIDProvider should give the authorizer the ability
@@ -35,6 +37,7 @@ func CheckOrganizationIDClaim(fn OrganizationIDProvider) AdditionalCheck {
 		if orgID == "" {
 			return oidc.ErrOrgIDNotPresent
 		}
+		r.Header.Set(FormanceHeaderOrganizationID, orgID)
 
 		if expectedOrgID != "" && orgID != expectedOrgID {
 			return oidc.ErrOrgIDInvalid


### PR DESCRIPTION
Relates to EN-518