### PR TITLE
fix(audit): async HTTP audit publishing

### DIFF
--- a/pkg/audit/flags.go
+++ b/pkg/audit/flags.go
@@ -1,0 +1,30 @@
+package audit
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	AuditEnabledFlag = "audit-enabled"
+)
+
+type Config struct {
+	Enabled bool
+}
+
+func AddFlags(flags *pflag.FlagSet) {
+	flags.Bool(AuditEnabledFlag, false, "Enable audit")
+}
+
+func ConfigFromFlags(flags *pflag.FlagSet) (Config, error) {
+	enabled, err := flags.GetBool(AuditEnabledFlag)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to read %s flag: %w", AuditEnabledFlag, err)
+	}
+
+	return Config{
+		Enabled: enabled,
+	}, nil
+}

--- a/pkg/audit/flags_test.go
+++ b/pkg/audit/flags_test.go
@@ -1,0 +1,60 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/service"
+)
+
+func TestConfigFromFlagsDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddFlags(flags)
+
+	cfg, err := ConfigFromFlags(flags)
+
+	require.NoError(t, err)
+	assert.False(t, cfg.Enabled)
+}
+
+func TestConfigFromFlagsEnabledFromFlag(t *testing.T) {
+	t.Parallel()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddFlags(flags)
+	require.NoError(t, flags.Set(AuditEnabledFlag, "true"))
+
+	cfg, err := ConfigFromFlags(flags)
+
+	require.NoError(t, err)
+	assert.True(t, cfg.Enabled)
+}
+
+func TestConfigFromFlagsEnabledFromEnv(t *testing.T) {
+	t.Setenv("AUDIT_ENABLED", "true")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddFlags(flags)
+	service.BindEnvToFlagSet(flags)
+
+	cfg, err := ConfigFromFlags(flags)
+
+	require.NoError(t, err)
+	assert.True(t, cfg.Enabled)
+}
+
+func TestConfigFromFlagsReturnsErrorWhenFlagIsMissing(t *testing.T) {
+	t.Parallel()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+	_, err := ConfigFromFlags(flags)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), AuditEnabledFlag)
+}

