### PR TITLE
fix(audit): prevent audit bypass via client-controlled header (EN-1152)

### DIFF
--- a/pkg/audit/flags.go
+++ b/pkg/audit/flags.go
@@ -7,15 +7,21 @@ import (
 )
 
 const (
-	AuditEnabledFlag = "audit-enabled"
+	AuditEnabledFlag             = "audit-enabled"
+	AuditHandledHeaderSecretFlag = "audit-handled-header-secret"
 )
 
 type Config struct {
 	Enabled bool
+	// HandledHeaderSecret is the shared secret required for the audit
+	// middleware to honor the HandledHeader dedup header. Without it, any
+	// client can spoof the header and bypass the audit trail.
+	HandledHeaderSecret string
 }
 
 func AddFlags(flags *pflag.FlagSet) {
 	flags.Bool(AuditEnabledFlag, false, "Enable audit")
+	flags.String(AuditHandledHeaderSecretFlag, "", "Shared secret required to honor the audit-handled dedup header; without it the header is spoofable by external clients")
 }
 
 func ConfigFromFlags(flags *pflag.FlagSet) (Config, error) {
@@ -24,7 +30,13 @@ func ConfigFromFlags(flags *pflag.FlagSet) (Config, error) {
 		return Config{}, fmt.Errorf("failed to read %s flag: %w", AuditEnabledFlag, err)
 	}
 
+	handledHeaderSecret, err := flags.GetString(AuditHandledHeaderSecretFlag)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to read %s flag: %w", AuditHandledHeaderSecretFlag, err)
+	}
+
 	return Config{
-		Enabled: enabled,
+		Enabled:             enabled,
+		HandledHeaderSecret: handledHeaderSecret,
 	}, nil
 }

--- a/pkg/audit/flags_test.go
+++ b/pkg/audit/flags_test.go
@@ -48,6 +48,44 @@ func TestConfigFromFlagsEnabledFromEnv(t *testing.T) {
 	assert.True(t, cfg.Enabled)
 }
 
