### PR TITLE
fix(api): FetchAllPaginated body leak, nil cursor panic, infinite loop (EN-1153)

### DIFF
--- a/pkg/transport/api/response.go
+++ b/pkg/transport/api/response.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -47,18 +48,37 @@ func FetchAllPaginated[T any](ctx context.Context, client *http.Client, _url str
 		if err != nil {
 			return nil, err
 		}
-		if rsp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("unexpected status code %d while waiting for %d", rsp.StatusCode, http.StatusOK)
-		}
-		apiResponse := BaseResponse[T]{}
-		if err := json.NewDecoder(rsp.Body).Decode(&apiResponse); err != nil {
-			return nil, errors.Wrap(err, "decoding cursir")
+		apiResponse, err := decodePaginatedResponse[T](rsp)
+		if err != nil {
+			return nil, err
 		}
 		ret = append(ret, apiResponse.Cursor.Data...)
 		if !apiResponse.Cursor.HasMore {
 			break
 		}
+		if apiResponse.Cursor.Next == "" || apiResponse.Cursor.Next == nextToken {
+			return nil, errors.New("paginated response did not advance: empty or repeated next cursor while hasMore is true")
+		}
 		nextToken = apiResponse.Cursor.Next
 	}
 	return ret, nil
+}
+
+func decodePaginatedResponse[T any](rsp *http.Response) (*BaseResponse[T], error) {
+	defer func() {
+		_, _ = io.Copy(io.Discard, rsp.Body)
+		_ = rsp.Body.Close()
+	}()
+
+	if rsp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d while waiting for %d", rsp.StatusCode, http.StatusOK)
+	}
+	apiResponse := &BaseResponse[T]{}
+	if err := json.NewDecoder(rsp.Body).Decode(apiResponse); err != nil {
+		return nil, errors.Wrap(err, "decoding cursor")
+	}
+	if apiResponse.Cursor == nil {
+		return nil, errors.New("missing cursor in paginated response")
+	}
+	return apiResponse, nil
 }

--- a/pkg/transport/api/response_test.go
+++ b/pkg/transport/api/response_test.go
@@ -1,7 +1,11 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,4 +31,93 @@ func TestCursor(t *testing.T) {
 	require.Equal(t,
 		`{"hasMore":true,"data":[1,2,3]}`,
 		string(by))
+}
+
+func TestFetchAllPaginated(t *testing.T) {
+	t.Parallel()
+
+	t.Run("multi-page success", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var rsp BaseResponse[int64]
+			switch r.URL.Query().Get("cursor") {
+			case "":
+				rsp = BaseResponse[int64]{
+					Cursor: &bunpaginate.Cursor[int64]{
+						HasMore: true,
+						Next:    "page2",
+						Data:    []int64{1, 2},
+					},
+				}
+			case "page2":
+				rsp = BaseResponse[int64]{
+					Cursor: &bunpaginate.Cursor[int64]{
+						HasMore: false,
+						Data:    []int64{3, 4},
+					},
+				}
+			default:
+				http.Error(w, "unexpected cursor", http.StatusBadRequest)
+				return
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(rsp))
+		}))
+		t.Cleanup(srv.Close)
+
+		ret, err := FetchAllPaginated[int64](context.Background(), srv.Client(), srv.URL, url.Values{})
+		require.NoError(t, err)
+		require.Equal(t, []int64{1, 2, 3, 4}, ret)
+	})
+
+	t.Run("200 without cursor returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(BaseResponse[int64]{}))
+		}))
+		t.Cleanup(srv.Close)
+
+		ret, err := FetchAllPaginated[int64](context.Background(), srv.Client(), srv.URL, url.Values{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "missing cursor")
+		require.Nil(t, ret)
+	})
+
+	t.Run("repeated next cursor returns an error instead of looping", func(t *testing.T) {
+		t.Parallel()
+
+		var calls int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			require.NoError(t, json.NewEncoder(w).Encode(BaseResponse[int64]{
+				Cursor: &bunpaginate.Cursor[int64]{
+					HasMore: true,
+					Next:    "same-token",
+					Data:    []int64{1},
+				},
+			}))
+		}))
+		t.Cleanup(srv.Close)
+
+		ret, err := FetchAllPaginated[int64](context.Background(), srv.Client(), srv.URL, url.Values{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "did not advance")
+		require.Nil(t, ret)
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("non-200 status code returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}))
+		t.Cleanup(srv.Close)
+
+		ret, err := FetchAllPaginated[int64](context.Background(), srv.Client(), srv.URL, url.Values{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unexpected status code 500")
+		require.Nil(t, ret)
+	})
 }


### PR DESCRIPTION
## Summary

Fixes three bugs in `FetchAllPaginated` (`pkg/transport/api/response.go`):

1. **Response body leak**: `rsp.Body` was never closed on any path (success, non-200, decode error). Since this runs in a pagination loop, every page leaked a connection. The body is now drained and closed on every iteration via a deferred close in `decodePaginatedResponse`.
2. **Nil cursor panic**: a 200 response without a `cursor` object caused a nil pointer dereference on `apiResponse.Cursor.Data`. A clear error is now returned instead.
3. **Infinite loop**: if the server kept returning `hasMore: true`, the loop never terminated. The loop now fails with an error when the `next` token is empty or identical to the previous one while `hasMore` is true.

Also fixes the "decoding cursir" typo in the error message.

## Tests

Regression tests added with `httptest.Server`:
- multi-page success (cursor token forwarded, pages aggregated)
- 200 without cursor returns an error (no panic)
- server returning the same `next` token forever returns an error instead of looping
- non-200 status code returns an error

`go build ./...` and `go test ./pkg/transport/...` pass.

## Reference

Jira: https://formance-team.atlassian.net/browse/EN-1153