--- a/pkg/audit/httpaudit/async_publisher.go
+++ b/pkg/audit/httpaudit/async_publisher.go
@@ -1,0 +1,238 @@
+package httpaudit
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+
+	"github.com/formancehq/go-libs/v5/pkg/audit"
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+const (
+	defaultAsyncPublishingQueueCapacity = 1024
+	defaultAsyncPublishingWorkerCount   = 1
+)
+
+var ErrAsyncPublisherClosed = errors.New("async audit publisher closed")
+
+type auditEventPublisher interface {
+	Publish(ctx context.Context, payload audit.Payload)
+}
+
+type syncAuditEventPublisher struct {
+	publisher message.Publisher
+	topicName string
+	appName   string
+}
+
+func (p syncAuditEventPublisher) Publish(ctx context.Context, payload audit.Payload) {
+	audit.PublishEvent(ctx, p.publisher, p.topicName, p.appName, payload)
+}
+
+type asyncPublishingConfig struct {
+	queueCapacity int
+	workerCount   int
+	onDrop        func(context.Context, audit.Payload)
+	onError       func(context.Context, audit.Payload, error)
+}
+
+func defaultAsyncPublishingConfig() asyncPublishingConfig {
+	return asyncPublishingConfig{
+		queueCapacity: defaultAsyncPublishingQueueCapacity,
+		workerCount:   defaultAsyncPublishingWorkerCount,
+	}
+}
+
+// AsyncPublishingOption configures HTTP audit async publishing.
+type AsyncPublishingOption func(*asyncPublishingConfig)
+
+// WithAsyncPublishingQueueCapacity sets the fixed queue capacity used by async audit publishing.
+func WithAsyncPublishingQueueCapacity(capacity int) AsyncPublishingOption {
+	return func(c *asyncPublishingConfig) {
+		c.queueCapacity = capacity
+	}
+}
+
+// WithAsyncPublishingWorkerCount sets the fixed number of workers used by async audit publishing.
+func WithAsyncPublishingWorkerCount(workerCount int) AsyncPublishingOption {
+	return func(c *asyncPublishingConfig) {
+		c.workerCount = workerCount
+	}
+}
+
+// WithAsyncPublishingDropCallback is called after an audit event is dropped because the queue is full.
+func WithAsyncPublishingDropCallback(fn func(context.Context, audit.Payload)) AsyncPublishingOption {
+	return func(c *asyncPublishingConfig) {
+		c.onDrop = fn
+	}
+}
+
+// WithAsyncPublishingErrorCallback is called after a worker fails to publish an audit event.
+func WithAsyncPublishingErrorCallback(fn func(context.Context, audit.Payload, error)) AsyncPublishingOption {
+	return func(c *asyncPublishingConfig) {
+		c.onError = fn
+	}
+}
+
+func newAsyncPublishingConfig(opts ...AsyncPublishingOption) asyncPublishingConfig {
+	cfg := defaultAsyncPublishingConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.queueCapacity < 1 {
+		cfg.queueCapacity = defaultAsyncPublishingQueueCapacity
+	}
+	if cfg.workerCount < 1 {
+		cfg.workerCount = defaultAsyncPublishingWorkerCount
+	}
+	return cfg
+}
+
+type asyncAuditEvent struct {
+	ctx     context.Context
+	payload audit.Payload
+	message *message.Message
+}
+
+// AsyncPublisherStats reports async audit publishing counters.
+type AsyncPublisherStats struct {
+	Enqueued      uint64
+	Dropped       uint64
+	Published     uint64
+	PublishErrors uint64
+}
+
+// AsyncPublisher publishes audit events through a bounded worker pool.
+type AsyncPublisher struct {
+	publisher message.Publisher
+	topicName string
+	appName   string
+	cfg       asyncPublishingConfig
+
+	queue chan asyncAuditEvent
+
+	mu     sync.RWMutex
+	closed bool
+	wg     sync.WaitGroup
+
+	enqueued      atomic.Uint64
+	dropped       atomic.Uint64
+	published     atomic.Uint64
+	publishErrors atomic.Uint64
+}
+
+// NewAsyncPublisher creates a bounded async publisher for HTTP audit events.
+func NewAsyncPublisher(publisher message.Publisher, topicName string, appName string, opts ...AsyncPublishingOption) *AsyncPublisher {
+	cfg := newAsyncPublishingConfig(opts...)
+	p := &AsyncPublisher{
+		publisher: publisher,
+		topicName: topicName,
+		appName:   appName,
+		cfg:       cfg,
+		queue:     make(chan asyncAuditEvent, cfg.queueCapacity),
+	}
+
+	p.wg.Add(cfg.workerCount)
+	for range cfg.workerCount {
+		go p.worker()
+	}
+
+	return p
+}
+
+// Publish enqueues an audit event without waiting for the underlying publisher.
+// If the bounded queue is full, the event is dropped and counted.
+func (p *AsyncPublisher) Publish(ctx context.Context, payload audit.Payload) {
+	detachedCtx := context.WithoutCancel(ctx)
+	detachedCtx = logging.ContextWithLogger(detachedCtx, logging.FromContext(ctx))
+	msg := audit.NewEventMessage(detachedCtx, p.appName, payload)
+
+	p.mu.RLock()
+	if p.closed {
+		onDrop := p.cfg.onDrop
+		p.mu.RUnlock()
+
+		p.dropped.Add(1)
+		logger := logging.FromContext(ctx)
+		logger.WithField("audit_payload_id", payload.ID).Errorf("failed to enqueue audit message: %v", ErrAsyncPublisherClosed)
+		if onDrop != nil {
+			onDrop(ctx, payload)
+		}
+		return
+	}
+
+	select {
+	case p.queue <- asyncAuditEvent{
+		ctx:     detachedCtx,
+		payload: payload,
+		message: msg,
+	}:
+		p.mu.RUnlock()
+		p.enqueued.Add(1)
+	default:
+		onDrop := p.cfg.onDrop
+		p.mu.RUnlock()
+
+		p.dropped.Add(1)
+		logger := logging.FromContext(ctx)
+		logger.WithField("audit_payload_id", payload.ID).Errorf("audit publish queue full, dropping audit message")
+		if onDrop != nil {
+			onDrop(ctx, payload)
+		}
+	}
+}
+
+// Close stops accepting new events and waits for workers to drain queued events
+// until ctx is canceled.
+func (p *AsyncPublisher) Close(ctx context.Context) error {
+	p.mu.Lock()
+	if !p.closed {
+		p.closed = true
+		close(p.queue)
+	}
+	p.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Stats returns a snapshot of async audit publishing counters.
+func (p *AsyncPublisher) Stats() AsyncPublisherStats {
+	return AsyncPublisherStats{
+		Enqueued:      p.enqueued.Load(),
+		Dropped:       p.dropped.Load(),
+		Published:     p.published.Load(),
+		PublishErrors: p.publishErrors.Load(),
+	}
+}
+
+func (p *AsyncPublisher) worker() {
+	defer p.wg.Done()
+
+	for event := range p.queue {
+		if err := p.publisher.Publish(p.topicName, event.message); err != nil {
+			p.publishErrors.Add(1)
+			logger := logging.FromContext(event.ctx)
+			logger.WithField("audit_payload_id", event.payload.ID).Errorf("failed to publish audit message asynchronously: %v", err)
+			if p.cfg.onError != nil {
+				p.cfg.onError(event.ctx, event.payload, err)
+			}
+			continue
+		}
+		p.published.Add(1)
+	}
+}

--- a/pkg/audit/httpaudit/middleware.go
+++ b/pkg/audit/httpaudit/middleware.go
@@ -20,7 +20,9 @@ import (
 type HTTPOption func(*httpOptions)
 
 type httpOptions struct {
+	enabled        bool
 	sensitivePaths map[string]struct{}
+	eventPublisher auditEventPublisher
 }
 
 // WithSensitivePaths sets paths for which the response body should not be captured.
@@ -30,6 +32,34 @@ func WithSensitivePaths(paths ...string) HTTPOption {
 			o.sensitivePaths[p] = struct{}{}
 		}
 	}
+}
+
+// WithEnabled enables or disables HTTP audit event capture and publication.
+func WithEnabled(enabled bool) HTTPOption {
+	return func(o *httpOptions) {
+		o.enabled = enabled
+	}
+}
+
+// WithConfig configures HTTP audit event capture from audit.Config.
+func WithConfig(config audit.Config) HTTPOption {
+	return WithEnabled(config.Enabled)
+}
+
+// WithAsyncPublishing enables async publishing using a caller-managed AsyncPublisher.
+// Callers should close the publisher during shutdown to drain queued audit events.
+func WithAsyncPublishing(publisher *AsyncPublisher) HTTPOption {
+	return func(o *httpOptions) {
+		if publisher != nil {
+			o.eventPublisher = publisher
+		}
+	}
+}
+
+// WithAsyncPublisher enables async publishing using a caller-managed AsyncPublisher.
+// Use this option when the caller needs explicit lifecycle control via AsyncPublisher.Close.
+func WithAsyncPublisher(publisher *AsyncPublisher) HTTPOption {
+	return WithAsyncPublishing(publisher)
 }
 
 var bufPool = sync.Pool{
@@ -50,8 +80,25 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 		opt(ho)
 	}
 
