### PR TITLE
fix(s3): remove hardcoded dummy credentials, add miniotesting

### DIFF
--- a/pkg/fx/storagefx/s3.go
+++ b/pkg/fx/storagefx/s3.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -33,14 +32,7 @@ func s3AWSModule(cmd *cobra.Command, s3EndpointOverride string) fx.Option {
 	return fx.Options(
 		fx.Provide(
 			fx.Annotate(func(optFn func(*config.LoadOptions) error) []func(*config.LoadOptions) error {
-				loadOptions := []func(*config.LoadOptions) error{optFn}
-				if s3EndpointOverride != "" {
-					// if we are overriding the endpoint assume we are in a dev context
-					loadOptions = append(loadOptions, config.WithCredentialsProvider(
-						credentials.NewStaticCredentialsProvider("dummy", "dummy", "dummy"),
-					))
-				}
-				return loadOptions
+				return []func(*config.LoadOptions) error{optFn}
 			}, fx.ParamTags(`name:"s3-bucket-aws-enabled"`), fx.ResultTags(`name:"s3-bucket-load-opts"`)),
 		),
 		fx.Provide(

--- a/pkg/fx/storagefx/s3.go
+++ b/pkg/fx/storagefx/s3.go
@@ -19,16 +19,17 @@ func S3ModuleFromFlags(cmd *cobra.Command) fx.Option {
 
 	awsEnabled, _ := cmd.Flags().GetBool(s3bucket.S3BucketAWSEnabledFlag)
 	endpointOverride, _ := cmd.Flags().GetString(s3bucket.S3BucketEndpointOverrideFlag)
+	pathStyle, _ := cmd.Flags().GetBool(s3bucket.S3BucketPathStyleFlag)
 	if awsEnabled {
 		options = append(options,
 			fx.Supply(fx.Annotate(iam.LoadOptionFromFlags(cmd.Flags()), fx.ResultTags(`name:"s3-bucket-aws-enabled"`))),
-			s3AWSModule(cmd, endpointOverride),
+			s3AWSModule(cmd, endpointOverride, pathStyle),
 		)
 	}
 	return fx.Options(options...)
 }
 
-func s3AWSModule(cmd *cobra.Command, s3EndpointOverride string) fx.Option {
+func s3AWSModule(cmd *cobra.Command, s3EndpointOverride string, pathStyle bool) fx.Option {
 	return fx.Options(
 		fx.Provide(
 			fx.Annotate(func(optFn func(*config.LoadOptions) error) []func(*config.LoadOptions) error {
@@ -48,6 +49,10 @@ func s3AWSModule(cmd *cobra.Command, s3EndpointOverride string) fx.Option {
 			fx.Annotate(func() ([]func(*s3.Options), error) {
 				s3Opts := []func(*s3.Options){}
 				if s3EndpointOverride == "" {
+					// Real AWS S3: always use path style
+					s3Opts = append(s3Opts, func(o *s3.Options) {
+						o.UsePathStyle = true
+					})
 					return s3Opts, nil
 				}
 
@@ -56,9 +61,13 @@ func s3AWSModule(cmd *cobra.Command, s3EndpointOverride string) fx.Option {
 					return s3Opts, fmt.Errorf("unable to parse s3 url %q", s3EndpointOverride)
 				}
 				s3Opts = append(s3Opts, func(o *s3.Options) {
-					o.UsePathStyle = true
 					o.BaseEndpoint = aws.String(s3Url.String())
 				})
+				if pathStyle {
+					s3Opts = append(s3Opts, func(o *s3.Options) {
+						o.UsePathStyle = true
+					})
+				}
 				return s3Opts, nil
 			}, fx.ResultTags(`name:"s3-bucket-aws-opts"`, ``)),
 		),

--- a/pkg/storage/s3/module.go
+++ b/pkg/storage/s3/module.go
@@ -7,9 +7,11 @@ import (
 const (
 	S3BucketAWSEnabledFlag       = "s3-bucket-aws-enabled"
 	S3BucketEndpointOverrideFlag = "s3-bucket-endpoint-override"
+	S3BucketPathStyleFlag        = "s3-bucket-path-style"
 )
 
 func AddFlags(flags *pflag.FlagSet) {
 	flags.Bool(S3BucketAWSEnabledFlag, true, "Use AWS S3")
 	flags.String(S3BucketEndpointOverrideFlag, "", "Connect to S3 using a custom endpoint (eg. localstack)")
+	flags.Bool(S3BucketPathStyleFlag, false, "Use path-style addressing for S3-compatible endpoints (always enabled for AWS S3)")
 }

--- a/pkg/testing/platform/miniotesting/ginkgo.go
+++ b/pkg/testing/platform/miniotesting/ginkgo.go
@@ -1,0 +1,23 @@
+package miniotesting
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/formancehq/go-libs/v5/pkg/testing/deferred"
+	. "github.com/formancehq/go-libs/v5/pkg/testing/docker/ginkgo"
+)
+
+func WithNewMinioServer(fn func(p *deferred.Deferred[*MinioServer]), opts ...Option) bool {
+	return Context("With new minio server", func() {
+		ret := deferred.New[*MinioServer]()
+		BeforeEach(func() {
+			ret.Reset()
+			ret.SetValue(CreateMinioServer(
+				GinkgoT(),
+				ActualDockerPool(),
+				opts...,
+			))
+		})
+		fn(ret)
+	})
+}

--- a/pkg/testing/platform/miniotesting/minio.go
+++ b/pkg/testing/platform/miniotesting/minio.go
@@ -1,0 +1,123 @@
+package miniotesting
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/formancehq/go-libs/v5/pkg/testing/docker"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	DefaultAccessKey = "minioadmin"
+	DefaultSecretKey = "minioadmin"
+	DefaultRegion    = "us-east-1"
+)
+
+type T interface {
+	require.TestingT
+	Cleanup(func())
+	Helper()
+}
+
+type MinioServer struct {
+	Endpoint  string
+	AccessKey string
+	SecretKey string
+	Region    string
+}
+
+func (s *MinioServer) GetAWSConfig() aws.Config {
+	return aws.Config{
+		Region:      s.Region,
+		Credentials: credentials.NewStaticCredentialsProvider(s.AccessKey, s.SecretKey, ""),
+	}
+}
+
+func (s *MinioServer) NewS3Client() *s3.Client {
+	return s3.NewFromConfig(s.GetAWSConfig(), func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(s.Endpoint)
+		o.UsePathStyle = true
+	})
+}
+
+func (s *MinioServer) CreateBucket(ctx context.Context, t T, bucket string) {
+	t.Helper()
+	client := s.NewS3Client()
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket:                    aws.String(bucket),
+		CreateBucketConfiguration: &s3types.CreateBucketConfiguration{LocationConstraint: s3types.BucketLocationConstraint(s.Region)},
+	})
+	require.NoError(t, err, "creating minio bucket %q", bucket)
+}
+
+type Option func(*config)
+
+type config struct {
+	accessKey string
+	secretKey string
+	tag       string
+}
+
+func WithCredentials(accessKey, secretKey string) Option {
+	return func(c *config) {
+		c.accessKey = accessKey
+		c.secretKey = secretKey
+	}
+}
+
+func WithTag(tag string) Option {
+	return func(c *config) {
+		c.tag = tag
+	}
+}
+
+func CreateMinioServer(t T, pool *docker.Pool, opts ...Option) *MinioServer {
+	t.Helper()
+
+	cfg := &config{
+		accessKey: DefaultAccessKey,
+		secretKey: DefaultSecretKey,
+		tag:       "latest",
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	resource := pool.Run(docker.Configuration{
+		RunOptions: &dockertest.RunOptions{
+			Repository: "minio/minio",
+			Tag:        cfg.tag,
+			Cmd:        []string{"server", "/data"},
+			Env: []string{
+				"MINIO_ROOT_USER=" + cfg.accessKey,
+				"MINIO_ROOT_PASSWORD=" + cfg.secretKey,
+			},
+		},
+		CheckFn: func(ctx context.Context, resource *dockertest.Resource) error {
+			endpoint := fmt.Sprintf("http://127.0.0.1:%s", resource.GetPort("9000/tcp"))
+			resp, err := http.Get(endpoint + "/minio/health/live")
+			if err != nil {
+				return err
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("minio health check returned %d", resp.StatusCode)
+			}
+			return nil
+		},
+	})
+
+	return &MinioServer{
+		Endpoint:  fmt.Sprintf("http://127.0.0.1:%s", resource.GetPort("9000/tcp")),
+		AccessKey: cfg.accessKey,
+		SecretKey: cfg.secretKey,
+		Region:    DefaultRegion,
+	}
+}

--- a/pkg/testing/platform/miniotesting/minio.go
+++ b/pkg/testing/platform/miniotesting/minio.go
@@ -9,15 +9,17 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/formancehq/go-libs/v5/pkg/testing/docker"
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/testing/docker"
 )
 
 const (
 	DefaultAccessKey = "minioadmin"
 	DefaultSecretKey = "minioadmin"
 	DefaultRegion    = "us-east-1"
+	DefaultTag       = "RELEASE.2025-04-22T22-12-26Z"
 )
 
 type T interface {
@@ -84,7 +86,7 @@ func CreateMinioServer(t T, pool *docker.Pool, opts ...Option) *MinioServer {
 	cfg := &config{
 		accessKey: DefaultAccessKey,
 		secretKey: DefaultSecretKey,
-		tag:       "latest",
+		tag:       DefaultTag,
 	}
 	for _, opt := range opts {
 		opt(cfg)

--- a/pkg/testing/platform/miniotesting/minio_test.go
+++ b/pkg/testing/platform/miniotesting/minio_test.go
@@ -149,6 +149,7 @@ func TestS3ModuleFromFlags_WithMinioCredentials(t *testing.T) {
 
 	require.NoError(t, cmd.Flags().Set("s3-bucket-aws-enabled", "true"))
 	require.NoError(t, cmd.Flags().Set("s3-bucket-endpoint-override", srv.Endpoint))
+	require.NoError(t, cmd.Flags().Set("s3-bucket-path-style", "true"))
 	require.NoError(t, cmd.Flags().Set("aws-access-key-id", srv.AccessKey))
 	require.NoError(t, cmd.Flags().Set("aws-secret-access-key", srv.SecretKey))
 	require.NoError(t, cmd.Flags().Set("aws-region", srv.Region))

--- a/pkg/testing/platform/miniotesting/minio_test.go
+++ b/pkg/testing/platform/miniotesting/minio_test.go
@@ -1,0 +1,183 @@
+package miniotesting
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/formancehq/go-libs/v5/pkg/cloud/aws/iam"
+	"github.com/formancehq/go-libs/v5/pkg/fx/storagefx"
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	s3bucket "github.com/formancehq/go-libs/v5/pkg/storage/s3"
+	"github.com/formancehq/go-libs/v5/pkg/testing/docker"
+	"github.com/formancehq/go-libs/v5/pkg/testing/utils"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+var srv *MinioServer
+
+func TestMain(m *testing.M) {
+	utils.WithTestMain(func(t *utils.TestingTForMain) int {
+		pool := docker.NewPool(t, logging.Testing())
+		srv = CreateMinioServer(t, pool)
+		return m.Run()
+	})
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := &config{
+		accessKey: DefaultAccessKey,
+		secretKey: DefaultSecretKey,
+		tag:       "latest",
+	}
+
+	assert.Equal(t, "minioadmin", cfg.accessKey)
+	assert.Equal(t, "minioadmin", cfg.secretKey)
+	assert.Equal(t, "latest", cfg.tag)
+}
+
+func TestWithCredentials(t *testing.T) {
+	cfg := &config{
+		accessKey: DefaultAccessKey,
+		secretKey: DefaultSecretKey,
+		tag:       "latest",
+	}
+
+	WithCredentials("custom-key", "custom-secret")(cfg)
+	assert.Equal(t, "custom-key", cfg.accessKey)
+	assert.Equal(t, "custom-secret", cfg.secretKey)
+}
+
+func TestWithTag(t *testing.T) {
+	cfg := &config{
+		accessKey: DefaultAccessKey,
+		secretKey: DefaultSecretKey,
+		tag:       "latest",
+	}
+
+	WithTag("RELEASE.2024-01-01T00-00-00Z")(cfg)
+	assert.Equal(t, "RELEASE.2024-01-01T00-00-00Z", cfg.tag)
+}
+
+func TestMinioServer_GetAWSConfig(t *testing.T) {
+	cfg := srv.GetAWSConfig()
+	assert.Equal(t, "us-east-1", cfg.Region)
+	require.NotNil(t, cfg.Credentials)
+
+	creds, err := cfg.Credentials.Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, DefaultAccessKey, creds.AccessKeyID)
+	assert.Equal(t, DefaultSecretKey, creds.SecretAccessKey)
+}
+
+func TestMinioServer_NewS3Client(t *testing.T) {
+	client := srv.NewS3Client()
+	require.NotNil(t, client)
+	assert.Equal(t, srv.Endpoint, *client.Options().BaseEndpoint)
+}
+
+func TestMinioServer_CreateBucketAndListBuckets(t *testing.T) {
+	ctx := context.Background()
+
+	srv.CreateBucket(ctx, t, "test-bucket")
+
+	client := srv.NewS3Client()
+	result, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	require.NoError(t, err)
+
+	var found bool
+	for _, b := range result.Buckets {
+		if aws.ToString(b.Name) == "test-bucket" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "bucket 'test-bucket' should exist")
+}
+
+func TestMinioServer_PutAndGetObject(t *testing.T) {
+	ctx := context.Background()
+	bucket := "put-get-test"
+
+	srv.CreateBucket(ctx, t, bucket)
+
+	client := srv.NewS3Client()
+
+	body := []byte("hello minio")
+	_, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("test-key"),
+		Body:   bytes.NewReader(body),
+	})
+	require.NoError(t, err)
+
+	out, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("test-key"),
+	})
+	require.NoError(t, err)
+	defer out.Body.Close()
+
+	got, err := io.ReadAll(out.Body)
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
+}
+
+func TestS3ModuleFromFlags_WithMinioCredentials(t *testing.T) {
+	ctx := context.Background()
+	bucket := "fx-module-test"
+
+	srv.CreateBucket(ctx, t, bucket)
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	s3bucket.AddFlags(cmd.Flags())
+	iam.AddFlags(cmd.Flags())
+	cmd.SetContext(ctx)
+
+	require.NoError(t, cmd.Flags().Set("s3-bucket-aws-enabled", "true"))
+	require.NoError(t, cmd.Flags().Set("s3-bucket-endpoint-override", srv.Endpoint))
+	require.NoError(t, cmd.Flags().Set("aws-access-key-id", srv.AccessKey))
+	require.NoError(t, cmd.Flags().Set("aws-secret-access-key", srv.SecretKey))
+	require.NoError(t, cmd.Flags().Set("aws-region", srv.Region))
+
+	var client *s3.Client
+	app := fxtest.New(t,
+		storagefx.S3ModuleFromFlags(cmd),
+		fx.Populate(&client),
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	require.NotNil(t, client)
+
+	body := []byte("fx module test data")
+	_, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("fx-test-key"),
+		Body:   bytes.NewReader(body),
+	})
+	require.NoError(t, err)
+
+	out, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("fx-test-key"),
+	})
+	require.NoError(t, err)
+	defer out.Body.Close()
+
+	got, err := io.ReadAll(out.Body)
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
+}

--- a/pkg/testing/platform/miniotesting/minio_test.go
+++ b/pkg/testing/platform/miniotesting/minio_test.go
@@ -8,17 +8,18 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
 	"github.com/formancehq/go-libs/v5/pkg/cloud/aws/iam"
 	"github.com/formancehq/go-libs/v5/pkg/fx/storagefx"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 	s3bucket "github.com/formancehq/go-libs/v5/pkg/storage/s3"
 	"github.com/formancehq/go-libs/v5/pkg/testing/docker"
 	"github.com/formancehq/go-libs/v5/pkg/testing/utils"
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/fx"
-	"go.uber.org/fx/fxtest"
 )
 
 var srv *MinioServer