+func TestConfigFromFlagsHandledHeaderSecretEmptyByDefault(t *testing.T) {
+	t.Parallel()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddFlags(flags)
+
+	cfg, err := ConfigFromFlags(flags)
+
+	require.NoError(t, err)
+	assert.Empty(t, cfg.HandledHeaderSecret)
+}
+
+func TestConfigFromFlagsHandledHeaderSecretFromFlag(t *testing.T) {
+	t.Parallel()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddFlags(flags)
+	require.NoError(t, flags.Set(AuditHandledHeaderSecretFlag, "super-secret"))
+
+	cfg, err := ConfigFromFlags(flags)
+
+	require.NoError(t, err)
+	assert.Equal(t, "super-secret", cfg.HandledHeaderSecret)
+}
+
+func TestConfigFromFlagsHandledHeaderSecretFromEnv(t *testing.T) {
+	t.Setenv("AUDIT_HANDLED_HEADER_SECRET", "env-secret")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddFlags(flags)
+	service.BindEnvToFlagSet(flags)
+
+	cfg, err := ConfigFromFlags(flags)
+
+	require.NoError(t, err)
+	assert.Equal(t, "env-secret", cfg.HandledHeaderSecret)
+}
+
 func TestConfigFromFlagsReturnsErrorWhenFlagIsMissing(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/audit/httpaudit/middleware.go
+++ b/pkg/audit/httpaudit/middleware.go
@@ -3,6 +3,7 @@ package httpaudit
 import (
 	"bufio"
 	"bytes"
+	"crypto/subtle"
 	"errors"
 	"io"
 	"mime"
@@ -14,15 +15,17 @@ import (
 	"github.com/ThreeDotsLabs/watermill/message"
 
 	"github.com/formancehq/go-libs/v5/pkg/audit"
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
 // HTTPOption configures HTTP-specific audit behavior.
 type HTTPOption func(*httpOptions)
 
 type httpOptions struct {
-	enabled        bool
-	sensitivePaths map[string]struct{}
-	eventPublisher auditEventPublisher
+	enabled             bool
+	sensitivePaths      map[string]struct{}
+	eventPublisher      auditEventPublisher
+	handledHeaderSecret string
 }
 
 // WithSensitivePaths sets paths for which the response body should not be captured.
@@ -41,9 +44,28 @@ func WithEnabled(enabled bool) HTTPOption {
 	}
 }
 
+// WithHandledHeaderSecret sets the shared secret required to honor the
+// audit.HandledHeader dedup header.
+//
+// When a secret is configured, the middleware only skips audit when the
+// incoming header value matches the secret, and marks handled requests by
+// setting the header to the secret so trusted downstream services (sharing
+// the same secret) deduplicate correctly. When no secret is configured, any
+// non-empty header value skips audit, which lets external clients bypass the
+// audit trail; configure a secret on every service in the request path that
+// is reachable, directly or indirectly, by untrusted clients.
+func WithHandledHeaderSecret(secret string) HTTPOption {
+	return func(o *httpOptions) {
+		o.handledHeaderSecret = secret
+	}
+}
+
 // WithConfig configures HTTP audit event capture from audit.Config.
 func WithConfig(config audit.Config) HTTPOption {
-	return WithEnabled(config.Enabled)
+	return func(o *httpOptions) {
+		WithEnabled(config.Enabled)(o)
+		WithHandledHeaderSecret(config.HandledHeaderSecret)(o)
+	}
 }
 
 // WithAsyncPublishing enables async publishing using a caller-managed AsyncPublisher.
@@ -80,8 +102,19 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 		opt(ho)
 	}
 
+	handledHeaderValue := "true"
+	if ho.handledHeaderSecret != "" {
+		handledHeaderValue = ho.handledHeaderSecret
+	}
+
 	var eventPublisher auditEventPublisher
 	if ho.enabled {
+		if ho.handledHeaderSecret == "" {
+			logging.Infof(
+				"WARNING: audit middleware configured without a handled-header secret: any client sending the %s header can bypass the audit trail; configure WithHandledHeaderSecret (flag --%s)",
+				audit.HandledHeader, audit.AuditHandledHeaderSecretFlag,
+			)
+		}
 		eventPublisher = auditEventPublisher(syncAuditEventPublisher{
 			publisher: publisher,
 			topicName: topicName,
@@ -99,9 +132,17 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				return
 			}
 
-			if r.Header.Get(audit.HandledHeader) != "" {
-				next.ServeHTTP(w, r)
-				return
+			// Skip audit when an upstream trusted hop already handled it.
+			// With a secret configured, only a header carrying the exact
+			// secret is honored; anything else (e.g. a client-forged value)
+			// is still audited. Without a secret, keep the legacy behavior
+			// of trusting any non-empty value.
+			if headerValue := r.Header.Get(audit.HandledHeader); headerValue != "" {
+				if ho.handledHeaderSecret == "" ||
+					subtle.ConstantTimeCompare([]byte(headerValue), []byte(ho.handledHeaderSecret)) == 1 {
+					next.ServeHTTP(w, r)
+					return
+				}
 			}
 
 			var (
@@ -125,7 +166,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 			requestHeaders.Del("Authorization")
 			requestHeaders.Del(audit.HandledHeader)
 
-			r.Header.Set(audit.HandledHeader, "true")
+			r.Header.Set(audit.HandledHeader, handledHeaderValue)
 
 			buf := bufPool.Get().(*bytes.Buffer)
 			buf.Reset()

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -489,6 +489,131 @@ func TestMiddleware_SkipsWhenHeaderPresent(t *testing.T) {
 	assert.Empty(t, messages)
 }
 
+func TestMiddleware_SecretConfiguredAuditsForgedHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		headerValue string
+	}{
+		{name: "legacy true value", headerValue: "true"},
+		{name: "arbitrary client value", headerValue: "x"},
+		{name: "wrong secret", headerValue: "not-the-secret"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pub := publish.InMemory()
+			topic := "audit-events"
+
+			var downstreamHeaderValue string
+			handler := Middleware(pub, topic, "test-app", nil,
+				WithEnabled(true),
+				WithHandledHeaderSecret("super-secret"),
+			)(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					downstreamHeaderValue = r.Header.Get(audit.HandledHeader)
+					w.WriteHeader(http.StatusOK)
+				}),
+			)
+
+			req := httptest.NewRequest("GET", "/api/test", nil)
+			req.Header.Set(audit.HandledHeader, tt.headerValue)
+			req = req.WithContext(logging.TestingContext())
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code)
+
+			messages := pub.AllMessages()[topic]
+			require.Len(t, messages, 1, "request with forged header must still be audited")
+
+			// Downstream services sharing the secret must see the secret, not the forged value.
+			assert.Equal(t, "super-secret", downstreamHeaderValue)
+
+			// The secret must not leak into the audit payload.
+			var event publish.EventMessage
+			require.NoError(t, json.Unmarshal(messages[0].Payload, &event))
+
+			payloadBytes, _ := json.Marshal(event.Payload)
+			var payload audit.Payload
+			require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+
+			assert.Empty(t, payload.HTTP.Request.Header.Get(audit.HandledHeader))
+			assert.NotContains(t, string(messages[0].Payload), "super-secret")
+		})
+	}
+}
+
+func TestMiddleware_SecretConfiguredSkipsWhenHeaderMatches(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	handler := Middleware(pub, topic, "test-app", nil,
+		WithEnabled(true),
+		WithHandledHeaderSecret("super-secret"),
+	)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set(audit.HandledHeader, "super-secret")
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "ok", rr.Body.String())
+
+	assert.Empty(t, pub.AllMessages()[topic])
+}
+
+func TestMiddleware_SecretConfiguredViaConfigFromFlags(t *testing.T) {
+	t.Parallel()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	audit.AddFlags(flags)
+	require.NoError(t, flags.Set(audit.AuditEnabledFlag, "true"))
+	require.NoError(t, flags.Set(audit.AuditHandledHeaderSecretFlag, "flag-secret"))
+
+	cfg, err := audit.ConfigFromFlags(flags)
+	require.NoError(t, err)
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	handler := Middleware(pub, topic, "test-app", nil, WithConfig(cfg))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	// A client-forged header value is still audited.
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set(audit.HandledHeader, "true")
+	req = req.WithContext(logging.TestingContext())
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Len(t, pub.AllMessages()[topic], 1)
+
+	// The configured secret skips audit.
+	req = httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set(audit.HandledHeader, "flag-secret")
+	req = req.WithContext(logging.TestingContext())
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Len(t, pub.AllMessages()[topic], 1)
+}
+
 func TestMiddleware_SetsHeaderForDownstream(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -14,6 +14,13 @@ const (
 // HandledHeader is set by the audit middleware after processing a request.
 // When present on an incoming request, the middleware skips audit to avoid
 // duplicate events (e.g. gateway already audited, upstream service sees this header).
+//
+// Trust requirement: this header is only trustworthy when every hop that can
+// set it is trusted. Edge components (e.g. the gateway) MUST strip it from
+// external requests, or a shared secret MUST be configured (see
+// httpaudit.WithHandledHeaderSecret / AuditHandledHeaderSecretFlag) so that
+// only holders of the secret can mark a request as already audited.
+// Otherwise, any external client can send this header to bypass the audit trail.
 const HandledHeader = "X-Formance-Audit"
 
 type Payload struct {


### PR DESCRIPTION
## Problem

The HTTP audit middleware skips auditing any request that carries a non-empty `X-Formance-Audit` (`audit.HandledHeader`) header. This header is meant to deduplicate audit events between the gateway and internal services, but nothing distinguishes a gateway-set header from a client-set one. **Any external client sending `X-Formance-Audit: x` escapes the audit trail entirely** — fail-open for a compliance feature.

Jira: [EN-1152](https://formance-team.atlassian.net/browse/EN-1152)

## Fix

Introduce a shared-secret scheme for the dedup header, backward compatible:

- New HTTP option `httpaudit.WithHandledHeaderSecret(secret)` and flag `--audit-handled-header-secret` (env `AUDIT_HANDLED_HEADER_SECRET`), wired through `audit.Config` / `WithConfig`.
- **With a secret configured:** the audit skip only happens when the incoming header value equals the secret (constant-time comparison via `crypto/subtle`). Any other value — including anything an external client could guess, like `true` — is still audited. The middleware marks handled requests by setting the header to the secret so trusted downstream services sharing the same secret deduplicate correctly. The secret never appears in the audit payload (the header was already stripped from captured headers).
- **Without a secret:** legacy behavior is preserved (any non-empty value skips audit), but a warning is logged once at middleware construction stating that the dedup header is spoofable.
- The trust requirement is documented on the `HandledHeader` constant and the new option.

## Migration

No action is required to upgrade — behavior is unchanged until a secret is configured. To close the bypass:

1. Generate a random secret and configure it on **every** service in the request path (gateway and internal services) via `--audit-handled-header-secret` / `AUDIT_HANDLED_HEADER_SECRET` or `httpaudit.WithHandledHeaderSecret`.
2. Roll out to all services; mismatched configuration only causes duplicate audit events (fail-closed), never missing ones.

## Tests

- With a secret: forged header values (`true`, `x`, wrong secret) are still audited, downstream sees the secret, and the secret does not leak into the audit payload.
- With a secret: a header carrying the correct secret skips audit.
- Without a secret: legacy skip behavior holds (existing `TestMiddleware_SkipsWhenHeaderPresent`).
- Flag/config plumbing: default empty, set via flag, set via env, propagated through `WithConfig`.

`go build ./...` and `go test ./pkg/audit/...` pass.

[EN-1152]: https://formance-team.atlassian.net/browse/EN-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