### PR TITLE
chore: Update to v4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters:
     errcheck:
       exclude-functions:
         - (io.Closer).Close
-        - (*github.com/formancehq/go-libs/v3/publish/circuit_breaker.CircuitBreaker).Close
+        - (*github.com/formancehq/go-libs/v4/publish/circuit_breaker.CircuitBreaker).Close
     staticcheck:
       checks:
         - -ST1001 # Use fmt.Errorf for error construction using Sprintf

--- a/api/handler_info_test.go
+++ b/api/handler_info_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/api"
+	"github.com/formancehq/go-libs/v4/api"
 )
 
 func TestInfoHandler(t *testing.T) {

--- a/api/idempotency_test.go
+++ b/api/idempotency_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/api"
+	"github.com/formancehq/go-libs/v4/api"
 )
 
 func TestIdempotencyKeyFromRequest(t *testing.T) {

--- a/api/link_test.go
+++ b/api/link_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/api"
+	"github.com/formancehq/go-libs/v4/api"
 )
 
 func TestLink(t *testing.T) {

--- a/api/logging_chi.go
+++ b/api/logging_chi.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5/middleware"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type chiLogEntry struct {

--- a/api/logging_chi_test.go
+++ b/api/logging_chi_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/api"
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/api"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 func TestChiLogFormatter(t *testing.T) {

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/api"
+	"github.com/formancehq/go-libs/v4/api"
 )
 
 func TestQueryParamBool(t *testing.T) {

--- a/api/response.go
+++ b/api/response.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/formancehq/go-libs/v3/bun/bunpaginate"
+	"github.com/formancehq/go-libs/v4/bun/bunpaginate"
 )
 
 type BaseResponse[T any] struct {

--- a/api/response_test.go
+++ b/api/response_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/bun/bunpaginate"
+	"github.com/formancehq/go-libs/v4/bun/bunpaginate"
 )
 
 func TestCursor(t *testing.T) {

--- a/api/response_utils.go
+++ b/api/response_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/bun/bunpaginate"
+	"github.com/formancehq/go-libs/v4/bun/bunpaginate"
 )
 
 func Encode(t require.TestingT, v interface{}) []byte {

--- a/api/utils.go
+++ b/api/utils.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/formancehq/go-libs/v3/bun/bunpaginate"
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/bun/bunpaginate"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 const (

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/api"
-	"github.com/formancehq/go-libs/v3/bun/bunpaginate"
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/api"
+	"github.com/formancehq/go-libs/v4/bun/bunpaginate"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 func TestWriteErrorResponse(t *testing.T) {

--- a/auth/additional_checks.go
+++ b/auth/additional_checks.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v4/oidc"
 )
 
 type AdditionalCheck func(*http.Request, *oidc.AccessTokenClaims) error

--- a/auth/additional_checks_test.go
+++ b/auth/additional_checks_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/formancehq/go-libs/v3/auth"
-	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v4/auth"
+	"github.com/formancehq/go-libs/v4/oidc"
 )
 
 func TestCheckAudienceClaim(t *testing.T) {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v4/oidc"
 )
 
 type JWTAuth struct {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/oidc"
-	libtime "github.com/formancehq/go-libs/v3/time"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/oidc"
+	libtime "github.com/formancehq/go-libs/v4/time"
 )
 
 func setupTestKeySet(t *testing.T) (oidc.KeySet, *rsa.PrivateKey, string) {

--- a/auth/control_plane_agent.go
+++ b/auth/control_plane_agent.go
@@ -1,6 +1,6 @@
 package auth
 
-import "github.com/formancehq/go-libs/v3/oidc"
+import "github.com/formancehq/go-libs/v4/oidc"
 
 //go:generate mockgen -source control_plane_agent.go -destination control_plane_agent_generated.go -package auth . ControlPlaneAgent
 type ControlPlaneAgent interface {

--- a/auth/control_plane_agent_test.go
+++ b/auth/control_plane_agent_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/formancehq/go-libs/v3/auth"
-	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v4/auth"
+	"github.com/formancehq/go-libs/v4/oidc"
 )
 
 func TestDefaultControlPlaneAgent_GetScopes(t *testing.T) {

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/oidc"
 )
 
 const (

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	gomock "go.uber.org/mock/gomock"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/oidc"
 )
 
 func TestMiddleware(t *testing.T) {

--- a/auth/module.go
+++ b/auth/module.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/oidc"
-	"github.com/formancehq/go-libs/v3/oidc/client"
+	"github.com/formancehq/go-libs/v4/oidc"
+	"github.com/formancehq/go-libs/v4/oidc/client"
 )
 
 type ModuleConfig struct {

--- a/auth/module_test.go
+++ b/auth/module_test.go
@@ -14,9 +14,9 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 
-	"github.com/formancehq/go-libs/v3/auth"
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v4/auth"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/oidc"
 )
 
 // setupTestOIDCServer creates an HTTP test server that simulates an OIDC provider

--- a/auth/scopes.go
+++ b/auth/scopes.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/formancehq/go-libs/v3/collectionutils"
-	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v4/collectionutils"
+	"github.com/formancehq/go-libs/v4/oidc"
 )
 
 func checkScopes(service string, method string, scopes oidc.SpaceDelimitedArray) (bool, error) {

--- a/bun/bunconnect/connect.go
+++ b/bun/bunconnect/connect.go
@@ -12,7 +12,7 @@ import (
 	"github.com/uptrace/bun/dialect/pgdialect"
 	"github.com/uptrace/bun/extra/bunotel"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type ConnectionOptions struct {

--- a/bun/bunconnect/flags.go
+++ b/bun/bunconnect/flags.go
@@ -14,8 +14,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/formancehq/go-libs/v3/aws/iam"
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/aws/iam"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 const (

--- a/bun/bunconnect/iam.go
+++ b/bun/bunconnect/iam.go
@@ -14,11 +14,11 @@ import (
 	"github.com/xo/dburl"
 	"go.opentelemetry.io/otel"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/otlp"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/otlp"
 )
 
-var tracer = otel.Tracer("github.com/formancehq/go-libs/v3/bun/bunconnect")
+var tracer = otel.Tracer("github.com/formancehq/go-libs/v4/bun/bunconnect")
 
 type iamDriver struct {
 	awsConfig aws.Config

--- a/bun/bunconnect/module.go
+++ b/bun/bunconnect/module.go
@@ -6,8 +6,8 @@ import (
 	"github.com/uptrace/bun"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/bun/bundebug"
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/bun/bundebug"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 func Module(connectionOptions ConnectionOptions, debug bool) fx.Option {

--- a/bun/bundebug/debug_hook.go
+++ b/bun/bundebug/debug_hook.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/uptrace/bun"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type QueryHook struct {

--- a/bun/bunmigrate/command.go
+++ b/bun/bunmigrate/command.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/uptrace/bun"
 
-	"github.com/formancehq/go-libs/v3/bun/bunconnect"
+	"github.com/formancehq/go-libs/v4/bun/bunconnect"
 )
 
 type Executor func(cmd *cobra.Command, args []string, db *bun.DB) error

--- a/bun/bunmigrate/run.go
+++ b/bun/bunmigrate/run.go
@@ -11,9 +11,9 @@ import (
 	"github.com/uptrace/bun"
 	"github.com/xo/dburl"
 
-	"github.com/formancehq/go-libs/v3/bun/bunconnect"
-	sharedlogging "github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/pointer"
+	"github.com/formancehq/go-libs/v4/bun/bunconnect"
+	sharedlogging "github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/pointer"
 )
 
 func isDatabaseExists(ctx context.Context, db *bun.DB, name string) (bool, error) {

--- a/bun/bunmigrate/run_test.go
+++ b/bun/bunmigrate/run_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 
-	"github.com/formancehq/go-libs/v3/bun/bunconnect"
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/testing/docker"
-	"github.com/formancehq/go-libs/v3/testing/platform/pgtesting"
+	"github.com/formancehq/go-libs/v4/bun/bunconnect"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/testing/docker"
+	"github.com/formancehq/go-libs/v4/testing/platform/pgtesting"
 )
 
 func TestRunMigrate(t *testing.T) {

--- a/bun/bunpaginate/cursor.go
+++ b/bun/bunpaginate/cursor.go
@@ -1,6 +1,6 @@
 package bunpaginate
 
-import "github.com/formancehq/go-libs/v3/collectionutils"
+import "github.com/formancehq/go-libs/v4/collectionutils"
 
 type Cursor[T any] struct {
 	PageSize int    `json:"pageSize,omitempty"`

--- a/bun/bunpaginate/main_test.go
+++ b/bun/bunpaginate/main_test.go
@@ -3,10 +3,10 @@ package bunpaginate_test
 import (
 	"testing"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/testing/docker"
-	"github.com/formancehq/go-libs/v3/testing/platform/pgtesting"
-	"github.com/formancehq/go-libs/v3/testing/utils"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/testing/docker"
+	"github.com/formancehq/go-libs/v4/testing/platform/pgtesting"
+	"github.com/formancehq/go-libs/v4/testing/utils"
 )
 
 var srv *pgtesting.PostgresServer

--- a/bun/bunpaginate/pagination_column.go
+++ b/bun/bunpaginate/pagination_column.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/uptrace/bun"
 
-	libtime "github.com/formancehq/go-libs/v3/time"
+	libtime "github.com/formancehq/go-libs/v4/time"
 )
 
 func UsingColumn[FILTERS any, ENTITY any](ctx context.Context,

--- a/bun/bunpaginate/pagination_column_test.go
+++ b/bun/bunpaginate/pagination_column_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 
-	"github.com/formancehq/go-libs/v3/bun/bunconnect"
-	"github.com/formancehq/go-libs/v3/bun/bundebug"
-	"github.com/formancehq/go-libs/v3/bun/bunpaginate"
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/bun/bunconnect"
+	"github.com/formancehq/go-libs/v4/bun/bundebug"
+	"github.com/formancehq/go-libs/v4/bun/bunpaginate"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 func TestColumnPagination(t *testing.T) {

--- a/bun/bunpaginate/pagination_offset_test.go
+++ b/bun/bunpaginate/pagination_offset_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 
-	"github.com/formancehq/go-libs/v3/bun/bunconnect"
-	"github.com/formancehq/go-libs/v3/bun/bundebug"
-	bunpaginate2 "github.com/formancehq/go-libs/v3/bun/bunpaginate"
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/bun/bunconnect"
+	"github.com/formancehq/go-libs/v4/bun/bundebug"
+	bunpaginate2 "github.com/formancehq/go-libs/v4/bun/bunpaginate"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 func TestOffsetPagination(t *testing.T) {

--- a/bun/bunpaginate/pagination_query_options.go
+++ b/bun/bunpaginate/pagination_query_options.go
@@ -3,7 +3,7 @@ package bunpaginate
 import (
 	"encoding/json"
 
-	"github.com/formancehq/go-libs/v3/query"
+	"github.com/formancehq/go-libs/v4/query"
 )
 
 type PaginatedQueryOptions[T any] struct {

--- a/collectionutils/linked_list_test.go
+++ b/collectionutils/linked_list_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/collectionutils"
+	"github.com/formancehq/go-libs/v4/collectionutils"
 )
 
 func TestLinkedList(t *testing.T) {

--- a/collectionutils/map_test.go
+++ b/collectionutils/map_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/collectionutils"
+	"github.com/formancehq/go-libs/v4/collectionutils"
 )
 
 func TestKeys(t *testing.T) {

--- a/collectionutils/slice_test.go
+++ b/collectionutils/slice_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/collectionutils"
+	"github.com/formancehq/go-libs/v4/collectionutils"
 )
 
 func TestMap(t *testing.T) {

--- a/errorsutils/errors_test.go
+++ b/errorsutils/errors_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/errorsutils"
+	"github.com/formancehq/go-libs/v4/errorsutils"
 )
 
 func TestErrorWithExitCode(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/formancehq/go-libs/v3
+module github.com/formancehq/go-libs/v4
 
 go 1.24.4
 

--- a/grpcserver/serverport.go
+++ b/grpcserver/serverport.go
@@ -6,8 +6,8 @@ import (
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/serverport"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/serverport"
 )
 
 const serverPortDiscr = "grpc"

--- a/health/controller_test.go
+++ b/health/controller_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/health"
+	"github.com/formancehq/go-libs/v4/health"
 )
 
 func TestHealthController(t *testing.T) {

--- a/httpclient/debug.go
+++ b/httpclient/debug.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type httpTransport struct {

--- a/httpserver/middlewares.go
+++ b/httpserver/middlewares.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type loggingResponseWriter struct {

--- a/httpserver/serverport.go
+++ b/httpserver/serverport.go
@@ -9,8 +9,8 @@ import (
 
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/serverport"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/serverport"
 )
 
 func ContextWithServerInfo(ctx context.Context) context.Context {

--- a/licence/cli.go
+++ b/licence/cli.go
@@ -8,8 +8,8 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/errorsutils"
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/errorsutils"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 var licenceEnabled = false

--- a/licence/cli_test.go
+++ b/licence/cli_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type cliMockLogger struct {

--- a/licence/licence.go
+++ b/licence/licence.go
@@ -3,7 +3,7 @@ package licence
 import (
 	"time"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type Licence struct {

--- a/licence/licence_test.go
+++ b/licence/licence_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 // Mock logger

--- a/logging/adapter_hclog_test.go
+++ b/logging/adapter_hclog_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 func TestHcLogAdapterHook(t *testing.T) {

--- a/migrations/migrator.go
+++ b/migrations/migrator.go
@@ -17,10 +17,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/otlp"
-	"github.com/formancehq/go-libs/v3/platform/postgres"
-	"github.com/formancehq/go-libs/v3/time"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/otlp"
+	"github.com/formancehq/go-libs/v4/platform/postgres"
+	"github.com/formancehq/go-libs/v4/time"
 )
 
 const (

--- a/migrations/migrator_test.go
+++ b/migrations/migrator_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/uptrace/bun/dialect/pgdialect"
 	"github.com/uptrace/bun/extra/bundebug"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/testing/docker"
-	"github.com/formancehq/go-libs/v3/testing/platform/pgtesting"
-	"github.com/formancehq/go-libs/v3/testing/utils"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/testing/docker"
+	"github.com/formancehq/go-libs/v4/testing/platform/pgtesting"
+	"github.com/formancehq/go-libs/v4/testing/utils"
 )
 
 var (

--- a/migrations/versions.go
+++ b/migrations/versions.go
@@ -1,6 +1,6 @@
 package migrations
 
-import "github.com/formancehq/go-libs/v3/time"
+import "github.com/formancehq/go-libs/v4/time"
 
 type Version struct {
 	ID            int       `bun:"id,type:serial,pk,scanonly"`

--- a/oidc/client/device.go
+++ b/oidc/client/device.go
@@ -9,9 +9,9 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/formancehq/go-libs/v3/oidc"
-	httphelper "github.com/formancehq/go-libs/v3/oidc/http"
-	"github.com/formancehq/go-libs/v3/time"
+	"github.com/formancehq/go-libs/v4/oidc"
+	httphelper "github.com/formancehq/go-libs/v4/oidc/http"
+	"github.com/formancehq/go-libs/v4/time"
 )
 
 func newDeviceClientCredentialsRequest(scopes []string, rp RelyingParty) (*oidc.ClientCredentialsRequest, error) {

--- a/oidc/client/discover.go
+++ b/oidc/client/discover.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/formancehq/go-libs/v3/oidc"
-	httphelper "github.com/formancehq/go-libs/v3/oidc/http"
+	"github.com/formancehq/go-libs/v4/oidc"
+	httphelper "github.com/formancehq/go-libs/v4/oidc/http"
 )
 
 // Discover calls the discovery endpoint of the provided issuer and returns its configuration

--- a/oidc/client/introspect.go
+++ b/oidc/client/introspect.go
@@ -3,8 +3,8 @@ package client
 import (
 	"context"
 
-	"github.com/formancehq/go-libs/v3/oidc"
-	httphelper "github.com/formancehq/go-libs/v3/oidc/http"
+	"github.com/formancehq/go-libs/v4/oidc"
+	httphelper "github.com/formancehq/go-libs/v4/oidc/http"
 )
 
 func Introspect(ctx context.Context, relyingParty RelyingParty, token string) (*oidc.IntrospectionResponse, error) {

--- a/oidc/client/jwks.go
+++ b/oidc/client/jwks.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 
-	"github.com/formancehq/go-libs/v3/oidc"
-	httphelper "github.com/formancehq/go-libs/v3/oidc/http"
+	"github.com/formancehq/go-libs/v4/oidc"
+	httphelper "github.com/formancehq/go-libs/v4/oidc/http"
 )
 
 func NewRemoteKeySet(client *http.Client, jwksURL string, opts ...func(*remoteKeySet)) oidc.KeySet {

--- a/oidc/client/relying_party.go
+++ b/oidc/client/relying_party.go
@@ -8,8 +8,8 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"golang.org/x/oauth2"
 
-	"github.com/formancehq/go-libs/v3/oidc"
-	httphelper "github.com/formancehq/go-libs/v3/oidc/http"
+	"github.com/formancehq/go-libs/v4/oidc"
+	httphelper "github.com/formancehq/go-libs/v4/oidc/http"
 )
 
 const (

--- a/oidc/client/signing.go
+++ b/oidc/client/signing.go
@@ -4,9 +4,9 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/zitadel/oidc/v3/pkg/crypto"
 
-	"github.com/formancehq/go-libs/v3/oidc"
-	httphelper "github.com/formancehq/go-libs/v3/oidc/http"
-	"github.com/formancehq/go-libs/v3/time"
+	"github.com/formancehq/go-libs/v4/oidc"
+	httphelper "github.com/formancehq/go-libs/v4/oidc/http"
+	"github.com/formancehq/go-libs/v4/time"
 )
 
 var (

--- a/oidc/client/token.go
+++ b/oidc/client/token.go
@@ -6,9 +6,9 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/formancehq/go-libs/v3/oidc"
-	httphelper "github.com/formancehq/go-libs/v3/oidc/http"
-	"github.com/formancehq/go-libs/v3/time"
+	"github.com/formancehq/go-libs/v4/oidc"
+	httphelper "github.com/formancehq/go-libs/v4/oidc/http"
+	"github.com/formancehq/go-libs/v4/time"
 )
 
 type TokenEndpointCaller interface {

--- a/oidc/client/token_code_exchange.go
+++ b/oidc/client/token_code_exchange.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v4/oidc"
 )
 
 type CodeExchangeOpt func() []oauth2.AuthCodeOption

--- a/oidc/client/token_exchange.go
+++ b/oidc/client/token_exchange.go
@@ -6,9 +6,9 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/formancehq/go-libs/v3/oidc"
-	httphelper "github.com/formancehq/go-libs/v3/oidc/http"
-	"github.com/formancehq/go-libs/v3/time"
+	"github.com/formancehq/go-libs/v4/oidc"
+	httphelper "github.com/formancehq/go-libs/v4/oidc/http"
+	"github.com/formancehq/go-libs/v4/time"
 )
 
 // TokenExchange performs a token exchange as defined in RFC 8693.

--- a/oidc/client/token_refresh.go
+++ b/oidc/client/token_refresh.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v4/oidc"
 )
 
 func (t tokenEndpointCaller) TokenEndpoint() string {

--- a/oidc/client/user_info.go
+++ b/oidc/client/user_info.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	httphelper "github.com/formancehq/go-libs/v3/oidc/http"
+	httphelper "github.com/formancehq/go-libs/v4/oidc/http"
 )
 
 // Userinfo will call the OIDC [UserInfo] Endpoint with the provided token and returns

--- a/oidc/client/verifier.go
+++ b/oidc/client/verifier.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 
-	"github.com/formancehq/go-libs/v3/oidc"
-	"github.com/formancehq/go-libs/v3/time"
+	"github.com/formancehq/go-libs/v4/oidc"
+	"github.com/formancehq/go-libs/v4/time"
 )
 
 // VerifyTokens implement the Token Response Validation as defined in OIDC specification

--- a/oidc/http/http.go
+++ b/oidc/http/http.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v4/oidc"
 )
 
 var DefaultHTTPClient = &http.Client{

--- a/oidc/organization_aware_access_token_claims.go
+++ b/oidc/organization_aware_access_token_claims.go
@@ -1,6 +1,6 @@
 package oidc
 
-import "github.com/formancehq/go-libs/v3/time"
+import "github.com/formancehq/go-libs/v4/time"
 
 const ClaimOrganizationID = "organization_id"
 

--- a/oidc/token.go
+++ b/oidc/token.go
@@ -9,7 +9,7 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/crypto"
 	"golang.org/x/oauth2"
 
-	"github.com/formancehq/go-libs/v3/time"
+	"github.com/formancehq/go-libs/v4/time"
 )
 
 const (

--- a/oidc/token_request.go
+++ b/oidc/token_request.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/formancehq/go-libs/v3/time"
+	"github.com/formancehq/go-libs/v4/time"
 )
 
 const (

--- a/oidc/types.go
+++ b/oidc/types.go
@@ -12,7 +12,7 @@ import (
 	"github.com/zitadel/schema"
 	"golang.org/x/text/language"
 
-	"github.com/formancehq/go-libs/v3/time"
+	"github.com/formancehq/go-libs/v4/time"
 )
 
 type Audience []string

--- a/oidc/verifier.go
+++ b/oidc/verifier.go
@@ -12,7 +12,7 @@ import (
 	jose "github.com/go-jose/go-jose/v4"
 	str "github.com/zitadel/oidc/v3/pkg/strings"
 
-	"github.com/formancehq/go-libs/v3/time"
+	"github.com/formancehq/go-libs/v4/time"
 )
 
 type Claims interface {

--- a/otlp/otlpmetrics/cli.go
+++ b/otlp/otlpmetrics/cli.go
@@ -7,7 +7,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/otlp"
+	"github.com/formancehq/go-libs/v4/otlp"
 )
 
 const (

--- a/otlp/otlpmetrics/module.go
+++ b/otlp/otlpmetrics/module.go
@@ -15,8 +15,8 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/otlp"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/otlp"
 )
 
 const (

--- a/otlp/otlptraces/cli.go
+++ b/otlp/otlptraces/cli.go
@@ -5,7 +5,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/otlp"
+	"github.com/formancehq/go-libs/v4/otlp"
 )
 
 const (

--- a/otlp/otlptraces/cli_test.go
+++ b/otlp/otlptraces/cli_test.go
@@ -14,7 +14,7 @@ import (
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/otlp"
+	"github.com/formancehq/go-libs/v4/otlp"
 )
 
 func TestOTLPTracesModule(t *testing.T) {

--- a/otlp/otlptraces/traces.go
+++ b/otlp/otlptraces/traces.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/otlp"
+	"github.com/formancehq/go-libs/v4/otlp"
 )
 
 const (

--- a/otlp/otlptraces/traces_test.go
+++ b/otlp/otlptraces/traces_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/otlp"
+	"github.com/formancehq/go-libs/v4/otlp"
 )
 
 func TestTracesModule(t *testing.T) {

--- a/platform/postgres/errors_test.go
+++ b/platform/postgres/errors_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/platform/postgres"
+	"github.com/formancehq/go-libs/v4/platform/postgres"
 )
 
 func TestResolveError(t *testing.T) {

--- a/pointer/utils_test.go
+++ b/pointer/utils_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/pointer"
+	"github.com/formancehq/go-libs/v4/pointer"
 )
 
 func TestFor(t *testing.T) {

--- a/profiling/module.go
+++ b/profiling/module.go
@@ -5,7 +5,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/httpserver"
+	"github.com/formancehq/go-libs/v4/httpserver"
 )
 
 // NewModule creates an HTTP server serving pprof "/debug" endpoints on bindPort

--- a/publish/circuit_breaker/circuit_breaker.go
+++ b/publish/circuit_breaker/circuit_breaker.go
@@ -12,8 +12,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/publish/circuit_breaker/storage"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/publish/circuit_breaker/storage"
 )
 
 type State string

--- a/publish/circuit_breaker/circuit_breaker_test.go
+++ b/publish/circuit_breaker/circuit_breaker_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 func TestCircuitBreaker(t *testing.T) {

--- a/publish/circuit_breaker/module.go
+++ b/publish/circuit_breaker/module.go
@@ -6,9 +6,9 @@ import (
 
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/publish/circuit_breaker/storage"
-	topicmapper "github.com/formancehq/go-libs/v3/publish/topic_mapper"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/publish/circuit_breaker/storage"
+	topicmapper "github.com/formancehq/go-libs/v4/publish/topic_mapper"
 )
 
 func Module(schema string, openIntervalDuration time.Duration, storageLimit int, debug bool) fx.Option {

--- a/publish/circuit_breaker/storage/migrations.go
+++ b/publish/circuit_breaker/storage/migrations.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/uptrace/bun"
 
-	"github.com/formancehq/go-libs/v3/migrations"
+	"github.com/formancehq/go-libs/v4/migrations"
 )
 
 func registerMigrations(migrator *migrations.Migrator, schema string) {

--- a/publish/circuit_breaker/storage/module.go
+++ b/publish/circuit_breaker/storage/module.go
@@ -6,8 +6,8 @@ import (
 	"github.com/uptrace/bun"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/bun/bunconnect"
-	"github.com/formancehq/go-libs/v3/bun/bundebug"
+	"github.com/formancehq/go-libs/v4/bun/bunconnect"
+	"github.com/formancehq/go-libs/v4/bun/bundebug"
 )
 
 func Module(schema string, storageLimit int, debug bool) fx.Option {

--- a/publish/circuit_breaker/utils_test.go
+++ b/publish/circuit_breaker/utils_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill/message"
 
-	"github.com/formancehq/go-libs/v3/publish/circuit_breaker/storage"
+	"github.com/formancehq/go-libs/v4/publish/circuit_breaker/storage"
 )
 
 type payload struct {

--- a/publish/cli.go
+++ b/publish/cli.go
@@ -13,9 +13,9 @@ import (
 	"github.com/xdg-go/scram"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/aws/iam"
-	circuitbreaker "github.com/formancehq/go-libs/v3/publish/circuit_breaker"
-	topicmapper "github.com/formancehq/go-libs/v3/publish/topic_mapper"
+	"github.com/formancehq/go-libs/v4/aws/iam"
+	circuitbreaker "github.com/formancehq/go-libs/v4/publish/circuit_breaker"
+	topicmapper "github.com/formancehq/go-libs/v4/publish/topic_mapper"
 )
 
 const (

--- a/publish/logging.go
+++ b/publish/logging.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type watermillLoggerAdapter struct {

--- a/publish/logging_test.go
+++ b/publish/logging_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	"go.uber.org/mock/gomock"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/publish"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/publish"
 )
 
 func TestWatermillLoggerAdapter_Error(t *testing.T) {

--- a/publish/module.go
+++ b/publish/module.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	topicmapper "github.com/formancehq/go-libs/v3/publish/topic_mapper"
+	"github.com/formancehq/go-libs/v4/logging"
+	topicmapper "github.com/formancehq/go-libs/v4/publish/topic_mapper"
 )
 
 func newGoChannel() *gochannel.GoChannel {

--- a/publish/module_test.go
+++ b/publish/module_test.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 func TestModule(t *testing.T) {

--- a/publish/nats.go
+++ b/publish/nats.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 func NewNatsConn(config wNats.PublisherConfig) (*nats.Conn, error) {

--- a/publish/sns.go
+++ b/publish/sns.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/service"
+	"github.com/formancehq/go-libs/v4/service"
 )
 
 func NewSnsPublisher(cmd *cobra.Command, logger watermill.LoggerAdapter, config aws.Config, optFns []func(*snsservice.Options)) (*sns.Publisher, error) {

--- a/publish/sqs.go
+++ b/publish/sqs.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/service"
+	"github.com/formancehq/go-libs/v4/service"
 )
 
 func NewSqsSubscriber(cmd *cobra.Command, logger watermill.LoggerAdapter, config aws.Config, optFns []func(*sqsservice.Options)) (*sqs.Subscriber, error) {

--- a/queue/listener.go
+++ b/queue/listener.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill/message"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type (

--- a/queue/listener_test.go
+++ b/queue/listener_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/queue"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/queue"
 )
 
 func TestNewListenerWorkerCount(t *testing.T) {

--- a/queue/localstack_integration_test.go
+++ b/queue/localstack_integration_test.go
@@ -20,8 +20,8 @@ import (
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/queue"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/queue"
 )
 
 func TestListener(t *testing.T) {

--- a/s3bucket/module.go
+++ b/s3bucket/module.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/aws/iam"
+	"github.com/formancehq/go-libs/v4/aws/iam"
 )
 
 const (

--- a/service/app.go
+++ b/service/app.go
@@ -11,9 +11,9 @@ import (
 	"go.uber.org/dig"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/errorsutils"
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/otlp/otlptraces"
+	"github.com/formancehq/go-libs/v4/errorsutils"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/otlp/otlptraces"
 )
 
 const (

--- a/temporal/client_module.go
+++ b/temporal/client_module.go
@@ -17,7 +17,7 @@ import (
 	"go.temporal.io/sdk/interceptor"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type SearchAttributes struct {

--- a/temporal/logger.go
+++ b/temporal/logger.go
@@ -3,7 +3,7 @@ package temporal
 import (
 	"go.temporal.io/sdk/log"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 func keyvalsToMap(keyvals ...interface{}) map[string]any {

--- a/temporal/worker.go
+++ b/temporal/worker.go
@@ -9,7 +9,7 @@ import (
 	temporalworkflow "go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type Definition struct {

--- a/testing/api/matchers.go
+++ b/testing/api/matchers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/onsi/gomega/types"
 	"github.com/pkg/errors"
 
-	"github.com/formancehq/go-libs/v3/api"
+	"github.com/formancehq/go-libs/v4/api"
 )
 
 type HaveErrorCodeMatcher struct {

--- a/testing/api/utils.go
+++ b/testing/api/utils.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/api"
-	"github.com/formancehq/go-libs/v3/bun/bunpaginate"
+	"github.com/formancehq/go-libs/v4/api"
+	"github.com/formancehq/go-libs/v4/bun/bunpaginate"
 )
 
 func ReadErrorResponse(t *testing.T, r io.Reader) *api.ErrorResponse {

--- a/testing/deferred/ginkgo/helpers.go
+++ b/testing/deferred/ginkgo/helpers.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/formancehq/go-libs/v3/testing/deferred"
+	"github.com/formancehq/go-libs/v4/testing/deferred"
 )
 
 func DeferMap[From, To any](d *deferred.Deferred[From], mapper func(From) To) *deferred.Deferred[To] {

--- a/testing/docker/ginkgo/ginkgo.go
+++ b/testing/docker/ginkgo/ginkgo.go
@@ -3,8 +3,8 @@ package ginkgo
 import (
 	. "github.com/onsi/ginkgo/v2"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/testing/docker"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/testing/docker"
 )
 
 var pool = new(docker.Pool)

--- a/testing/docker/pool.go
+++ b/testing/docker/pool.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type T interface {

--- a/testing/migrations/testing.go
+++ b/testing/migrations/testing.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/migrations"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/migrations"
 )
 
 type HookFn func(ctx context.Context, t *testing.T, db bun.IDB)

--- a/testing/platform/clickhousetesting/clickhouse.go
+++ b/testing/platform/clickhousetesting/clickhouse.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/testing/docker"
+	"github.com/formancehq/go-libs/v4/testing/docker"
 )
 
 type TestingT interface {

--- a/testing/platform/clickhousetesting/ginkgo.go
+++ b/testing/platform/clickhousetesting/ginkgo.go
@@ -3,8 +3,8 @@ package clickhousetesting
 import (
 	. "github.com/onsi/ginkgo/v2"
 
-	"github.com/formancehq/go-libs/v3/testing/deferred"
-	. "github.com/formancehq/go-libs/v3/testing/docker/ginkgo"
+	"github.com/formancehq/go-libs/v4/testing/deferred"
+	. "github.com/formancehq/go-libs/v4/testing/docker/ginkgo"
 )
 
 func WithClickhouse(fn func(d *deferred.Deferred[*Server])) {

--- a/testing/platform/elastictesting/elastic.go
+++ b/testing/platform/elastictesting/elastic.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/testing/docker"
+	"github.com/formancehq/go-libs/v4/testing/docker"
 )
 
 type Configuration struct {

--- a/testing/platform/localstacktesting/localstack.go
+++ b/testing/platform/localstacktesting/localstack.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/testing/docker"
+	"github.com/formancehq/go-libs/v4/testing/docker"
 )
 
 var (

--- a/testing/platform/localstacktesting/localstack_test.go
+++ b/testing/platform/localstacktesting/localstack_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/testing/docker"
-	"github.com/formancehq/go-libs/v3/testing/utils"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/testing/docker"
+	"github.com/formancehq/go-libs/v4/testing/utils"
 )
 
 var srv *LocalstackServer

--- a/testing/platform/natstesting/ginkgo.go
+++ b/testing/platform/natstesting/ginkgo.go
@@ -3,8 +3,8 @@ package natstesting
 import (
 	. "github.com/onsi/ginkgo/v2"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/testing/deferred"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/testing/deferred"
 )
 
 func WithNewNatsServer(logger logging.Logger, fn func(p *deferred.Deferred[*NatsServer])) bool {

--- a/testing/platform/natstesting/nats.go
+++ b/testing/platform/natstesting/nats.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v4/logging"
 )
 
 type NatsT interface {

--- a/testing/platform/pgtesting/ginkgo.go
+++ b/testing/platform/pgtesting/ginkgo.go
@@ -3,8 +3,8 @@ package pgtesting
 import (
 	. "github.com/onsi/ginkgo/v2"
 
-	"github.com/formancehq/go-libs/v3/testing/deferred"
-	. "github.com/formancehq/go-libs/v3/testing/docker/ginkgo"
+	"github.com/formancehq/go-libs/v4/testing/deferred"
+	. "github.com/formancehq/go-libs/v4/testing/docker/ginkgo"
 )
 
 func WithNewPostgresServer(fn func(p *deferred.Deferred[*PostgresServer])) bool {

--- a/testing/platform/pgtesting/postgres.go
+++ b/testing/platform/pgtesting/postgres.go
@@ -13,9 +13,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/bun/bunconnect"
-	sharedlogging "github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/testing/docker"
+	"github.com/formancehq/go-libs/v4/bun/bunconnect"
+	sharedlogging "github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/testing/docker"
 )
 
 type T interface {

--- a/testing/platform/pgtesting/postgres_test.go
+++ b/testing/platform/pgtesting/postgres_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/testing/docker"
-	"github.com/formancehq/go-libs/v3/testing/utils"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/testing/docker"
+	"github.com/formancehq/go-libs/v4/testing/utils"
 )
 
 var srv *PostgresServer

--- a/testing/testservice/ginkgo/helpers.go
+++ b/testing/testservice/ginkgo/helpers.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 
-	"github.com/formancehq/go-libs/v3/testing/deferred"
-	"github.com/formancehq/go-libs/v3/testing/testservice"
+	"github.com/formancehq/go-libs/v4/testing/deferred"
+	"github.com/formancehq/go-libs/v4/testing/testservice"
 )
 
 func DeferNew(

--- a/testing/testservice/instrumentation_debug.go
+++ b/testing/testservice/instrumentation_debug.go
@@ -3,7 +3,7 @@ package testservice
 import (
 	"context"
 
-	"github.com/formancehq/go-libs/v3/service"
+	"github.com/formancehq/go-libs/v4/service"
 )
 
 func DebugInstrumentation(debug bool) Instrumentation {

--- a/testing/testservice/instrumentation_grpcserver.go
+++ b/testing/testservice/instrumentation_grpcserver.go
@@ -3,7 +3,7 @@ package testservice
 import (
 	"context"
 
-	"github.com/formancehq/go-libs/v3/grpcserver"
+	"github.com/formancehq/go-libs/v4/grpcserver"
 )
 
 func GRPCServerInstrumentation() Instrumentation {

--- a/testing/testservice/instrumentation_httpserver.go
+++ b/testing/testservice/instrumentation_httpserver.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/formancehq/go-libs/v3/httpserver"
+	"github.com/formancehq/go-libs/v4/httpserver"
 )
 
 func HTTPServerInstrumentation() Instrumentation {

--- a/testing/testservice/instrumentation_nats.go
+++ b/testing/testservice/instrumentation_nats.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/formancehq/go-libs/v3/publish"
-	"github.com/formancehq/go-libs/v3/testing/deferred"
+	"github.com/formancehq/go-libs/v4/publish"
+	"github.com/formancehq/go-libs/v4/testing/deferred"
 )
 
 func NatsInstrumentation(url *deferred.Deferred[string]) Instrumentation {

--- a/testing/testservice/instrumentation_otlp.go
+++ b/testing/testservice/instrumentation_otlp.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/formancehq/go-libs/v3/otlp"
-	"github.com/formancehq/go-libs/v3/otlp/otlpmetrics"
-	"github.com/formancehq/go-libs/v3/testing/deferred"
+	"github.com/formancehq/go-libs/v4/otlp"
+	"github.com/formancehq/go-libs/v4/otlp/otlpmetrics"
+	"github.com/formancehq/go-libs/v4/testing/deferred"
 )
 
 func OTLPInstrumentation(otlpConfiguration *deferred.Deferred[OTLPConfig]) Instrumentation {

--- a/testing/testservice/instrumentation_postgres.go
+++ b/testing/testservice/instrumentation_postgres.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/formancehq/go-libs/v3/bun/bunconnect"
-	"github.com/formancehq/go-libs/v3/testing/deferred"
+	"github.com/formancehq/go-libs/v4/bun/bunconnect"
+	"github.com/formancehq/go-libs/v4/testing/deferred"
 )
 
 func PostgresInstrumentation(postgresConfiguration *deferred.Deferred[bunconnect.ConnectionOptions]) Instrumentation {

--- a/testing/testservice/service.go
+++ b/testing/testservice/service.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/go-libs/v3/service"
+	"github.com/formancehq/go-libs/v4/logging"
+	"github.com/formancehq/go-libs/v4/service"
 )
 
 type Service struct {

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	libtime "github.com/formancehq/go-libs/v3/time"
+	libtime "github.com/formancehq/go-libs/v4/time"
 )
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
release go-libs v4 since https://github.com/formancehq/go-libs/pull/546 is a breaking change