@@ -35,12 +36,12 @@ func TestDefaultConfig(t *testing.T) {
 	cfg := &config{
 		accessKey: DefaultAccessKey,
 		secretKey: DefaultSecretKey,
-		tag:       "latest",
+		tag:       DefaultTag,
 	}
 
 	assert.Equal(t, "minioadmin", cfg.accessKey)
 	assert.Equal(t, "minioadmin", cfg.secretKey)
-	assert.Equal(t, "latest", cfg.tag)
+	assert.Equal(t, DefaultTag, cfg.tag)
 }
 
 func TestWithCredentials(t *testing.T) {


### PR DESCRIPTION
## Summary
- **Remove hardcoded dummy S3 credentials** in `pkg/fx/storagefx/s3.go` — the `s3AWSModule` unconditionally injected `StaticCredentialsProvider("dummy", "dummy", "dummy")` when an endpoint override was set, overriding real credentials from IAM flags. This broke S3 operations against MinIO or any auth-requiring S3-compatible store.
- **Make path-style addressing configurable** — added `--s3-bucket-path-style` flag. Path style is always enabled for real AWS S3 (no endpoint override). For S3-compatible services (endpoint override), it's now explicitly configurable instead of being hardcoded.
- **Add `pkg/testing/platform/miniotesting`** — reusable package for spinning up MinIO containers in tests, following the same pattern as `localstacktesting` and `pgtesting`.

## Why
The dummy credentials were intended for LocalStack (which doesn't need auth), but they silently overwrote real IAM credentials when used with MinIO. This caused `InvalidAccessKeyId` errors in integration tests of services like `terraform-hcp-proxy`.

## Credential configuration
Credentials are no longer magically injected. They must be provided explicitly via:
- CLI flags: `--aws-access-key-id` / `--aws-secret-access-key`
- Environment variables: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
- AWS default credential chain (IAM role, shared config, etc.)

## Path-style addressing
- **Real AWS S3** (no endpoint override): always `UsePathStyle = true`
- **S3-compatible services** (endpoint override): configurable via `--s3-bucket-path-style` flag (default: `false`)

## Test plan
- [x] Unit tests: config options, AWS config construction, S3 client creation
- [x] Integration tests: create bucket, put/get object, `S3ModuleFromFlags` with real MinIO credentials and path-style flag
- [x] All 8 tests pass against a real MinIO container

🤖 Generated with [Claude Code](https://claude.com/claude-code)