### PR TITLE
fix(errors): exit-code extraction panics on wrapped errors (EN-1158)

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -19,12 +19,37 @@ func (e ErrorWithExitCode) Error() string {
 }
 
 func (e ErrorWithExitCode) Is(err error) bool {
-	_, ok := err.(ErrorWithExitCode)
-	return ok
+	switch err.(type) {
+	case ErrorWithExitCode, *ErrorWithExitCode:
+		return true
+	default:
+		return false
+	}
 }
 
 func IsErrorWithExitCode(err error) bool {
 	return errors.Is(err, ErrorWithExitCode{})
+}
+
+// ExitCodeFromError extracts the exit code carried by an ErrorWithExitCode
+// anywhere in the wrap chain of err. It returns the exit code and true if
+// such an error is found, or 0 and false otherwise.
+//
+// Unlike a direct type assertion, it survives intermediate wrapping
+// (e.g. fmt.Errorf("...: %w", err)) and matches both the pointer and value
+// forms of ErrorWithExitCode.
+func ExitCodeFromError(err error) (int, bool) {
+	var ptr *ErrorWithExitCode
+	if errors.As(err, &ptr) {
+		return ptr.ExitCode, true
+	}
+
+	var value ErrorWithExitCode
+	if errors.As(err, &value) {
+		return value.ExitCode, true
+	}
+
+	return 0, false
 }
 
 func NewErrorWithExitCode(err error, exitCode int) *ErrorWithExitCode {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -92,6 +92,59 @@ func TestErrorWithExitCode(t *testing.T) {
 		require.False(t, errWithCode.Is(plainErr))
 	})
 
+	t.Run("errors.Is with pointer target", func(t *testing.T) {
+		t.Parallel()
+		// errors.Is must match when the target is the pointer form returned
+		// by NewErrorWithExitCode, even through wrapping
+		errWithCode := errorsutils.NewErrorWithExitCode(errors.New("test error"), 42)
+
+		require.True(t, errors.Is(errWithCode, errorsutils.NewErrorWithExitCode(nil, 0)))
+
+		wrapped := fmt.Errorf("wrapped: %w", errWithCode)
+		require.True(t, errors.Is(wrapped, errorsutils.NewErrorWithExitCode(nil, 0)))
+
+		// Value target keeps working
+		require.True(t, errors.Is(wrapped, errorsutils.ErrorWithExitCode{}))
+
+		// Plain error never matches
+		require.False(t, errors.Is(errors.New("plain error"), errorsutils.NewErrorWithExitCode(nil, 0)))
+	})
+
+	t.Run("ExitCodeFromError", func(t *testing.T) {
+		t.Parallel()
+		errWithCode := errorsutils.NewErrorWithExitCode(errors.New("base error"), 42)
+
+		// Direct error
+		exitCode, ok := errorsutils.ExitCodeFromError(errWithCode)
+		require.True(t, ok)
+		require.Equal(t, 42, exitCode)
+
+		// Double-wrapped error: this is the regression for the old
+		// direct type assertion which panicked on wrapped errors
+		wrappedTwice := fmt.Errorf("wrapped twice: %w", fmt.Errorf("wrapped once: %w", errWithCode))
+		require.NotPanics(t, func() {
+			exitCode, ok = errorsutils.ExitCodeFromError(wrappedTwice)
+		})
+		require.True(t, ok)
+		require.Equal(t, 42, exitCode)
+
+		// Value form in the chain
+		valueErr := fmt.Errorf("wrapped: %w", errorsutils.ErrorWithExitCode{Err: errors.New("base"), ExitCode: 7})
+		exitCode, ok = errorsutils.ExitCodeFromError(valueErr)
+		require.True(t, ok)
+		require.Equal(t, 7, exitCode)
+
+		// Plain error
+		exitCode, ok = errorsutils.ExitCodeFromError(errors.New("plain error"))
+		require.False(t, ok)
+		require.Equal(t, 0, exitCode)
+
+		// Nil error
+		exitCode, ok = errorsutils.ExitCodeFromError(nil)
+		require.False(t, ok)
+		require.Equal(t, 0, exitCode)
+	})
+
 	t.Run("IsErrorWithExitCode", func(t *testing.T) {
 		t.Parallel()
 		// Test with ErrorWithExitCode

--- a/pkg/service/app.go
+++ b/pkg/service/app.go
@@ -55,11 +55,11 @@ func (a *App) Run(cmd *cobra.Command) error {
 
 	app := a.newFxApp(a.logger, gracePeriod, totalStopTimeout)
 	if err := app.Start(logging.ContextWithLogger(cmd.Context(), a.logger)); err != nil {
-		switch {
-		case errorsutils.IsErrorWithExitCode(err):
+		switch exitCode, hasExitCode := errorsutils.ExitCodeFromError(err); {
+		case hasExitCode:
 			a.logger.Errorf("Error: %v", err)
 			// We want to have a specific exit code for the error
-			os.Exit(err.(*errorsutils.ErrorWithExitCode).ExitCode)
+			os.Exit(exitCode)
 		default:
 			// Return complete error if we are debugging
 			// While polluting the output most of the time, it sometimes gives some precious information


### PR DESCRIPTION
## Summary

Fixes [EN-1158](https://formance-team.atlassian.net/browse/EN-1158).

`App.Run` in `pkg/service/app.go` detected an `ErrorWithExitCode` by walking the wrap chain (`errorsutils.IsErrorWithExitCode` uses `errors.Is`), but then extracted the exit code with a **direct type assertion on the head of the chain**:

```go
case errorsutils.IsErrorWithExitCode(err):
    os.Exit(err.(*errorsutils.ErrorWithExitCode).ExitCode)
```

Any intermediate wrapping (e.g. `fmt.Errorf("...: %w", err)`, which fx and dig commonly do) made the guard pass while the assertion panicked with an interface conversion error — masking the real failure and losing the intended exit code.

## Changes

- **`pkg/errors`**: new helper `ExitCodeFromError(err) (int, bool)` that extracts the exit code via `errors.As`, surviving arbitrary wrapping and matching both the pointer and value forms of `ErrorWithExitCode`. Callers no longer need to repeat the assertion.
- **`pkg/errors`**: `ErrorWithExitCode.Is` now matches both `ErrorWithExitCode` and `*ErrorWithExitCode` targets, so `errors.Is(x, NewErrorWithExitCode(...))` (pointer target, the form returned by the constructor) works instead of always returning false.
- **`pkg/service/app.go`**: uses `ExitCodeFromError` instead of the direct type assertion.
- Existing exported API (`IsErrorWithExitCode`, `NewErrorWithExitCode`, `ErrorWithExitCode`) is unchanged and backward compatible. The only other user in the repo (`pkg/fx/authnfx/licence.go`) just constructs the error and needs no change.

## Tests

- Regression test: a double-wrapped `ErrorWithExitCode` passed through `ExitCodeFromError` yields the right exit code without panicking.
- `errors.Is` with a pointer target (wrapped and unwrapped) now passes.
- `go build ./...` and `go test ./pkg/errors/... ./pkg/service/...` pass.

[EN-1158]: https://formance-team.atlassian.net/browse/EN-1158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