### PR TITLE
fix(storage): validate pagination column to prevent SQL injection (EN-1147)

### DIFF
--- a/pkg/storage/bun/paginate/pagination_column.go
+++ b/pkg/storage/bun/paginate/pagination_column.go
@@ -18,28 +18,37 @@ func UsingColumn[FILTERS any, ENTITY any](ctx context.Context,
 	query ColumnPaginatedQuery[FILTERS]) (*Cursor[ENTITY], error) {
 	ret := make([]ENTITY, 0)
 
+	// The column comes from the client-provided cursor, so it must be validated
+	// against the entity known pagination fields before being used in any SQL
+	// expression to prevent SQL injection.
+	var v ENTITY
+	fields := findPaginationFieldPath(v, query.Column)
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("invalid pagination column %q", query.Column)
+	}
+
 	sb = sb.Model(&ret)
 	sb = sb.Limit(int(query.PageSize) + 1) // Fetch one additional item to find the next token
 	order := query.Order
 	if query.Reverse {
 		order = order.Reverse()
 	}
-	sb = sb.OrderExpr(fmt.Sprintf("%s %s", query.Column, order))
+	sb = sb.OrderExpr("? ?", bun.Ident(query.Column), bun.Safe(order.String()))
 
 	if query.PaginationID != nil {
 		if query.Reverse {
 			switch query.Order {
 			case OrderAsc:
-				sb = sb.Where(fmt.Sprintf("%s < ?", query.Column), query.PaginationID)
+				sb = sb.Where("? < ?", bun.Ident(query.Column), query.PaginationID)
 			case OrderDesc:
-				sb = sb.Where(fmt.Sprintf("%s > ?", query.Column), query.PaginationID)
+				sb = sb.Where("? > ?", bun.Ident(query.Column), query.PaginationID)
 			}
 		} else {
 			switch query.Order {
 			case OrderAsc:
-				sb = sb.Where(fmt.Sprintf("%s >= ?", query.Column), query.PaginationID)
+				sb = sb.Where("? >= ?", bun.Ident(query.Column), query.PaginationID)
 			case OrderDesc:
-				sb = sb.Where(fmt.Sprintf("%s <= ?", query.Column), query.PaginationID)
+				sb = sb.Where("? <= ?", bun.Ident(query.Column), query.PaginationID)
 			}
 		}
 	}
@@ -47,9 +56,6 @@ func UsingColumn[FILTERS any, ENTITY any](ctx context.Context,
 	if err := sb.Scan(ctx); err != nil {
 		return nil, err
 	}
-
-	var v ENTITY
-	fields := findPaginationFieldPath(v, query.Column)
 
 	var (
 		paginationIDs = make([]*big.Int, 0)

--- a/pkg/storage/bun/paginate/pagination_column_test.go
+++ b/pkg/storage/bun/paginate/pagination_column_test.go
@@ -318,6 +318,29 @@ func TestColumnPagination(t *testing.T) {
 		},
 	}
 
+	t.Run("invalid pagination column", func(t *testing.T) {
+		t.Parallel()
+
+		for _, column := range []string{
+			"id; DROP TABLE models--",
+			"(SELECT 1)",
+			"id, pair",
+			"unknown",
+			"",
+		} {
+			models := make([]model, 0)
+			query := db.NewSelect().Model(&models).Column("id")
+			_, err := bunpaginate.UsingColumn[bool, model](context.Background(), query, bunpaginate.ColumnPaginatedQuery[bool]{
+				PageSize:     10,
+				Column:       column,
+				PaginationID: big.NewInt(int64(10)),
+				Order:        bunpaginate.OrderAsc,
+			})
+			require.Error(t, err)
+			require.ErrorContains(t, err, "invalid pagination column")
+		}
+	})
+
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Vulnerability

`UsingColumn` in `pkg/storage/bun/paginate/pagination_column.go` interpolated `query.Column` unescaped into the `ORDER BY` and `WHERE` clauses via `fmt.Sprintf`:

```go
sb = sb.OrderExpr(fmt.Sprintf("%s %s", query.Column, order))
...
sb = sb.Where(fmt.Sprintf("%s < ?", query.Column), query.PaginationID)
```

`ColumnPaginatedQuery` is round-tripped through the base64-encoded `cursor=` HTTP query parameter (`Extract` -> `UnmarshalCursor` in `pagination.go`), so any client crafting its own cursor fully controls `Column`. Nothing validated it, making this a SQL injection vector in every service using column-based pagination.

## Fix

- **Validate before building SQL**: `query.Column` is now resolved against the ENTITY's known pagination fields (via the existing `findPaginationFieldPath` reflection helper, moved to the top of `UsingColumn`). If the column does not resolve to a field carrying a matching `bun` tag, the function returns `invalid pagination column "..."` before any SQL is constructed. This also turns the previous panic path (nil field path during cursor extraction) into a clean error.
- **Defense in depth**: the validated column is now passed as `bun.Ident` (properly quoted identifier) in the `OrderExpr`/`Where` calls instead of being string-formatted, and the order keyword is emitted via `bun.Safe(order.String())` (an internal enum constrained to `ASC`/`DESC`).

## Tests

- New regression subtest `TestColumnPagination/invalid_pagination_column`: malicious columns (`id; DROP TABLE models--`, `(SELECT 1)`, `id, pair`), unknown columns, and the empty string are all rejected with an error.
- All existing pagination tests (valid `id` column, asc/desc, cursors, filters) still pass against a real Postgres via docker: `go test ./pkg/storage/...` is green, plus `go build ./...` and `go vet`.

## Reference

https://formance-team.atlassian.net/browse/EN-1147