### PR TITLE
fix(httpserver): Serve goroutine panic kills the process (EN-1160)

### DIFF
--- a/pkg/transport/httpserver/serverport.go
+++ b/pkg/transport/httpserver/serverport.go
@@ -2,6 +2,7 @@ package httpserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -43,9 +44,8 @@ func startServer(ctx context.Context, s *serverport.Server, handler http.Handler
 	}
 
 	go func() {
-		err := srv.Serve(s.Listener)
-		if err != nil && err != http.ErrServerClosed {
-			panic(err)
+		if err := srv.Serve(s.Listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logging.FromContext(ctx).Errorf("failed to serve: %v", err)
 		}
 	}()
 

--- a/pkg/transport/httpserver/serverport_test.go
+++ b/pkg/transport/httpserver/serverport_test.go
@@ -1,0 +1,90 @@
+package httpserver
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/transport/serverport"
+)
+
+// safeBuffer is a goroutine-safe io.Writer used to capture log output emitted
+// from the Serve goroutine.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *safeBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *safeBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// TestStartServerServeErrorDoesNotPanic is a regression test for EN-1160: an
+// unexpected Serve error (anything other than http.ErrServerClosed) used to
+// panic inside an unmonitored goroutine, killing the whole process and
+// bypassing fx OnStop hooks. It must be logged instead.
+func TestStartServerServeErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	buf := &safeBuffer{}
+	ctx := logging.ContextWithLogger(context.Background(), logging.NewDefaultLogger(buf, false, false, false))
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := serverport.NewServer(serverPortDiscr, serverport.WithListener(listener))
+
+	stop, err := startServer(ctx, server, http.NewServeMux())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = stop(context.Background())
+	})
+
+	// Close the listener out from under the server: Serve returns a
+	// non-ErrServerClosed error. A panic in the Serve goroutine would crash
+	// the test binary; instead the error must be logged.
+	require.NoError(t, listener.Close())
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(buf.String(), "failed to serve")
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestStartServerGracefulShutdownDoesNotLogError checks that a graceful
+// shutdown (Serve returning http.ErrServerClosed) is not reported as an error.
+func TestStartServerGracefulShutdownDoesNotLogError(t *testing.T) {
+	t.Parallel()
+
+	buf := &safeBuffer{}
+	ctx := logging.ContextWithLogger(context.Background(), logging.NewDefaultLogger(buf, false, false, false))
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := serverport.NewServer(serverPortDiscr, serverport.WithListener(listener))
+
+	stop, err := startServer(ctx, server, http.NewServeMux())
+	require.NoError(t, err)
+
+	require.NoError(t, stop(context.Background()))
+
+	// Give the Serve goroutine time to observe http.ErrServerClosed.
+	time.Sleep(100 * time.Millisecond)
+	require.NotContains(t, buf.String(), "failed to serve")
+}


### PR DESCRIPTION
## Problem

In `pkg/transport/httpserver/serverport.go`, the goroutine running `srv.Serve` panicked on any error other than `http.ErrServerClosed`:

```go
go func() {
    err := srv.Serve(s.Listener)
    if err != nil && err != http.ErrServerClosed {
        panic(err)
    }
}()
```

A panic in an unmonitored goroutine is unrecoverable: it crashes the entire process and bypasses all fx `OnStop` hooks, so no graceful shutdown of other components can happen. The gRPC equivalent (`pkg/transport/grpcserver/serverport.go`) already logs the error instead.

## Fix

- Align with the grpcserver pattern: log the error via `logging.FromContext(ctx).Errorf("failed to serve: %v", err)` instead of panicking.
- Use `errors.Is(err, http.ErrServerClosed)` instead of `!=` so wrapped errors are handled correctly.
- Behavior is otherwise unchanged (graceful shutdown via `srv.Shutdown` still works and logs nothing).

## Tests

- `TestStartServerServeErrorDoesNotPanic` (regression): closes the listener out from under the server, forcing `Serve` to return a non-`ErrServerClosed` error. Before this fix, that panicked the test binary; now the test asserts the error is logged and the process survives.
- `TestStartServerGracefulShutdownDoesNotLogError`: a graceful shutdown must not be reported as a serve failure.

`go build ./...`, `go test ./pkg/transport/...` and `go test -race ./pkg/transport/httpserver/` all pass.

## References

- Jira: https://formance-team.atlassian.net/browse/EN-1160