### PR TITLE
fix: handle read-only Postgres sessions

### DIFF
--- a/pkg/storage/bun/connect/connect.go
+++ b/pkg/storage/bun/connect/connect.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/pgdialect"
 	"github.com/uptrace/bun/extra/bunotel"
@@ -52,14 +53,14 @@ func obfuscateDSN(dsn string) string {
 func OpenSQLDB(ctx context.Context, options ConnectionOptions, hooks ...bun.QueryHook) (*bun.DB, error) {
 	var (
 		sqldb *sql.DB
-		err   error
 	)
 	if options.Connector == nil {
 		logging.FromContext(ctx).Debugf("Opening database with default connector and dsn: '%s'", obfuscateDSN(options.DatabaseSourceName))
-		sqldb, err = sql.Open("pgx", options.DatabaseSourceName)
+		parseConfig, err := pgx.ParseConfig(options.DatabaseSourceName)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse dsn: %w", err)
 		}
+		sqldb = sql.OpenDB(buildPGXConnector(parseConfig))
 	} else {
 		logging.FromContext(ctx).Debugf("Opening database with connector and dsn: '%s'", obfuscateDSN(options.DatabaseSourceName))
 		connector, err := options.Connector(options.DatabaseSourceName)

--- a/pkg/storage/bun/connect/connect_test.go
+++ b/pkg/storage/bun/connect/connect_test.go
@@ -1,7 +1,11 @@
 package connect
 
 import (
+	"reflect"
 	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 func TestObfuscateDSN(t *testing.T) {
@@ -59,5 +63,26 @@ func TestObfuscateDSN(t *testing.T) {
 				t.Errorf("obfuscateDSN(%q) = %q, want %q", tt.dsn, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestBuildPGXConnectorDefaultsToReadWriteTargetSessionAttrs(t *testing.T) {
+	config, err := pgx.ParseConfig("postgres://localhost:5432/mydb?sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.ValidateConnect != nil {
+		t.Fatal("expected parsed config without target_session_attrs to have no ValidateConnect")
+	}
+
+	_ = buildPGXConnector(config)
+
+	if config.ValidateConnect == nil {
+		t.Fatal("expected connector builder to set ValidateConnect")
+	}
+	got := reflect.ValueOf(config.ValidateConnect).Pointer()
+	want := reflect.ValueOf(pgconn.ValidateConnectTargetSessionAttrsReadWrite).Pointer()
+	if got != want {
+		t.Fatalf("unexpected ValidateConnect func pointer: got %x, want %x", got, want)
 	}
 }

--- a/pkg/storage/bun/connect/flags.go
+++ b/pkg/storage/bun/connect/flags.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
@@ -94,9 +93,7 @@ func ConnectionOptionsFromFlags(flags *pflag.FlagSet, ctx context.Context, opts 
 				opt(parseConfig)
 			}
 
-			parseConfig.Tracer = newPgxTracer()
-
-			return stdlib.GetConnector(*parseConfig), nil
+			return buildPGXConnector(parseConfig), nil
 		}
 	}
 

--- a/pkg/storage/bun/connect/iam.go
+++ b/pkg/storage/bun/connect/iam.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pkg/errors"
 	"github.com/xo/dburl"
 	"go.opentelemetry.io/otel"
@@ -100,9 +99,7 @@ func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
 		opt(config)
 	}
 
-	config.Tracer = newPgxTracer()
-
-	return stdlib.GetConnector(*config).Connect(ctx)
+	return buildPGXConnector(config).Connect(ctx)
 }
 
 func (i iamConnector) Driver() driver.Driver {

--- a/pkg/storage/bun/connect/pgx.go
+++ b/pkg/storage/bun/connect/pgx.go
@@ -1,0 +1,39 @@
+package connect
+
+import (
+	"context"
+	"database/sql/driver"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/stdlib"
+)
+
+func buildPGXConnector(config *pgx.ConnConfig) driver.Connector {
+	if config.ValidateConnect == nil {
+		config.ValidateConnect = pgconn.ValidateConnectTargetSessionAttrsReadWrite
+	}
+	config.Tracer = newPgxTracer()
+
+	return stdlib.GetConnector(*config, stdlib.OptionResetSession(resetReadOnlySession))
+}
+
+func resetReadOnlySession(ctx context.Context, conn *pgx.Conn) error {
+	var readOnly string
+	if err := conn.QueryRow(ctx, "show transaction_read_only").Scan(&readOnly); err != nil {
+		return err
+	}
+	if readOnly == "on" {
+		return driver.ErrBadConn
+	}
+
+	var defaultReadOnly string
+	if err := conn.QueryRow(ctx, "show default_transaction_read_only").Scan(&defaultReadOnly); err != nil {
+		return err
+	}
+	if defaultReadOnly == "on" {
+		return driver.ErrBadConn
+	}
+
+	return nil
+}

--- a/pkg/storage/postgres/errors.go
+++ b/pkg/storage/postgres/errors.go
@@ -29,6 +29,8 @@ func ResolveError(err error) error {
 				return newErrTooManyClient(err)
 			case pgerrcode.DeadlockDetected:
 				return ErrDeadlockDetected
+			case pgerrcode.ReadOnlySQLTransaction:
+				return ErrReadOnlyTransaction
 			case pgerrcode.SerializationFailure:
 				return ErrSerialization
 			case pgerrcode.UndefinedTable:
@@ -49,11 +51,12 @@ func ResolveError(err error) error {
 }
 
 var (
-	ErrNotFound         = errors.New("not found")
-	ErrDeadlockDetected = errors.New("deadlock detected")
-	ErrSerialization    = errors.New("serialization error")
-	ErrMissingTable     = errors.New("missing table")
-	ErrMissingSchema    = errors.New("missing schema")
+	ErrNotFound            = errors.New("not found")
+	ErrDeadlockDetected    = errors.New("deadlock detected")
+	ErrReadOnlyTransaction = errors.New("read-only transaction")
+	ErrSerialization       = errors.New("serialization error")
+	ErrMissingTable        = errors.New("missing table")
+	ErrMissingSchema       = errors.New("missing schema")
 )
 
 func IsNotFoundError(err error) bool {

--- a/pkg/storage/postgres/errors_test.go
+++ b/pkg/storage/postgres/errors_test.go
@@ -113,6 +113,16 @@ func TestResolveError(t *testing.T) {
 		require.ErrorIs(t, err, postgres.ErrDeadlockDetected)
 	})
 
+	t.Run("ReadOnlyTransactionError", func(t *testing.T) {
+		t.Parallel()
+		pgErr := &pgconn.PgError{
+			Code:    "25006",
+			Message: "cannot execute CREATE TABLE in a read-only transaction",
+		}
+		err := postgres.ResolveError(pgErr)
+		require.ErrorIs(t, err, postgres.ErrReadOnlyTransaction)
+	})
+
 	t.Run("SerializationError", func(t *testing.T) {
 		t.Parallel()
 		pgErr := &pgconn.PgError{

--- a/pkg/testing/platform/pgtesting/postgres_test.go
+++ b/pkg/testing/platform/pgtesting/postgres_test.go
@@ -2,6 +2,7 @@ package pgtesting
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	bunconnect "github.com/formancehq/go-libs/v5/pkg/storage/bun/connect"
 	"github.com/formancehq/go-libs/v5/pkg/testing/docker"
 	"github.com/formancehq/go-libs/v5/pkg/testing/utils"
 )
@@ -33,4 +35,56 @@ func TestPostgres(t *testing.T) {
 			require.NoError(t, conn.Close(context.Background()))
 		})
 	}
+}
+
+func TestConnectRejectsReadOnlySessions(t *testing.T) {
+	t.Parallel()
+	database := srv.NewDatabase(t)
+	ctx := logging.TestingContext()
+
+	t.Run("reset_session_discards_read_only_connections_before_reuse", func(t *testing.T) {
+		t.Parallel()
+
+		db, err := bunconnect.OpenSQLDB(ctx, bunconnect.ConnectionOptions{
+			DatabaseSourceName: database.ConnString(),
+			MaxIdleConns:       1,
+			MaxOpenConns:       1,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, db.Close())
+		})
+
+		_, err = db.ExecContext(ctx, "set default_transaction_read_only=on")
+		require.NoError(t, err)
+
+		_, err = db.ExecContext(ctx, "create temp table reset_session_probe(id int)")
+		require.NoError(t, err)
+
+		var readOnly string
+		require.NoError(t, db.QueryRowContext(ctx, "show transaction_read_only").Scan(&readOnly))
+		require.Equal(t, "off", readOnly)
+	})
+}
+
+func TestReadOnlySQLState25006(t *testing.T) {
+	t.Parallel()
+	database := srv.NewDatabase(t)
+	ctx := logging.TestingContext()
+
+	db, err := sql.Open("pgx", database.ConnString())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tx.Rollback()
+	})
+
+	_, err = tx.ExecContext(ctx, "create temp table read_only_sqlstate_probe(id int)")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "SQLSTATE 25006")
 }


### PR DESCRIPTION
## Summary
- map PostgreSQL SQLSTATE `25006` to `postgres.ErrReadOnlyTransaction`
- route pgx connector creation through a shared helper that defaults to read-write targets
- add `OptionResetSession` handling to discard read-only sessions before reuse
- cover SQLSTATE mapping, read-write target selection, and read-only session reset behavior with tests

## Validation
- `nix develop --command go test ./pkg/storage/postgres ./pkg/storage/bun/connect ./pkg/testing/platform/pgtesting`
- `nix develop --command just tests`
- `nix develop --command just pc`
