### PR TITLE
fix(migrations): scope version_id unique index name per table (backport v4)

### DIFF
--- a/migrations/migrator.go
+++ b/migrations/migrator.go
@@ -92,8 +92,8 @@ func (m *Migrator) initSchema(ctx context.Context, db bun.IDB) error {
 		add column if not exists actual_counter numeric,
 		add column if not exists terminated_at timestamp;
 	
-		create unique index if not exists 
-		idx_version_id on ` + m.tableName + ` (version_id);
+		create unique index if not exists
+		"idx_` + m.tableName + `_version_id" on ` + m.tableName + ` (version_id);
 	`
 
 	_, err := db.ExecContext(ctx, query)

--- a/migrations/migrator_test.go
+++ b/migrations/migrator_test.go
@@ -162,6 +162,28 @@ func TestMigrationsNominal(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestTwoMigratorsSameSchema reproduces a bug where two migrators using
+// different table names but sharing the same schema could not coexist:
+// the version_id unique index name was hardcoded ("idx_version_id"), and
+// since index names are scoped per-schema in PostgreSQL, the second
+// migrator's CREATE UNIQUE INDEX IF NOT EXISTS was silently skipped,
+// leaving its INSERT ... ON CONFLICT (version_id) without a matching
+// unique constraint (SQLSTATE 42P10).
+func TestTwoMigratorsSameSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	schema := uuid.NewString()[:8]
+
+	first := NewMigrator(bunDB, WithSchema(schema), WithTableName("first_migrations"))
+	first.RegisterMigrations(Migration{Up: func(ctx context.Context, db bun.IDB) error { return nil }})
+	require.NoError(t, first.Up(ctx))
+
+	second := NewMigrator(bunDB, WithSchema(schema), WithTableName("second_migrations"))
+	second.RegisterMigrations(Migration{Up: func(ctx context.Context, db bun.IDB) error { return nil }})
+	require.NoError(t, second.Up(ctx))
+}
+
 func TestAddFlags(t *testing.T) {
 	t.Parallel()
 

--- a/queue/localstack_integration_test.go
+++ b/queue/localstack_integration_test.go
@@ -35,7 +35,7 @@ func initClient() (client *sqsservice.Client, queueURL string, ch <-chan *messag
 	if err != nil {
 		return nil, "", ch, fmt.Errorf("Could not connect to Docker %w", err)
 	}
-	l, err := localstack.NewInstance(fromEnvOpt)
+	l, err := localstack.NewInstance(fromEnvOpt, localstack.WithVersion("4.14"))
 	if err != nil {
 		return nil, "", ch, fmt.Errorf("Could not connect to Docker %w", err)
 	}

--- a/testing/platform/localstacktesting/localstack.go
+++ b/testing/platform/localstacktesting/localstack.go
@@ -23,7 +23,7 @@ var (
 	defaultHostIP   = "0.0.0.0"
 	defaultBindPort = 4566
 
-	defaultVersion = "community-archive"
+	defaultVersion = "4.14"
 	defaultOptions = []Option{
 		WithService("s3"),
 		WithDefaultRegion("us-east-1"),

--- a/testing/platform/localstacktesting/localstack.go
+++ b/testing/platform/localstacktesting/localstack.go
@@ -23,7 +23,7 @@ var (
 	defaultHostIP   = "0.0.0.0"
 	defaultBindPort = 4566
 
-	defaultVersion = "latest"
+	defaultVersion = "community-archive"
 	defaultOptions = []Option{
 		WithService("s3"),
 		WithDefaultRegion("us-east-1"),


### PR DESCRIPTION
## Summary

Backport of #594 from `main` to `release/v4`.

## Bug

The migrator's `initSchema` hardcoded the unique index on `version_id` as `idx_version_id`. In PostgreSQL, index names are scoped per-schema rather than per-table, so when two migrators with different `tableName` values share the same schema (e.g. system migrator + circuit-breaker migrator), the second `CREATE UNIQUE INDEX IF NOT EXISTS idx_version_id` becomes a silent no-op — the name already exists in the schema. The follow-up `INSERT ... ON CONFLICT (version_id)` then fails with **SQLSTATE 42P10** because no unique constraint covers the conflict-target column on the second table.

## Fix

Use `idx_<tableName>_version_id` so the name is unique per table within a schema, matching the per-table naming pattern PostgreSQL uses for auto-generated PK names.

## Forward compatibility

Existing databases self-heal on next deploy:
- The old `idx_version_id` (where present) is left untouched and still satisfies the `ON CONFLICT` planner check on the table that originally created it.
- On startup the new `idx_<tableName>_version_id` is created in addition, fixing any subsequent collocated migrators.

No data migration or manual intervention required.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./migrations/...`
- [x] `go test -tags=it -race -count=1 -timeout=180s ./migrations/...` (passes, including the new `TestTwoMigratorsSameSchema` regression test)