+	var eventPublisher auditEventPublisher
+	if ho.enabled {
+		eventPublisher = auditEventPublisher(syncAuditEventPublisher{
+			publisher: publisher,
+			topicName: topicName,
+			appName:   appName,
+		})
+		if ho.eventPublisher != nil {
+			eventPublisher = ho.eventPublisher
+		}
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !ho.enabled {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			if r.Header.Get(audit.HandledHeader) != "" {
 				next.ServeHTTP(w, r)
 				return
@@ -124,7 +171,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				},
 			}
 
-			audit.PublishEvent(r.Context(), publisher, topicName, appName, payload)
+			eventPublisher.Publish(r.Context(), payload)
 		})
 	}
 }

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -1,13 +1,21 @@
 package httpaudit
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,13 +24,69 @@ import (
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
+func TestMiddleware_DisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	var downstreamHeaderValue string
+	handler := Middleware(pub, topic, "test-app", nil)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			downstreamHeaderValue = r.Header.Get(audit.HandledHeader)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}),
+	)
+
+	req := httptest.NewRequest("POST", "/api/test", strings.NewReader(`{"key":"value"}`))
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "ok", rr.Body.String())
+	assert.Empty(t, downstreamHeaderValue)
+	assert.Empty(t, pub.AllMessages()[topic])
+}
+
+func TestMiddleware_WithConfigFromFlagsEnablesAudit(t *testing.T) {
+	t.Parallel()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	audit.AddFlags(flags)
+	require.NoError(t, flags.Set(audit.AuditEnabledFlag, "true"))
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	cfg, err := audit.ConfigFromFlags(flags)
+	require.NoError(t, err)
+
+	handler := Middleware(pub, topic, "test-app", nil, WithConfig(cfg))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Len(t, pub.AllMessages()[topic], 1)
+}
+
 func TestMiddleware_BasicCapture(t *testing.T) {
 	t.Parallel()
 
 	pub := publish.InMemory()
 	topic := "audit-events"
 
-	handler := Middleware(pub, topic, "test-app", nil)(
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -69,7 +133,7 @@ func TestMiddleware_AuthorizationHeaderStripped(t *testing.T) {
 	pub := publish.InMemory()
 	topic := "audit-events"
 
-	handler := Middleware(pub, topic, "test-app", nil)(
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -102,6 +166,7 @@ func TestMiddleware_SensitivePaths(t *testing.T) {
 	topic := "audit-events"
 
 	handler := Middleware(pub, topic, "test-app", nil,
+		WithEnabled(true),
 		WithSensitivePaths("/api/auth/oauth/token"),
 	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -137,7 +202,7 @@ func TestMiddleware_StreamRequestSkipsBodyCapture(t *testing.T) {
 	pub := publish.InMemory()
 	topic := "audit-events"
 
-	handler := Middleware(pub, topic, "test-app", nil)(
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("stream-data"))
@@ -170,7 +235,7 @@ func TestMiddleware_OctetStreamResponseNotCaptured(t *testing.T) {
 	pub := publish.InMemory()
 	topic := "audit-events"
 
-	handler := Middleware(pub, topic, "test-app", nil)(
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
@@ -206,7 +271,7 @@ func TestMiddleware_OrganizationAndStackID(t *testing.T) {
 	handler := Middleware(pub, topic, "test-app", []audit.Option{
 		audit.WithOrganizationID("org-123"),
 		audit.WithStackID("stack-456"),
-	})(
+	}, WithEnabled(true))(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -268,7 +333,7 @@ func TestMiddleware_IPAddressExtraction(t *testing.T) {
 			pub := publish.InMemory()
 			topic := "audit-events"
 
-			handler := Middleware(pub, topic, "test-app", nil)(
+			handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
 				}),
@@ -311,7 +376,7 @@ func TestMiddleware_StatusCodeCapture(t *testing.T) {
 			pub := publish.InMemory()
 			topic := "audit-events"
 
-			handler := Middleware(pub, topic, "test-app", nil)(
+			handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(code)
 				}),
@@ -345,7 +410,7 @@ func TestMiddleware_RequestBodyPassedThrough(t *testing.T) {
 	topic := "audit-events"
 
 	var receivedBody string
-	handler := Middleware(pub, topic, "test-app", nil)(
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
@@ -370,7 +435,7 @@ func TestMiddleware_NoAuthByDefault(t *testing.T) {
 	pub := publish.InMemory()
 	topic := "audit-events"
 
-	handler := Middleware(pub, topic, "test-app", nil)(
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -403,7 +468,7 @@ func TestMiddleware_SkipsWhenHeaderPresent(t *testing.T) {
 	pub := publish.InMemory()
 	topic := "audit-events"
 
-	handler := Middleware(pub, topic, "test-app", nil)(
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
@@ -431,7 +496,7 @@ func TestMiddleware_SetsHeaderForDownstream(t *testing.T) {
 	topic := "audit-events"
 
 	var downstreamHeaderValue string
-	handler := Middleware(pub, topic, "test-app", nil)(
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			downstreamHeaderValue = r.Header.Get(audit.HandledHeader)
 			w.WriteHeader(http.StatusOK)
@@ -456,7 +521,7 @@ func TestMiddleware_HeaderNotInAuditPayload(t *testing.T) {
 	pub := publish.InMemory()
 	topic := "audit-events"
 
-	handler := Middleware(pub, topic, "test-app", nil)(
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -479,4 +544,485 @@ func TestMiddleware_HeaderNotInAuditPayload(t *testing.T) {
 	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
 
 	assert.Empty(t, payload.HTTP.Request.Header.Get(audit.HandledHeader))
+}
+
+func TestMiddleware_DefaultPublishesSynchronously(t *testing.T) {
+	pub := newBlockingPublisher()
+	topic := "audit-events"
+
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req = req.WithContext(logging.TestingContext())
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+		close(done)
+	}()
+
+	pub.waitStarted(t)
+
+	select {
+	case <-done:
+		t.Fatal("handler returned before synchronous publish completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	pub.release()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not return after publisher completed")
+	}
+}
+
+func TestMiddleware_AsyncPublishingReturnsBeforeSlowPublisherCompletes(t *testing.T) {
+	pub := newBlockingPublisher()
+	topic := "audit-events"
+	asyncPublisher := NewAsyncPublisher(pub, topic, "test-app",
+		WithAsyncPublishingQueueCapacity(1),
+		WithAsyncPublishingWorkerCount(1),
+	)
+	defer func() {
+		pub.release()
+		require.NoError(t, asyncPublisher.Close(context.Background()))
+	}()
+
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true), WithAsyncPublisher(asyncPublisher))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req = req.WithContext(logging.TestingContext())
+
+	start := time.Now()
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	elapsed := time.Since(start)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Less(t, elapsed, 50*time.Millisecond)
+
+	pub.waitStarted(t)
+}
+
+func TestMiddleware_AsyncPublishingQueueIsBoundedAndDropsWhenFull(t *testing.T) {
+	pub := newBlockingPublisher()
+	topic := "audit-events"
+	var dropped atomic.Uint64
+	asyncPublisher := NewAsyncPublisher(pub, topic, "test-app",
+		WithAsyncPublishingQueueCapacity(1),
+		WithAsyncPublishingWorkerCount(1),
+		WithAsyncPublishingDropCallback(func(context.Context, audit.Payload) {
+			dropped.Add(1)
+		}),
+	)
+	defer func() {
+		pub.release()
+		require.NoError(t, asyncPublisher.Close(context.Background()))
+	}()
+
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true), WithAsyncPublisher(asyncPublisher))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	serveAuditRequest(t, handler)
+	pub.waitStarted(t)
+
+	serveAuditRequest(t, handler)
+	require.Eventually(t, func() bool {
+		return asyncPublisher.Stats().Enqueued == 2
+	}, time.Second, time.Millisecond)
+
+	serveAuditRequest(t, handler)
+	require.Eventually(t, func() bool {
+		return asyncPublisher.Stats().Dropped == 1
+	}, time.Second, time.Millisecond)
+
+	stats := asyncPublisher.Stats()
+	assert.Equal(t, uint64(2), stats.Enqueued)
+	assert.Equal(t, uint64(1), stats.Dropped)
+	assert.Equal(t, uint64(1), dropped.Load())
+}
+
+func TestMiddleware_AsyncPublishingWorkerCountIsBounded(t *testing.T) {
+	pub := newConcurrentBlockingPublisher()
+	topic := "audit-events"
+	asyncPublisher := NewAsyncPublisher(pub, topic, "test-app",
+		WithAsyncPublishingQueueCapacity(2),
+		WithAsyncPublishingWorkerCount(2),
+	)
+	defer func() {
+		pub.release()
+		require.NoError(t, asyncPublisher.Close(context.Background()))
+	}()
+
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true), WithAsyncPublisher(asyncPublisher))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	serveAuditRequest(t, handler)
+	serveAuditRequest(t, handler)
+	pub.waitCalls(t, 2)
+
+	serveAuditRequest(t, handler)
+	serveAuditRequest(t, handler)
+	require.Eventually(t, func() bool {
+		return asyncPublisher.Stats().Enqueued == 4
+	}, time.Second, time.Millisecond)
+
+	serveAuditRequest(t, handler)
+	require.Eventually(t, func() bool {
+		return asyncPublisher.Stats().Dropped == 1
+	}, time.Second, time.Millisecond)
+
+	assert.LessOrEqual(t, pub.maxInFlight.Load(), int64(2))
+}
+
+func TestMiddleware_AsyncPublishingLogsAndCountsPublishErrors(t *testing.T) {
+	var logBuffer bytes.Buffer
+	logger := logging.NewDefaultLogger(&logBuffer, true, false, false)
+	errPublisher := &errorPublisher{err: errors.New("publisher failed")}
+	topic := "audit-events"
+	asyncPublisher := NewAsyncPublisher(errPublisher, topic, "test-app",
+		WithAsyncPublishingQueueCapacity(1),
+		WithAsyncPublishingWorkerCount(1),
+	)
+
+	handler := Middleware(errPublisher, topic, "test-app", nil, WithEnabled(true), WithAsyncPublisher(asyncPublisher))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req = req.WithContext(logging.ContextWithLogger(context.Background(), logger))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Eventually(t, func() bool {
+		return asyncPublisher.Stats().PublishErrors == 1
+	}, time.Second, time.Millisecond)
+	require.NoError(t, asyncPublisher.Close(context.Background()))
+
+	stats := asyncPublisher.Stats()
+	assert.Equal(t, uint64(1), stats.Enqueued)
+	assert.Equal(t, uint64(0), stats.Published)
+	assert.Equal(t, uint64(1), stats.PublishErrors)
+	assert.Contains(t, logBuffer.String(), "failed to publish audit message asynchronously")
+	assert.Contains(t, logBuffer.String(), "publisher failed")
+}
+
+func TestMiddleware_PublishLatencyRegression(t *testing.T) {
+	topic := "audit-events"
+	publishDelay := 100 * time.Millisecond
+
+	t.Run("synchronous response includes publish delay", func(t *testing.T) {
+		pub := &delayedPublisher{delay: publishDelay}
+		handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}),
+		)
+
+		start := time.Now()
+		serveAuditRequest(t, handler)
+
+		assert.GreaterOrEqual(t, time.Since(start), publishDelay)
+		assert.Equal(t, uint64(1), pub.calls.Load())
+	})
+
+	t.Run("async response does not include publish delay", func(t *testing.T) {
+		pub := &delayedPublisher{delay: publishDelay}
+		asyncPublisher := NewAsyncPublisher(pub, topic, "test-app",
+			WithAsyncPublishingQueueCapacity(1),
+			WithAsyncPublishingWorkerCount(1),
+		)
+		defer func() {
+			require.NoError(t, asyncPublisher.Close(context.Background()))
+		}()
+
+		handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true), WithAsyncPublisher(asyncPublisher))(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}),
+		)
+
+		start := time.Now()
+		serveAuditRequest(t, handler)
+
+		assert.Less(t, time.Since(start), publishDelay/2)
+		require.Eventually(t, func() bool {
+			return asyncPublisher.Stats().Published == 1
+		}, time.Second, time.Millisecond)
+		assert.Equal(t, uint64(1), pub.calls.Load())
+	})
+}
+
+func TestMiddleware_WithAsyncPublishingUsesCallerManagedPublisher(t *testing.T) {
+	pub := &delayedPublisher{}
+	topic := "audit-events"
+	asyncPublisher := NewAsyncPublisher(pub, topic, "test-app",
+		WithAsyncPublishingQueueCapacity(1),
+		WithAsyncPublishingWorkerCount(1),
+	)
+	defer func() {
+		require.NoError(t, asyncPublisher.Close(context.Background()))
+	}()
+
+	handler := Middleware(pub, topic, "test-app", nil,
+		WithEnabled(true),
+		WithAsyncPublishing(asyncPublisher),
+	)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	serveAuditRequest(t, handler)
+
+	require.Eventually(t, func() bool {
+		return pub.calls.Load() == 1
+	}, time.Second, time.Millisecond)
+}
+
+func TestAsyncPublisher_CapturesEventDateBeforeQueueDelay(t *testing.T) {
+	pub := newSequentialBlockingRecorderPublisher()
+	asyncPublisher := NewAsyncPublisher(pub, "audit-events", "test-app",
+		WithAsyncPublishingQueueCapacity(1),
+		WithAsyncPublishingWorkerCount(1),
+	)
+	defer func() {
+		pub.release()
+		require.NoError(t, asyncPublisher.Close(context.Background()))
+	}()
+
+	asyncPublisher.Publish(logging.TestingContext(), audit.Payload{ID: "first"})
+	pub.waitCalls(t, 1)
+
+	beforeSecondEnqueue := time.Now().UTC()
+	asyncPublisher.Publish(logging.TestingContext(), audit.Payload{ID: "second"})
+	time.Sleep(50 * time.Millisecond)
+	releaseTime := time.Now().UTC()
+	pub.release()
+	pub.waitCalls(t, 2)
+
+	msgs := pub.messages()
+	require.Len(t, msgs, 2)
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(msgs[1].Payload, &event))
+	assert.GreaterOrEqual(t, event.Date.UnixNano(), beforeSecondEnqueue.UnixNano())
+	assert.Less(t, event.Date.UnixNano(), releaseTime.UnixNano())
+}
+
+func TestAsyncPublisher_CloseRespectsContextTimeout(t *testing.T) {
+	pub := newBlockingPublisher()
+	asyncPublisher := NewAsyncPublisher(pub, "audit-events", "test-app",
+		WithAsyncPublishingQueueCapacity(1),
+		WithAsyncPublishingWorkerCount(1),
+	)
+
+	asyncPublisher.Publish(logging.TestingContext(), audit.Payload{ID: "payload-id"})
+	pub.waitStarted(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	require.ErrorIs(t, asyncPublisher.Close(ctx), context.DeadlineExceeded)
+
+	pub.release()
+	require.NoError(t, asyncPublisher.Close(context.Background()))
+}
+
+func serveAuditRequest(t *testing.T, handler http.Handler) {
+	t.Helper()
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req = req.WithContext(logging.TestingContext())
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+type blockingPublisher struct {
+	started     chan struct{}
+	released    chan struct{}
+	startedOnce sync.Once
+	releaseOnce sync.Once
+	calls       atomic.Uint64
+}
+
+func newBlockingPublisher() *blockingPublisher {
+	return &blockingPublisher{
+		started:  make(chan struct{}),
+		released: make(chan struct{}),
+	}
+}
+
+func (p *blockingPublisher) Publish(string, ...*message.Message) error {
+	p.calls.Add(1)
+	p.startedOnce.Do(func() {
+		close(p.started)
+	})
+	<-p.released
+	return nil
+}
+
+func (p *blockingPublisher) Close() error {
+	return nil
+}
+
+func (p *blockingPublisher) waitStarted(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-p.started:
+	case <-time.After(time.Second):
+		t.Fatal("publisher was not called")
+	}
+}
+
+func (p *blockingPublisher) release() {
+	p.releaseOnce.Do(func() {
+		close(p.released)
+	})
+}
+
+type concurrentBlockingPublisher struct {
+	released    chan struct{}
+	releaseOnce sync.Once
+	calls       atomic.Uint64
+	inFlight    atomic.Int64
+	maxInFlight atomic.Int64
+}
+
+func newConcurrentBlockingPublisher() *concurrentBlockingPublisher {
+	return &concurrentBlockingPublisher{
+		released: make(chan struct{}),
+	}
+}
+
+func (p *concurrentBlockingPublisher) Publish(string, ...*message.Message) error {
+	p.calls.Add(1)
+	inFlight := p.inFlight.Add(1)
+	for {
+		maxInFlight := p.maxInFlight.Load()
+		if inFlight <= maxInFlight || p.maxInFlight.CompareAndSwap(maxInFlight, inFlight) {
+			break
+		}
+	}
+
+	<-p.released
+	p.inFlight.Add(-1)
+	return nil
+}
+
+func (p *concurrentBlockingPublisher) Close() error {
+	return nil
+}
+
+func (p *concurrentBlockingPublisher) waitCalls(t *testing.T, calls uint64) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return p.calls.Load() >= calls
+	}, time.Second, time.Millisecond)
+}
+
+func (p *concurrentBlockingPublisher) release() {
+	p.releaseOnce.Do(func() {
+		close(p.released)
+	})
+}
+
+type sequentialBlockingRecorderPublisher struct {
+	mu          sync.Mutex
+	released    chan struct{}
+	releaseOnce sync.Once
+	calls       atomic.Uint64
+	messagesSet []*message.Message
+}
+
+func newSequentialBlockingRecorderPublisher() *sequentialBlockingRecorderPublisher {
+	return &sequentialBlockingRecorderPublisher{
+		released: make(chan struct{}),
+	}
+}
+
+func (p *sequentialBlockingRecorderPublisher) Publish(_ string, messages ...*message.Message) error {
+	call := p.calls.Add(1)
+	p.mu.Lock()
+	p.messagesSet = append(p.messagesSet, messages...)
+	p.mu.Unlock()
+
+	if call == 1 {
+		<-p.released
+	}
+	return nil
+}
+
+func (p *sequentialBlockingRecorderPublisher) Close() error {
+	return nil
+}
+
+func (p *sequentialBlockingRecorderPublisher) waitCalls(t *testing.T, calls uint64) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return p.calls.Load() >= calls
+	}, time.Second, time.Millisecond)
+}
+
+func (p *sequentialBlockingRecorderPublisher) release() {
+	p.releaseOnce.Do(func() {
+		close(p.released)
+	})
+}
+
+func (p *sequentialBlockingRecorderPublisher) messages() []*message.Message {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return append([]*message.Message(nil), p.messagesSet...)
+}
+
+type delayedPublisher struct {
+	delay time.Duration
+	calls atomic.Uint64
+}
+
+func (p *delayedPublisher) Publish(string, ...*message.Message) error {
+	p.calls.Add(1)
+	time.Sleep(p.delay)
+	return nil
+}
+
+func (p *delayedPublisher) Close() error {
+	return nil
+}
+
+type errorPublisher struct {
+	err   error
+	calls atomic.Uint64
+}
+
+func (p *errorPublisher) Publish(string, ...*message.Message) error {
+	p.calls.Add(1)
+	return p.err
+}
+
+func (p *errorPublisher) Close() error {
+	return nil
 }

