### PR TITLE
fix(migrations): scope version_id unique index name per table

### DIFF
--- a/pkg/storage/migrations/migrator.go
+++ b/pkg/storage/migrations/migrator.go
@@ -91,9 +91,9 @@ func (m *Migrator) initSchema(ctx context.Context, db bun.IDB) error {
 		add column if not exists max_counter numeric,
 		add column if not exists actual_counter numeric,
 		add column if not exists terminated_at timestamp;
-	
-		create unique index if not exists 
-		idx_version_id on ` + m.tableName + ` (version_id);
+
+		create unique index if not exists
+		"idx_` + m.tableName + `_version_id" on ` + m.tableName + ` (version_id);
 	`
 
 	_, err := db.ExecContext(ctx, query)

--- a/pkg/storage/migrations/migrator_test.go
+++ b/pkg/storage/migrations/migrator_test.go
@@ -162,6 +162,28 @@ func TestMigrationsNominal(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestTwoMigratorsSameSchema reproduces a bug where two migrators using
+// different table names but sharing the same schema could not coexist:
+// the version_id unique index name was hardcoded ("idx_version_id"), and
+// since index names are scoped per-schema in PostgreSQL, the second
+// migrator's CREATE UNIQUE INDEX IF NOT EXISTS was silently skipped,
+// leaving its INSERT ... ON CONFLICT (version_id) without a matching
+// unique constraint (SQLSTATE 42P10).
+func TestTwoMigratorsSameSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	schema := uuid.NewString()[:8]
+
+	first := NewMigrator(bunDB, WithSchema(schema), WithTableName("first_migrations"))
+	first.RegisterMigrations(Migration{Up: func(ctx context.Context, db bun.IDB) error { return nil }})
+	require.NoError(t, first.Up(ctx))
+
+	second := NewMigrator(bunDB, WithSchema(schema), WithTableName("second_migrations"))
+	second.RegisterMigrations(Migration{Up: func(ctx context.Context, db bun.IDB) error { return nil }})
+	require.NoError(t, second.Up(ctx))
+}
+
 func TestAddFlags(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

PostgreSQL scopes index names per-schema, not per-table. The migrator's `initSchema` hardcoded the unique index on `version_id` as `idx_version_id`, so two migrators sharing a schema with different `tableName` values collided on that name. The second `CREATE UNIQUE INDEX IF NOT EXISTS idx_version_id` becomes a silent no-op (Postgres matches by name only), leaving its table with no unique index on `version_id`. The follow-up `INSERT ... ON CONFLICT (version_id)` then fails with **SQLSTATE 42P10**.

This change derives the index name from `tableName` (`idx_<tableName>_version_id`), matching the per-table naming pattern Postgres uses for auto-generated PK names. Multiple migrators can now coexist in any single schema.

## Concrete impact

Multiple staging stacks crashing at startup with:

```
Error: failed to create version table: failed to insert version:
ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification (SQLSTATE 42P10)
```

Triggered when a service runs both:
- the system migrator (`goose_db_version` / `goose_db_version_v3`), and
- the circuit-breaker migrator (`circuit_breaker_migrations`),

in the same schema (`_system` for ledger, `public` for payments / orchestration). Confirmed live: Postgres returned `NOTICE: relation "idx_version_id" already exists, skipping` for the circuit-breaker migrator's `CREATE UNIQUE INDEX`, leaving its table without the unique index needed by the subsequent INSERT.

## Forward compatibility

Existing databases keep working unchanged on the next deploy:

- Tables that already have `idx_version_id` (the system migrator's table) — the old index is left in place and still satisfies the `ON CONFLICT (version_id)` planner check; the new `idx_<tableName>_version_id` is created in addition (redundant but harmless).
- Tables where the second migrator's index was never created (the broken case) — `CREATE UNIQUE INDEX IF NOT EXISTS idx_<tableName>_version_id` succeeds because the new name no longer collides; startup completes.

No DB-side migration or manual SQL is required to recover broken stacks: bumping go-libs in the affected services is enough.

## Test plan

- [x] Added `TestTwoMigratorsSameSchema` reproducing the exact failure mode (two migrators in one schema with different `tableName`s) — fails on `main`, passes with this change.
- [x] Existing migrator tests pass: `go test -tags=it -race ./pkg/storage/migrations/...`