### PR TITLE
fix(temporal): return error on truncated ciphertext (EN-1150)

### DIFF
--- a/pkg/workflow/temporal/encryption.go
+++ b/pkg/workflow/temporal/encryption.go
@@ -87,7 +87,7 @@ func (c *EncryptionDataConverter) FromPayload(payload *common.Payload, valuePtr 
 
 	nonceSize := gcm.NonceSize()
 	if len(ciphertext) < nonceSize {
-		return err
+		return fmt.Errorf("ciphertext too short: %d bytes, need at least %d", len(ciphertext), nonceSize)
 	}
 
 	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]

--- a/pkg/workflow/temporal/encryption_test.go
+++ b/pkg/workflow/temporal/encryption_test.go
@@ -1,6 +1,7 @@
 package temporal
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,6 +40,26 @@ func TestEncryption(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, payload[0].Foo, result[0].Foo)
 		require.Equal(t, payload[1].Foo, result[1].Foo)
+	})
+
+	t.Run("decrypt truncated ciphertext", func(t *testing.T) {
+		converter, err := NewEncryptionDataConverter([]byte("12345678901011121314151617181920"))
+		require.NoError(t, err)
+
+		payload := Payload{
+			Foo: "bar",
+		}
+		p, err := converter.ToPayload(&payload)
+		require.NoError(t, err)
+		require.NotNil(t, p)
+
+		// Truncate the encrypted data to less than the GCM nonce size
+		p.Data = []byte(base64.StdEncoding.EncodeToString([]byte("short")))
+
+		var result Payload
+		err = converter.FromPayload(p, &result)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "ciphertext too short")
 	})
 
 	t.Run("decrypt if metadata is not present", func(t *testing.T) {


### PR DESCRIPTION
## Bug

`EncryptionDataConverter.FromPayload` in `pkg/workflow/temporal/encryption.go` checked whether the decoded ciphertext was shorter than the GCM nonce size, but returned `err` — which is always `nil` at that point since `base64.StdEncoding.DecodeString` had just succeeded:

```go
nonceSize := gcm.NonceSize()
if len(ciphertext) < nonceSize {
    return err // err is nil here
}
```

A truncated encrypted payload therefore returned `nil` without decoding anything: the Temporal workflow/activity silently received zero-valued arguments instead of an error.

## Fix

Return a real error describing the problem:

```go
return fmt.Errorf("ciphertext too short: %d bytes, need at least %d", len(ciphertext), nonceSize)
```

Also adds a regression test (`decrypt truncated ciphertext`) asserting that decrypting a payload whose data is shorter than the GCM nonce returns an error.

## Testing

- `go build ./...`
- `go test ./pkg/workflow/...` — all tests pass

Jira: https://formance-team.atlassian.net/browse/EN-1150