### PR TITLE
feat(logging): add Trace level to Logger

### DIFF
--- a/pkg/authn/licence/licence_test.go
+++ b/pkg/authn/licence/licence_test.go
@@ -65,6 +65,8 @@ func (m *mockLogger) Warn(args ...any)                                {}
 func (m *mockLogger) Warnf(format string, args ...any)                {}
 func (m *mockLogger) Debug(args ...any)                               {}
 func (m *mockLogger) Debugf(format string, args ...any)               {}
+func (m *mockLogger) Trace(args ...any)                               {}
+func (m *mockLogger) Tracef(format string, args ...any)               {}
 func (m *mockLogger) Enabled(level logging.Level) bool                { return true }
 
 func (m *mockLogger) getMessage() string {

--- a/pkg/observe/log/adapter_logrus.go
+++ b/pkg/observe/log/adapter_logrus.go
@@ -11,6 +11,8 @@ import (
 
 type LogrusLogger struct {
 	entry interface {
+		Tracef(format string, args ...any)
+		Trace(args ...any)
 		Debugf(format string, args ...any)
 		Debug(args ...any)
 		Infof(format string, args ...any)
@@ -36,6 +38,12 @@ func (l *LogrusLogger) WithContext(ctx context.Context) Logger {
 	}
 }
 
+func (l *LogrusLogger) Trace(args ...any) {
+	l.entry.Trace(args...)
+}
+func (l *LogrusLogger) Tracef(fmt string, args ...any) {
+	l.entry.Tracef(fmt, args...)
+}
 func (l *LogrusLogger) Debug(args ...any) {
 	l.entry.Debug(args...)
 }
@@ -69,6 +77,8 @@ func (l *LogrusLogger) WithField(key string, value any) Logger {
 
 func toLogrusLevel(level Level) logrus.Level {
 	switch level {
+	case TraceLevel:
+		return logrus.TraceLevel
 	case DebugLevel:
 		return logrus.DebugLevel
 	case InfoLevel:
@@ -116,11 +126,24 @@ func NewDefaultLogger(
 	formatJSON bool,
 	otelTraces bool,
 ) *LogrusLogger {
+	level := InfoLevel
+	if debug {
+		level = DebugLevel
+	}
+	return NewDefaultLoggerWithLevel(w, level, formatJSON, otelTraces)
+}
+
+// NewDefaultLoggerWithLevel builds a LogrusLogger configured at the given level.
+// Prefer this constructor over NewDefaultLogger when callers need Trace verbosity.
+func NewDefaultLoggerWithLevel(
+	w io.Writer,
+	level Level,
+	formatJSON bool,
+	otelTraces bool,
+) *LogrusLogger {
 	l := logrus.New()
 	l.SetOutput(w)
-	if debug {
-		l.Level = logrus.DebugLevel
-	}
+	l.Level = toLogrusLevel(level)
 
 	var formatter logrus.Formatter
 	if formatJSON {

--- a/pkg/observe/log/adapter_zap_logger.go
+++ b/pkg/observe/log/adapter_zap_logger.go
@@ -1,0 +1,102 @@
+package logging
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+
+	"go.uber.org/zap"
+)
+
+// ZapLogger adapts a *zap.SugaredLogger to the Logger interface.
+//
+// Use NewZap to wrap an existing sugared logger, or NopZap for a silent
+// logger (mainly in tests and CLI subcommands that don't need output).
+//
+// Trace records are emitted at a custom zapcore.Level (see zapTraceLevel
+// in level_zap.go), one notch below DebugLevel. Cores that don't enable
+// that level — including OTel exporters wrapped with a MinLevelCore floor
+// at DebugLevel — will drop trace records, which is by design: trace is
+// meant for local stdout-only diagnostics.
+type ZapLogger struct {
+	sugar *zap.SugaredLogger
+}
+
+var _ Logger = (*ZapLogger)(nil)
+
+// NewZap wraps a *zap.SugaredLogger as a Logger.
+func NewZap(sugar *zap.SugaredLogger) *ZapLogger {
+	return &ZapLogger{sugar: sugar}
+}
+
+// NopZap returns a Logger backed by zap.NewNop() — useful in tests and
+// short-lived CLI commands that need a Logger but discard everything.
+func NopZap() *ZapLogger {
+	return &ZapLogger{sugar: zap.NewNop().Sugar()}
+}
+
+func (z *ZapLogger) Tracef(format string, args ...any) {
+	z.sugar.Logf(zapTraceLevel, format, args...)
+}
+func (z *ZapLogger) Trace(args ...any)                 { z.sugar.Log(zapTraceLevel, args...) }
+func (z *ZapLogger) Debugf(format string, args ...any) { z.sugar.Debugf(format, args...) }
+func (z *ZapLogger) Infof(format string, args ...any)  { z.sugar.Infof(format, args...) }
+func (z *ZapLogger) Errorf(format string, args ...any) { z.sugar.Errorf(format, args...) }
+func (z *ZapLogger) Debug(args ...any)                 { z.sugar.Debug(args...) }
+func (z *ZapLogger) Info(args ...any)                  { z.sugar.Info(args...) }
+func (z *ZapLogger) Error(args ...any)                 { z.sugar.Error(args...) }
+
+func (z *ZapLogger) Enabled(level Level) bool {
+	return z.sugar.Desugar().Core().Enabled(ToZapLevel(level))
+}
+
+func (z *ZapLogger) WithFields(fields map[string]any) Logger {
+	kvs := make([]any, 0, len(fields)*2)
+	for k, v := range fields {
+		kvs = append(kvs, k, v)
+	}
+
+	return &ZapLogger{sugar: z.sugar.With(kvs...)}
+}
+
+func (z *ZapLogger) WithField(key string, value any) Logger {
+	return &ZapLogger{sugar: z.sugar.With(key, value)}
+}
+
+// WithContext returns self; OTel correlation is expected to be handled by
+// an attached otelzap core (or equivalent bridge) rather than by re-wrapping
+// the logger per call.
+func (z *ZapLogger) WithContext(_ context.Context) Logger {
+	return z
+}
+
+// Writer returns an io.Writer that logs each scanned line at InfoLevel.
+// Useful for adapting third-party loggers that only accept an io.Writer.
+func (z *ZapLogger) Writer() io.Writer {
+	pr, pw := io.Pipe()
+
+	go func() {
+		scanner := bufio.NewScanner(pr)
+		for scanner.Scan() {
+			z.sugar.Info(scanner.Text())
+		}
+
+		if err := scanner.Err(); err != nil {
+			z.sugar.Errorf("log writer scanner error: %v", err)
+		}
+	}()
+
+	return pw
+}
+
+// Zap returns the underlying *zap.Logger. Use this when interfacing with
+// libraries that require a zap.Logger directly (e.g. etcd WAL).
+func (z *ZapLogger) Zap() *zap.Logger {
+	return z.sugar.Desugar()
+}
+
+// String implements fmt.Stringer for debug purposes.
+func (z *ZapLogger) String() string {
+	return fmt.Sprintf("ZapLogger{%v}", z.sugar)
+}

--- a/pkg/observe/log/adapter_zap_logger_test.go
+++ b/pkg/observe/log/adapter_zap_logger_test.go
@@ -1,0 +1,186 @@
+package logging
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// newTestZapLogger builds a ZapLogger writing to buf at the given level.
+// The console core uses ToZapLevel + EncodeLevelWithTrace so the test
+// exercises the full pipeline.
+func newTestZapLogger(buf *bytes.Buffer, level Level) (*ZapLogger, *threadSafeSyncer) {
+	sink := &threadSafeSyncer{buf: buf}
+
+	encCfg := zap.NewProductionEncoderConfig()
+	encCfg.EncodeLevel = EncodeLevelWithTrace(zapcore.LowercaseLevelEncoder)
+	enc := zapcore.NewJSONEncoder(encCfg)
+
+	core := zapcore.NewCore(enc, sink, ToZapLevel(level))
+	return NewZap(zap.New(core).Sugar()), sink
+}
+
+// threadSafeSyncer wraps a bytes.Buffer with a mutex; zapcore.AddSync
+// alone doesn't synchronise concurrent writes, which trips the race
+// detector when the Writer() goroutine logs in parallel with assertions.
+type threadSafeSyncer struct {
+	mu  sync.Mutex
+	buf *bytes.Buffer
+}
+
+func (s *threadSafeSyncer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *threadSafeSyncer) Sync() error { return nil }
+
+func (s *threadSafeSyncer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+func TestZapLoggerTraceEmittedAtTraceLevel(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger, sink := newTestZapLogger(&buf, TraceLevel)
+
+	logger.Trace("trace-msg")
+	logger.Tracef("trace-fmt-%d", 42)
+	logger.Debug("debug-msg")
+	logger.Info("info-msg")
+
+	out := sink.String()
+	for _, want := range []string{"trace-msg", "trace-fmt-42", "debug-msg", "info-msg", `"level":"trace"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestZapLoggerTraceSilentAtDebugLevel(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger, sink := newTestZapLogger(&buf, DebugLevel)
+
+	logger.Trace("should-not-appear")
+	logger.Tracef("nor-%s", "this")
+	logger.Debug("debug-still-emitted")
+
+	out := sink.String()
+	if strings.Contains(out, "should-not-appear") || strings.Contains(out, "nor-this") {
+		t.Errorf("trace records leaked into Debug-level output:\n%s", out)
+	}
+	if !strings.Contains(out, "debug-still-emitted") {
+		t.Errorf("debug record missing from output:\n%s", out)
+	}
+}
+
+func TestZapLoggerEnabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		configured Level
+		check      Level
+		want       bool
+	}{
+		{TraceLevel, TraceLevel, true},
+		{TraceLevel, DebugLevel, true},
+		{TraceLevel, InfoLevel, true},
+		{DebugLevel, TraceLevel, false},
+		{DebugLevel, DebugLevel, true},
+		{InfoLevel, DebugLevel, false},
+		{InfoLevel, InfoLevel, true},
+		{ErrorLevel, InfoLevel, false},
+		{ErrorLevel, ErrorLevel, true},
+	}
+
+	for _, tc := range cases {
+		var buf bytes.Buffer
+		logger, _ := newTestZapLogger(&buf, tc.configured)
+		if got := logger.Enabled(tc.check); got != tc.want {
+			t.Errorf("Enabled(%v) on level=%v = %v, want %v", tc.check, tc.configured, got, tc.want)
+		}
+	}
+}
+
+func TestZapLoggerWithFields(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	base, sink := newTestZapLogger(&buf, TraceLevel)
+
+	child := base.WithFields(map[string]any{"req_id": "abc", "n": 7})
+	child.Tracef("tagged")
+
+	out := sink.String()
+	for _, want := range []string{`"req_id":"abc"`, `"n":7`, "tagged"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestNopZap(t *testing.T) {
+	t.Parallel()
+
+	l := NopZap()
+	// All methods should be safe to call and produce no output.
+	l.Trace("x")
+	l.Tracef("x-%d", 1)
+	l.Debug("x")
+	l.Info("x")
+	l.Error("x")
+	l.WithField("k", "v").Trace("y")
+	if l.Enabled(ErrorLevel) {
+		t.Errorf("NopZap should report all levels as disabled")
+	}
+}
+
+// TestMinLevelCoreFiltersTrace verifies the canonical use case: a console
+// core accepting Trace, a second core (e.g. OTel bridge) wrapped with
+// MinLevelCore at DebugLevel rejecting Trace. Trace records must reach
+// the console only.
+func TestMinLevelCoreFiltersTrace(t *testing.T) {
+	t.Parallel()
+
+	var consoleBuf, otelBuf bytes.Buffer
+	consoleSink := &threadSafeSyncer{buf: &consoleBuf}
+	otelSink := &threadSafeSyncer{buf: &otelBuf}
+
+	encCfg := zap.NewProductionEncoderConfig()
+	encCfg.EncodeLevel = EncodeLevelWithTrace(zapcore.LowercaseLevelEncoder)
+	enc := zapcore.NewJSONEncoder(encCfg)
+
+	consoleCore := zapcore.NewCore(enc, consoleSink, ToZapLevel(TraceLevel))
+	otelCore := &MinLevelCore{
+		Core: zapcore.NewCore(enc, otelSink, ToZapLevel(TraceLevel)),
+		Min:  zapcore.DebugLevel,
+	}
+
+	logger := NewZap(zap.New(zapcore.NewTee(consoleCore, otelCore)).Sugar())
+
+	logger.Trace("trace-only-on-console")
+	logger.Debug("debug-on-both")
+
+	consoleOut := consoleSink.String()
+	otelOut := otelSink.String()
+
+	if !strings.Contains(consoleOut, "trace-only-on-console") {
+		t.Errorf("console core missed trace record:\n%s", consoleOut)
+	}
+	if strings.Contains(otelOut, "trace-only-on-console") {
+		t.Errorf("MinLevelCore failed to drop trace from OTel core:\n%s", otelOut)
+	}
+	if !strings.Contains(consoleOut, "debug-on-both") || !strings.Contains(otelOut, "debug-on-both") {
+		t.Errorf("debug record should reach both cores; console=%q otel=%q", consoleOut, otelOut)
+	}
+}

--- a/pkg/observe/log/level_zap.go
+++ b/pkg/observe/log/level_zap.go
@@ -1,0 +1,71 @@
+package logging
+
+import (
+	"go.uber.org/zap/zapcore"
+)
+
+// zapTraceLevel is the custom zapcore.Level used to emit TraceLevel records.
+// It sits at -2, one notch below zapcore.DebugLevel (-1), so any zapcore.Core
+// configured to accept Trace will also accept Debug and above.
+const zapTraceLevel zapcore.Level = -2
+
+// ToZapLevel maps a logging.Level to its zapcore counterpart. TraceLevel
+// maps to the custom zapTraceLevel; unknown levels fall back to InfoLevel.
+func ToZapLevel(level Level) zapcore.Level {
+	switch level {
+	case TraceLevel:
+		return zapTraceLevel
+	case DebugLevel:
+		return zapcore.DebugLevel
+	case InfoLevel:
+		return zapcore.InfoLevel
+	case ErrorLevel:
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel
+	}
+}
+
+// EncodeLevelWithTrace wraps a zapcore.LevelEncoder so the custom Trace level
+// is rendered as "trace" instead of falling back to zap's default formatting
+// (which would print something like "Level(-2)").
+func EncodeLevelWithTrace(base zapcore.LevelEncoder) zapcore.LevelEncoder {
+	return func(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
+		if l == zapTraceLevel {
+			enc.AppendString("trace")
+			return
+		}
+		base(l, enc)
+	}
+}
+
+// MinLevelCore wraps a zapcore.Core and rejects log entries below a minimum
+// level. Typical use: prevent Trace records from reaching an OTel exporter
+// core while still allowing them on the console core. Compose with
+// zapcore.NewTee to build multi-destination logging pipelines.
+//
+//	consoleCore := zapcore.NewCore(enc, console, logging.ToZapLevel(level))
+//	otelCore := &logging.MinLevelCore{Core: otelBridge, Min: zapcore.DebugLevel}
+//	root := zap.New(zapcore.NewTee(consoleCore, otelCore))
+type MinLevelCore struct {
+	zapcore.Core
+	Min zapcore.Level
+}
+
+func (c *MinLevelCore) Enabled(lvl zapcore.Level) bool {
+	if lvl < c.Min {
+		return false
+	}
+	return c.Core.Enabled(lvl)
+}
+
+func (c *MinLevelCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if ent.Level < c.Min {
+		return ce
+	}
+	return c.Core.Check(ent, ce)
+}
+
+func (c *MinLevelCore) With(fields []zapcore.Field) zapcore.Core {
+	return &MinLevelCore{Core: c.Core.With(fields), Min: c.Min}
+}

--- a/pkg/observe/log/logging.go
+++ b/pkg/observe/log/logging.go
@@ -2,23 +2,60 @@ package logging
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"strings"
 )
 
-// Level represents a logging severity level.
+// Level represents a logging severity level. Lower values are more verbose.
 type Level int
 
 const (
-	DebugLevel Level = iota
-	InfoLevel
-	ErrorLevel
+	TraceLevel Level = iota - 1 // -1, more verbose than Debug; reserved for per-event/per-request logs.
+	DebugLevel                  // 0
+	InfoLevel                   // 1
+	ErrorLevel                  // 2
 )
+
+// ParseLevel parses a textual level (case-insensitive) into a Level.
+func ParseLevel(s string) (Level, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "trace":
+		return TraceLevel, nil
+	case "debug":
+		return DebugLevel, nil
+	case "info":
+		return InfoLevel, nil
+	case "error":
+		return ErrorLevel, nil
+	default:
+		return 0, fmt.Errorf("unknown log level: %q (expected trace|debug|info|error)", s)
+	}
+}
+
+// String returns the textual representation of a Level.
+func (l Level) String() string {
+	switch l {
+	case TraceLevel:
+		return "trace"
+	case DebugLevel:
+		return "debug"
+	case InfoLevel:
+		return "info"
+	case ErrorLevel:
+		return "error"
+	default:
+		return fmt.Sprintf("level(%d)", int(l))
+	}
+}
 
 //go:generate mockgen -source logging.go -destination logging_generated.go -package logging . Logger
 type Logger interface {
+	Tracef(fmt string, args ...any)
 	Debugf(fmt string, args ...any)
 	Infof(fmt string, args ...any)
 	Errorf(fmt string, args ...any)
+	Trace(args ...any)
 	Debug(args ...any)
 	Info(args ...any)
 	Error(args ...any)
@@ -35,14 +72,20 @@ type Logger interface {
 	Enabled(level Level) bool
 }
 
-func Debugf(fmt string, args ...any) {
-	FromContext(context.TODO()).Debugf(fmt, args...)
+func Tracef(format string, args ...any) {
+	FromContext(context.TODO()).Tracef(format, args...)
 }
-func Infof(fmt string, args ...any) {
-	FromContext(context.TODO()).Infof(fmt, args...)
+func Debugf(format string, args ...any) {
+	FromContext(context.TODO()).Debugf(format, args...)
 }
-func Errorf(fmt string, args ...any) {
-	FromContext(context.TODO()).Errorf(fmt, args...)
+func Infof(format string, args ...any) {
+	FromContext(context.TODO()).Infof(format, args...)
+}
+func Errorf(format string, args ...any) {
+	FromContext(context.TODO()).Errorf(format, args...)
+}
+func Trace(args ...any) {
+	FromContext(context.TODO()).Trace(args...)
 }
 func Debug(args ...any) {
 	FromContext(context.TODO()).Debug(args...)

--- a/pkg/observe/log/logging_generated.go
+++ b/pkg/observe/log/logging_generated.go
@@ -196,6 +196,39 @@ func (mr *MockLoggerMockRecorder) WithFields(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithFields", reflect.TypeOf((*MockLogger)(nil).WithFields), arg0)
 }
 
+// Trace mocks base method.
+func (m *MockLogger) Trace(args ...any) {
+	m.ctrl.T.Helper()
+	varargs := []any{}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Trace", varargs...)
+}
+
+// Trace indicates an expected call of Trace.
+func (mr *MockLoggerMockRecorder) Trace(args ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trace", reflect.TypeOf((*MockLogger)(nil).Trace), args...)
+}
+
+// Tracef mocks base method.
+func (m *MockLogger) Tracef(fmt string, args ...any) {
+	m.ctrl.T.Helper()
+	varargs := []any{fmt}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Tracef", varargs...)
+}
+
+// Tracef indicates an expected call of Tracef.
+func (mr *MockLoggerMockRecorder) Tracef(fmt any, args ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{fmt}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tracef", reflect.TypeOf((*MockLogger)(nil).Tracef), varargs...)
+}
+
 // Writer mocks base method.
 func (m *MockLogger) Writer() io.Writer {
 	m.ctrl.T.Helper()

--- a/pkg/observe/log/logging_generated.go
+++ b/pkg/observe/log/logging_generated.go
@@ -154,6 +154,39 @@ func (mr *MockLoggerMockRecorder) Infof(fmt any, args ...any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Infof", reflect.TypeOf((*MockLogger)(nil).Infof), varargs...)
 }
 
+// Trace mocks base method.
+func (m *MockLogger) Trace(args ...any) {
+	m.ctrl.T.Helper()
+	varargs := []any{}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Trace", varargs...)
+}
+
+// Trace indicates an expected call of Trace.
+func (mr *MockLoggerMockRecorder) Trace(args ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trace", reflect.TypeOf((*MockLogger)(nil).Trace), args...)
+}
+
+// Tracef mocks base method.
+func (m *MockLogger) Tracef(fmt string, args ...any) {
+	m.ctrl.T.Helper()
+	varargs := []any{fmt}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Tracef", varargs...)
+}
+
+// Tracef indicates an expected call of Tracef.
+func (mr *MockLoggerMockRecorder) Tracef(fmt any, args ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{fmt}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tracef", reflect.TypeOf((*MockLogger)(nil).Tracef), varargs...)
+}
+
 // WithContext mocks base method.
 func (m *MockLogger) WithContext(ctx context.Context) Logger {
 	m.ctrl.T.Helper()
@@ -194,39 +227,6 @@ func (m *MockLogger) WithFields(arg0 map[string]any) Logger {
 func (mr *MockLoggerMockRecorder) WithFields(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithFields", reflect.TypeOf((*MockLogger)(nil).WithFields), arg0)
-}
-
-// Trace mocks base method.
-func (m *MockLogger) Trace(args ...any) {
-	m.ctrl.T.Helper()
-	varargs := []any{}
-	for _, a := range args {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "Trace", varargs...)
-}
-
-// Trace indicates an expected call of Trace.
-func (mr *MockLoggerMockRecorder) Trace(args ...any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trace", reflect.TypeOf((*MockLogger)(nil).Trace), args...)
-}
-
-// Tracef mocks base method.
-func (m *MockLogger) Tracef(fmt string, args ...any) {
-	m.ctrl.T.Helper()
-	varargs := []any{fmt}
-	for _, a := range args {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "Tracef", varargs...)
-}
-
-// Tracef indicates an expected call of Tracef.
-func (mr *MockLoggerMockRecorder) Tracef(fmt any, args ...any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{fmt}, args...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tracef", reflect.TypeOf((*MockLogger)(nil).Tracef), varargs...)
 }
 
 // Writer mocks base method.

--- a/pkg/observe/log/logging_test.go
+++ b/pkg/observe/log/logging_test.go
@@ -1,0 +1,86 @@
+package logging
+
+import (
+	"testing"
+)
+
+func TestParseLevel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in      string
+		want    Level
+		wantErr bool
+	}{
+		{"trace", TraceLevel, false},
+		{"TRACE", TraceLevel, false},
+		{"  Trace  ", TraceLevel, false},
+		{"debug", DebugLevel, false},
+		{"Debug", DebugLevel, false},
+		{"info", InfoLevel, false},
+		{"INFO", InfoLevel, false},
+		{"error", ErrorLevel, false},
+		{"Error", ErrorLevel, false},
+		{"warn", 0, true},
+		{"", 0, true},
+		{"verbose", 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseLevel(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseLevel(%q) = %v, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseLevel(%q) returned error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseLevel(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLevelString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		level Level
+		want  string
+	}{
+		{TraceLevel, "trace"},
+		{DebugLevel, "debug"},
+		{InfoLevel, "info"},
+		{ErrorLevel, "error"},
+		{Level(42), "level(42)"},
+	}
+
+	for _, tc := range cases {
+		got := tc.level.String()
+		if got != tc.want {
+			t.Errorf("Level(%d).String() = %q, want %q", int(tc.level), got, tc.want)
+		}
+	}
+}
+
+func TestLevelOrdering(t *testing.T) {
+	t.Parallel()
+
+	// Trace is more verbose than Debug, which is more verbose than Info, etc.
+	// The numeric ordering matters because callers compare levels directly
+	// and adapters map them to backend levels.
+	if !(TraceLevel < DebugLevel) {
+		t.Errorf("TraceLevel (%d) should be < DebugLevel (%d)", TraceLevel, DebugLevel)
+	}
+	if !(DebugLevel < InfoLevel) {
+		t.Errorf("DebugLevel (%d) should be < InfoLevel (%d)", DebugLevel, InfoLevel)
+	}
+	if !(InfoLevel < ErrorLevel) {
+		t.Errorf("InfoLevel (%d) should be < ErrorLevel (%d)", InfoLevel, ErrorLevel)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a new `TraceLevel` (value `-1`, below `DebugLevel`) and `Trace`/`Tracef` methods on the `logging.Logger` interface for per-event/per-request verbosity that is too noisy for `Debug`.
- `LogrusLogger` forwards `Trace*` to logrus's native Trace level; `toLogrusLevel` maps `TraceLevel` accordingly.
- Adds `ParseLevel(string)` (case-insensitive, accepts `error|info|debug|trace`) and `Level.String()` to support CLI flags like `--log-level=trace`.
- New `NewDefaultLoggerWithLevel(w, level, formatJSON, otelTraces)` constructor; the existing `NewDefaultLogger(w, debug, ...)` is preserved as a thin wrapper for backward compatibility.
- Regenerates the `MockLogger` and updates the hand-rolled `mockLogger` in `pkg/authn/licence/licence_test.go` to implement the new methods.

## Motivation

Services using this logger (e.g. ledger-v3) currently have only `Debug`/`Info`/`Error`, which forces them to choose between drowning useful lifecycle events in per-RPC / per-tick noise or leaving valuable diagnostics inaccessible. A `Trace` level lets each service classify "lifecycle" vs "per-event" logs cleanly and gate the latter behind `--log-level=trace`.

## Backward compatibility

- The `Level` enum keeps `DebugLevel = 0`, `InfoLevel = 1`, `ErrorLevel = 2` unchanged; `TraceLevel = -1` slots in below them.
- `NewDefaultLogger(w, debug, formatJSON, otelTraces)` keeps its signature and semantics.
- Existing callers of the `Logger` interface get two new methods. Hand-rolled implementations (e.g. test mocks outside go-libs) need to add no-op `Trace`/`Tracef` methods — this is a deliberate API extension.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass.
- [x] Existing tests pass; updated `mockLogger` in `pkg/authn/licence/licence_test.go`.
- [ ] Downstream service (ledger-v3) wires the new methods through its own `Logger` adapter and verifies trace emission visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)