### PR TITLE
fix(api): chiLogEntry.Panic defeats chi Recoverer (EN-1164)

### DIFF
--- a/pkg/transport/api/logging_chi.go
+++ b/pkg/transport/api/logging_chi.go
@@ -29,7 +29,12 @@ func (c *chiLogEntry) Write(status, bytes int, _ http.Header, elapsed time.Durat
 }
 
 func (c *chiLogEntry) Panic(v interface{}, stack []byte) {
-	panic(fmt.Sprintf("%s\n%s", v, stack))
+	logging.FromContext(c.r.Context()).
+		WithFields(map[string]any{
+			"panic": fmt.Sprintf("%v", v),
+			"stack": string(stack),
+		}).
+		Errorf("%s %s: panic recovered", c.r.Method, c.r.URL.Path)
 }
 
 var _ middleware.LogEntry = (*chiLogEntry)(nil)

--- a/pkg/transport/api/logging_chi_test.go
+++ b/pkg/transport/api/logging_chi_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/require"
 
@@ -73,16 +74,58 @@ func TestChiLogFormatter(t *testing.T) {
 
 	t.Run("Panic", func(t *testing.T) {
 		t.Parallel()
-		formatter := api.NewLogFormatter()
+		// Create a buffer to capture log output
+		var buf bytes.Buffer
+		logger := logging.NewDefaultLogger(&buf, true, false, false)
+
+		// Create a request with the logger in context
 		req, err := http.NewRequest("GET", "/test", nil)
 		require.NoError(t, err)
+		ctx := logging.ContextWithLogger(context.Background(), logger)
+		req = req.WithContext(ctx)
 
+		formatter := api.NewLogFormatter()
 		entry := formatter.NewLogEntry(req)
 
-		// Test that Panic method panics
-		require.Panics(t, func() {
+		// Panic must log the panic value and stack instead of re-panicking,
+		// otherwise chi's Recoverer cannot write the 500 response.
+		require.NotPanics(t, func() {
 			entry.Panic("test panic", []byte("stack trace"))
 		})
+
+		logOutput := buf.String()
+		require.Contains(t, logOutput, "GET /test")
+		require.Contains(t, logOutput, "test panic")
+		require.Contains(t, logOutput, "stack trace")
+	})
+
+	t.Run("Panicking handler returns 500 with Recoverer", func(t *testing.T) {
+		t.Parallel()
+		// Regression test for EN-1164: re-panicking from chiLogEntry.Panic
+		// aborted chi's Recoverer before it could write the 500 response.
+		var buf bytes.Buffer
+		logger := logging.NewDefaultLogger(&buf, true, false, false)
+
+		router := chi.NewRouter()
+		router.Use(middleware.RequestLogger(api.NewLogFormatter()))
+		router.Use(middleware.Recoverer)
+		router.Get("/panic", func(w http.ResponseWriter, r *http.Request) {
+			panic("boom")
+		})
+
+		req := httptest.NewRequest("GET", "/panic", nil)
+		req = req.WithContext(logging.ContextWithLogger(context.Background(), logger))
+		rr := httptest.NewRecorder()
+
+		// Recoverer must be able to complete its recovery path and write
+		// the 500 response instead of the panic being propagated
+		require.NotPanics(t, func() {
+			router.ServeHTTP(rr, req)
+		})
+		require.Equal(t, http.StatusInternalServerError, rr.Code)
+
+		// The panic value must have been logged
+		require.Contains(t, buf.String(), "boom")
 	})
 
 	t.Run("Integration with Chi middleware", func(t *testing.T) {


### PR DESCRIPTION
## Problem

`chiLogEntry.Panic` in `pkg/transport/api/logging_chi.go` re-panicked with the formatted panic value and stack:

```go
func (c *chiLogEntry) Panic(v interface{}, stack []byte) {
    panic(fmt.Sprintf("%s\n%s", v, stack))
}
```

chi's `middleware.Recoverer` calls `logEntry.Panic(rvr, stack)` **before** writing the 500 response. Re-panicking aborts the recovery path: the 500 is never written, the new panic propagates up to `net/http`, and the client gets a severed connection instead of a response. Any service combining `NewLogFormatter()` with chi's `Recoverer` effectively loses panic recovery.

## Fix

`Panic` now logs the panic value and stack at error level via the request-scoped logger (same pattern as `Write`), and does **not** re-panic. `Recoverer` can complete its recovery path and return HTTP 500 to the client.

## Tests

- Updated the `Panic` unit test: asserts no re-panic and that the panic value/stack are logged.
- Added a regression test: chi router with `middleware.RequestLogger(api.NewLogFormatter())` + `middleware.Recoverer` and a panicking handler must return HTTP 500 and log the panic.
- `go build ./...` and `go test ./pkg/transport/...` pass.

## Reference

Jira: https://formance-team.atlassian.net/browse/EN-1164