### PR TITLE
fix(migrations): scope version_id unique index name per table (backport v2.2)

### DIFF
--- a/migrations/migrator.go
+++ b/migrations/migrator.go
@@ -93,8 +93,8 @@ func (m *Migrator) initSchema(ctx context.Context, db bun.IDB) error {
 		add column if not exists actual_counter numeric,
 		add column if not exists terminated_at timestamp;
 	
-		create unique index if not exists 
-		idx_version_id on ` + m.tableName + ` (version_id);
+		create unique index if not exists
+		"idx_` + m.tableName + `_version_id" on ` + m.tableName + ` (version_id);
 	`
 
 	_, err := db.ExecContext(ctx, query)

--- a/migrations/migrator_test.go
+++ b/migrations/migrator_test.go
@@ -164,6 +164,28 @@ func TestMigrationsNominal(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestTwoMigratorsSameSchema reproduces a bug where two migrators using
+// different table names but sharing the same schema could not coexist:
+// the version_id unique index name was hardcoded ("idx_version_id"), and
+// since index names are scoped per-schema in PostgreSQL, the second
+// migrator's CREATE UNIQUE INDEX IF NOT EXISTS was silently skipped,
+// leaving its INSERT ... ON CONFLICT (version_id) without a matching
+// unique constraint (SQLSTATE 42P10).
+func TestTwoMigratorsSameSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	schema := uuid.NewString()[:8]
+
+	first := NewMigrator(bunDB, WithSchema(schema), WithTableName("first_migrations"))
+	first.RegisterMigrations(Migration{Up: func(ctx context.Context, db bun.IDB) error { return nil }})
+	require.NoError(t, first.Up(ctx))
+
+	second := NewMigrator(bunDB, WithSchema(schema), WithTableName("second_migrations"))
+	second.RegisterMigrations(Migration{Up: func(ctx context.Context, db bun.IDB) error { return nil }})
+	require.NoError(t, second.Up(ctx))
+}
+
 func TestAddFlags(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Backport of #594 to `release/v2.2`.

## Bug

The migrator's `initSchema` hardcoded the unique index on `version_id` as `idx_version_id`. Index names in PostgreSQL are scoped per-schema (not per-table), so when two migrators share a schema but use different `tableName` values, the second `CREATE UNIQUE INDEX IF NOT EXISTS idx_version_id ...` is a silent no-op (matched by name only). The follow-up `INSERT ... ON CONFLICT (version_id)` then fails with SQLSTATE 42P10 because no unique index covers the conflict target on the second table.

This was originally observed when the system migrator and the circuit-breaker migrator ran against the same schema.

## Fix

Use `idx_<tableName>_version_id` so the index name is unique per table within a schema. The name is quoted to remain consistent with how `tableName` may itself need quoting (matches the v5 fix in #594).

## Forward compatibility

Existing DBs self-heal on next deploy:
- The legacy `idx_version_id` (where present) is left untouched and still satisfies the `ON CONFLICT (version_id)` planner check on the original table.
- The new `idx_<tableName>_version_id` is created in addition by `CREATE UNIQUE INDEX IF NOT EXISTS` on next `initSchema`, so any new (second) migrator sharing the schema now gets its own unique index.

No data migration is required.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./migrations/...`
- [x] `go test -tags=it -race -count=1 -timeout=180s ./migrations/...` (integration tests pass against dockerized Postgres)
- [x] New regression test `TestTwoMigratorsSameSchema` reproduces the bug on the previous code and passes after the fix.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>