--- a/pkg/audit/publish.go
+++ b/pkg/audit/publish.go
@@ -17,21 +17,31 @@ import (
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
+// NewEventMessage builds the Watermill message used for audit events.
+func NewEventMessage(ctx context.Context, appName string, payload Payload) *message.Message {
+	return publish.NewMessage(
+		ctx,
+		publish.EventMessage{
+			Date:    time.Now().UTC(),
+			App:     appName,
+			Version: EventVersion,
+			Type:    EventTypeAudit,
+			Payload: payload,
+		},
+	)
+}
+
+// PublishEventWithError publishes an audit event to the configured publisher.
+func PublishEventWithError(ctx context.Context, publisher message.Publisher, topicName string, appName string, payload Payload) error {
+	return publisher.Publish(
+		topicName,
+		NewEventMessage(ctx, appName, payload),
+	)
+}
+
 // PublishEvent publishes an audit event to the configured publisher.
 func PublishEvent(ctx context.Context, publisher message.Publisher, topicName string, appName string, payload Payload) {
-	if err := publisher.Publish(
-		topicName,
-		publish.NewMessage(
-			ctx,
-			publish.EventMessage{
-				Date:    time.Now().UTC(),
-				App:     appName,
-				Version: EventVersion,
-				Type:    EventTypeAudit,
-				Payload: payload,
-			},
-		),
-	); err != nil {
+	if err := PublishEventWithError(ctx, publisher, topicName, appName, payload); err != nil {
 		logging.FromContext(ctx).Errorf("failed to publish audit message: %v", err)
 	}
 }

--- a/pkg/audit/publish_test.go
+++ b/pkg/audit/publish_test.go
@@ -1,0 +1,74 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
+)
+
+func TestNewEventMessage(t *testing.T) {
+	t.Parallel()
+
+	payload := Payload{ID: "payload-id"}
+
+	msg := NewEventMessage(context.Background(), "test-app", payload)
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(msg.Payload, &event))
+	assert.Equal(t, "test-app", event.App)
+	assert.Equal(t, EventVersion, event.Version)
+	assert.Equal(t, EventTypeAudit, event.Type)
+	assert.NotZero(t, event.Date)
+
+	payloadBytes, err := json.Marshal(event.Payload)
+	require.NoError(t, err)
+	var decodedPayload Payload
+	require.NoError(t, json.Unmarshal(payloadBytes, &decodedPayload))
+	assert.Equal(t, payload.ID, decodedPayload.ID)
+}
+
+func TestPublishEventWithError(t *testing.T) {
+	t.Parallel()
+
+	pub := &recordingPublisher{}
+	payload := Payload{ID: "payload-id"}
+
+	require.NoError(t, PublishEventWithError(context.Background(), pub, "audit-events", "test-app", payload))
+
+	require.Equal(t, "audit-events", pub.topic)
+	require.Len(t, pub.messages, 1)
+}
+
+func TestPublishEventWithErrorReturnsPublisherError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("publish failed")
+	pub := &recordingPublisher{err: expectedErr}
+
+	err := PublishEventWithError(context.Background(), pub, "audit-events", "test-app", Payload{})
+
+	require.ErrorIs(t, err, expectedErr)
+}
+
+type recordingPublisher struct {
+	topic    string
+	messages []*message.Message
+	err      error
+}
+
+func (p *recordingPublisher) Publish(topic string, messages ...*message.Message) error {
+	p.topic = topic
+	p.messages = append(p.messages, messages...)
+	return p.err
+}
+
+func (p *recordingPublisher) Close() error {
+	return nil
+}


### PR DESCRIPTION
## Summary
- add bounded async publishing for HTTP audit events
- keep the generic message publisher semantics unchanged
- make HTTP audit disabled by default and add `audit-enabled` / `AUDIT_ENABLED` configuration to opt in
- add queue overflow/drop logging, worker error accounting, stats, and close/drain support
- add regression tests for disabled-by-default behavior, flag/env activation, synchronous latency, async latency, bounded queue capacity, worker count, drops, errors, and shutdown timeout

## Validation
- go test ./pkg/audit/...
- go test -race ./pkg/audit/httpaudit
- go test ./...

Note: `just pc` could not be run locally because `just` is not installed in this environment.