### PR TITLE
fix(migrations): scope version_id unique index name per table (backport v3.6)

### DIFF
--- a/migrations/migrator.go
+++ b/migrations/migrator.go
@@ -92,8 +92,8 @@ func (m *Migrator) initSchema(ctx context.Context, db bun.IDB) error {
 		add column if not exists actual_counter numeric,
 		add column if not exists terminated_at timestamp;
 	
-		create unique index if not exists 
-		idx_version_id on ` + m.tableName + ` (version_id);
+		create unique index if not exists
+		"idx_` + m.tableName + `_version_id" on ` + m.tableName + ` (version_id);
 	`
 
 	_, err := db.ExecContext(ctx, query)

--- a/migrations/migrator_test.go
+++ b/migrations/migrator_test.go
@@ -162,6 +162,28 @@ func TestMigrationsNominal(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestTwoMigratorsSameSchema reproduces a bug where two migrators using
+// different table names but sharing the same schema could not coexist:
+// the version_id unique index name was hardcoded ("idx_version_id"), and
+// since index names are scoped per-schema in PostgreSQL, the second
+// migrator's CREATE UNIQUE INDEX IF NOT EXISTS was silently skipped,
+// leaving its INSERT ... ON CONFLICT (version_id) without a matching
+// unique constraint (SQLSTATE 42P10).
+func TestTwoMigratorsSameSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	schema := uuid.NewString()[:8]
+
+	first := NewMigrator(bunDB, WithSchema(schema), WithTableName("first_migrations"))
+	first.RegisterMigrations(Migration{Up: func(ctx context.Context, db bun.IDB) error { return nil }})
+	require.NoError(t, first.Up(ctx))
+
+	second := NewMigrator(bunDB, WithSchema(schema), WithTableName("second_migrations"))
+	second.RegisterMigrations(Migration{Up: func(ctx context.Context, db bun.IDB) error { return nil }})
+	require.NoError(t, second.Up(ctx))
+}
+
 func TestAddFlags(t *testing.T) {
 	t.Parallel()
 

--- a/queue/localstack_integration_test.go
+++ b/queue/localstack_integration_test.go
@@ -35,7 +35,7 @@ func initClient() (client *sqsservice.Client, queueURL string, ch <-chan *messag
 	if err != nil {
 		return nil, "", ch, fmt.Errorf("Could not connect to Docker %w", err)
 	}
-	l, err := localstack.NewInstance(fromEnvOpt)
+	l, err := localstack.NewInstance(fromEnvOpt, localstack.WithVersion("4.14"))
 	if err != nil {
 		return nil, "", ch, fmt.Errorf("Could not connect to Docker %w", err)
 	}

--- a/testing/platform/localstacktesting/localstack.go
+++ b/testing/platform/localstacktesting/localstack.go
@@ -23,7 +23,7 @@ var (
 	defaultHostIP   = "0.0.0.0"
 	defaultBindPort = 4566
 
-	defaultVersion = "community-archive"
+	defaultVersion = "4.14"
 	defaultOptions = []Option{
 		WithService("s3"),
 		WithDefaultRegion("us-east-1"),

--- a/testing/platform/localstacktesting/localstack.go
+++ b/testing/platform/localstacktesting/localstack.go
@@ -23,7 +23,7 @@ var (
 	defaultHostIP   = "0.0.0.0"
 	defaultBindPort = 4566
 
-	defaultVersion = "latest"
+	defaultVersion = "community-archive"
 	defaultOptions = []Option{
 		WithService("s3"),
 		WithDefaultRegion("us-east-1"),


### PR DESCRIPTION
## Summary

Backport of #594 to `release/v3.6`.

## Bug

In PostgreSQL, index names are scoped per-schema, not per-table. The migrator's `initSchema` hardcoded the unique index on `version_id` as `idx_version_id`. When two migrators share a schema but use different `tableName` values (e.g. a system migrator and a circuit-breaker migrator both rooted at `_system`), the second `CREATE UNIQUE INDEX IF NOT EXISTS idx_version_id` is a silent no-op because the name already exists in that schema (attached to the first table). The second table then has no unique index covering `version_id`, and the subsequent `INSERT ... ON CONFLICT (version_id) DO NOTHING` fails with:

```
SQLSTATE 42P10: there is no unique or exclusion constraint matching the ON CONFLICT specification
```

## Fix

Use `idx_<tableName>_version_id` so each table gets its own uniquely-named index in the shared schema. The new name is quoted to stay consistent with how `tableName` is otherwise treated in this codebase.

## Forward compatibility

Existing databases self-heal on next deploy: the old `idx_version_id` (where it exists) is left untouched and still satisfies the `ON CONFLICT` planner check for whichever table it's attached to; the new per-table index is created in addition on next `initSchema` run. No data migration required.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./migrations/...` passes
- [x] `go test -tags=it -race -count=1 -timeout=180s ./migrations/...` passes (including the new `TestTwoMigratorsSameSchema` regression test that fails on `release/v3.6` HEAD before this fix)