### PR TITLE
fix(api): ParsePageSize panics on user-controlled input (EN-1162)

### DIFF
--- a/pkg/transport/api/utils.go
+++ b/pkg/transport/api/utils.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -16,6 +14,7 @@ const (
 	defaultLimit = 15
 
 	// MaxPageSize is the maximum value accepted for the `pageSize` query parameter.
+	// Larger values are clamped to it.
 	MaxPageSize = bunpaginate.MaxPageSize
 
 	ErrorCodeNotFound   = "NOT_FOUND"
@@ -23,10 +22,6 @@ const (
 	ErrorCodeForbidden  = "FORBIDDEN"
 	ErrorCodeValidation = "VALIDATION"
 )
-
-// ErrInvalidPageSize is returned when the `pageSize` query parameter is not a
-// valid integer in the [1, MaxPageSize] range.
-var ErrInvalidPageSize = errors.New("invalid 'pageSize' query param")
 
 func writeJSON(w http.ResponseWriter, statusCode int, v any) {
 	w.Header().Set("Content-Type", "application/json")
@@ -122,42 +117,43 @@ func ParsePaginationToken(r *http.Request) string {
 	return r.URL.Query().Get("paginationToken")
 }
 
-// ParsePageSize parses the `pageSize` query parameter.
-// It returns defaultLimit when the parameter is absent or empty, and
-// ErrInvalidPageSize when the value is not an integer in the [1, MaxPageSize] range.
-func ParsePageSize(r *http.Request) (int, error) {
+// ParsePageSize parses the `pageSize` query parameter. It never fails:
+//   - absent or empty parameter: returns defaultLimit
+//   - invalid value (non-numeric, overflow, <= 0): logs and returns defaultLimit
+//   - value above MaxPageSize: logs and returns MaxPageSize
+func ParsePageSize(r *http.Request) int {
 	pageSize := r.URL.Query().Get("pageSize")
 	if pageSize == "" {
-		return defaultLimit, nil
+		return defaultLimit
 	}
 
 	v, err := strconv.ParseInt(pageSize, 10, 32)
-	if err != nil {
-		return 0, fmt.Errorf("%w: must be an integer between 1 and %d", ErrInvalidPageSize, MaxPageSize)
+	if err != nil || v <= 0 {
+		// note: the logger has no warning level, Infof is the closest
+		logging.FromContext(r.Context()).
+			Infof("invalid 'pageSize' query param %q, falling back to default page size %d", pageSize, defaultLimit)
+		return defaultLimit
 	}
-	if v <= 0 || v > MaxPageSize {
-		return 0, fmt.Errorf("%w: must be between 1 and %d", ErrInvalidPageSize, MaxPageSize)
+	if v > MaxPageSize {
+		logging.FromContext(r.Context()).
+			Debugf("'pageSize' query param %d exceeds maximum, clamped to %d", v, MaxPageSize)
+		return MaxPageSize
 	}
-	return int(v), nil
+	return int(v)
 }
 
-func ReadPaginatedRequest[T any](r *http.Request, f func(r *http.Request) T) (ListQuery[T], error) {
-	pageSize, err := ParsePageSize(r)
-	if err != nil {
-		return ListQuery[T]{}, err
-	}
-
+func ReadPaginatedRequest[T any](r *http.Request, f func(r *http.Request) T) ListQuery[T] {
 	var payload T
 	if f != nil {
 		payload = f(r)
 	}
 	return ListQuery[T]{
 		Pagination: Pagination{
-			Limit:           pageSize,
+			Limit:           ParsePageSize(r),
 			PaginationToken: ParsePaginationToken(r),
 		},
 		Payload: payload,
-	}, nil
+	}
 }
 
 func GetQueryMap(m map[string][]string, key string) map[string]string {

--- a/pkg/transport/api/utils.go
+++ b/pkg/transport/api/utils.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -13,11 +15,18 @@ import (
 const (
 	defaultLimit = 15
 
+	// MaxPageSize is the maximum value accepted for the `pageSize` query parameter.
+	MaxPageSize = bunpaginate.MaxPageSize
+
 	ErrorCodeNotFound   = "NOT_FOUND"
 	ErrorInternal       = "INTERNAL"
 	ErrorCodeForbidden  = "FORBIDDEN"
 	ErrorCodeValidation = "VALIDATION"
 )
+
+// ErrInvalidPageSize is returned when the `pageSize` query parameter is not a
+// valid integer in the [1, MaxPageSize] range.
+var ErrInvalidPageSize = errors.New("invalid 'pageSize' query param")
 
 func writeJSON(w http.ResponseWriter, statusCode int, v any) {
 	w.Header().Set("Content-Type", "application/json")
@@ -113,31 +122,42 @@ func ParsePaginationToken(r *http.Request) string {
 	return r.URL.Query().Get("paginationToken")
 }
 
-func ParsePageSize(r *http.Request) int {
+// ParsePageSize parses the `pageSize` query parameter.
+// It returns defaultLimit when the parameter is absent or empty, and
+// ErrInvalidPageSize when the value is not an integer in the [1, MaxPageSize] range.
+func ParsePageSize(r *http.Request) (int, error) {
 	pageSize := r.URL.Query().Get("pageSize")
 	if pageSize == "" {
-		return defaultLimit
+		return defaultLimit, nil
 	}
 
 	v, err := strconv.ParseInt(pageSize, 10, 32)
 	if err != nil {
-		panic(err)
+		return 0, fmt.Errorf("%w: must be an integer between 1 and %d", ErrInvalidPageSize, MaxPageSize)
 	}
-	return int(v)
+	if v <= 0 || v > MaxPageSize {
+		return 0, fmt.Errorf("%w: must be between 1 and %d", ErrInvalidPageSize, MaxPageSize)
+	}
+	return int(v), nil
 }
 
-func ReadPaginatedRequest[T any](r *http.Request, f func(r *http.Request) T) ListQuery[T] {
+func ReadPaginatedRequest[T any](r *http.Request, f func(r *http.Request) T) (ListQuery[T], error) {
+	pageSize, err := ParsePageSize(r)
+	if err != nil {
+		return ListQuery[T]{}, err
+	}
+
 	var payload T
 	if f != nil {
 		payload = f(r)
 	}
 	return ListQuery[T]{
 		Pagination: Pagination{
-			Limit:           ParsePageSize(r),
+			Limit:           pageSize,
 			PaginationToken: ParsePaginationToken(r),
 		},
 		Payload: payload,
-	}
+	}, nil
 }
 
 func GetQueryMap(m map[string][]string, key string) map[string]string {

--- a/pkg/transport/api/utils.go
+++ b/pkg/transport/api/utils.go
@@ -136,7 +136,7 @@ func ParsePageSize(r *http.Request) int {
 	}
 	if v > MaxPageSize {
 		logging.FromContext(r.Context()).
-			Debugf("'pageSize' query param %d exceeds maximum, clamped to %d", v, MaxPageSize)
+			Infof("'pageSize' query param %d exceeds maximum, clamped to %d", v, MaxPageSize)
 		return MaxPageSize
 	}
 	return int(v)

--- a/pkg/transport/api/utils_test.go
+++ b/pkg/transport/api/utils_test.go
@@ -486,7 +486,6 @@ func TestParsePageSize(t *testing.T) {
 		name           string
 		queryParams    map[string]string
 		expectedResult int
-		expectedError  error
 	}{
 		{
 			name: "with page size",
@@ -512,42 +511,42 @@ func TestParsePageSize(t *testing.T) {
 			queryParams: map[string]string{
 				"pageSize": "100",
 			},
-			expectedResult: 100,
+			expectedResult: api.MaxPageSize,
 		},
 		{
 			name: "with non-numeric page size",
 			queryParams: map[string]string{
 				"pageSize": "invalid",
 			},
-			expectedError: api.ErrInvalidPageSize,
+			expectedResult: 15, // falls back to default limit
 		},
 		{
 			name: "with negative page size",
 			queryParams: map[string]string{
 				"pageSize": "-1",
 			},
-			expectedError: api.ErrInvalidPageSize,
+			expectedResult: 15, // falls back to default limit
 		},
 		{
 			name: "with zero page size",
 			queryParams: map[string]string{
 				"pageSize": "0",
 			},
-			expectedError: api.ErrInvalidPageSize,
+			expectedResult: 15, // falls back to default limit
 		},
 		{
 			name: "with page size above max",
 			queryParams: map[string]string{
 				"pageSize": "101",
 			},
-			expectedError: api.ErrInvalidPageSize,
+			expectedResult: api.MaxPageSize, // clamped
 		},
 		{
 			name: "with huge page size overflowing int32",
 			queryParams: map[string]string{
 				"pageSize": "99999999999999999999",
 			},
-			expectedError: api.ErrInvalidPageSize,
+			expectedResult: 15, // falls back to default limit
 		},
 	}
 
@@ -567,17 +566,11 @@ func TestParsePageSize(t *testing.T) {
 
 			// Call the function, it must never panic
 			var result int
-			var err error
 			require.NotPanics(t, func() {
-				result, err = api.ParsePageSize(req)
+				result = api.ParsePageSize(req)
 			})
 
 			// Check the result
-			if tc.expectedError != nil {
-				require.ErrorIs(t, err, tc.expectedError)
-				return
-			}
-			require.NoError(t, err)
 			require.Equal(t, tc.expectedResult, result)
 		})
 	}
@@ -606,22 +599,20 @@ func TestReadPaginatedRequest(t *testing.T) {
 	}
 
 	// Call the function
-	result, err := api.ReadPaginatedRequest(req, payloadExtractor)
+	result := api.ReadPaginatedRequest(req, payloadExtractor)
 
 	// Check the result
-	require.NoError(t, err)
 	require.Equal(t, 20, result.Limit)
 	require.Equal(t, "test-token", result.PaginationToken)
 	require.Equal(t, TestPayload{Filter: ""}, result.Payload)
 
 	// Test with nil payload extractor
-	result, err = api.ReadPaginatedRequest[TestPayload](req, nil)
-	require.NoError(t, err)
+	result = api.ReadPaginatedRequest[TestPayload](req, nil)
 	require.Equal(t, 20, result.Limit)
 	require.Equal(t, "test-token", result.PaginationToken)
 	require.Equal(t, TestPayload{}, result.Payload)
 
-	// Invalid page size must be reported as a validation error, not a panic
+	// Invalid page size must fall back to the default limit, not panic
 	u, _ = url.Parse("http://example.com")
 	q = u.Query()
 	q.Set("pageSize", "invalid")
@@ -629,9 +620,9 @@ func TestReadPaginatedRequest(t *testing.T) {
 	req, _ = http.NewRequest("GET", u.String(), nil)
 
 	require.NotPanics(t, func() {
-		_, err = api.ReadPaginatedRequest(req, payloadExtractor)
+		result = api.ReadPaginatedRequest(req, payloadExtractor)
 	})
-	require.ErrorIs(t, err, api.ErrInvalidPageSize)
+	require.Equal(t, 15, result.Limit) // default limit
 }
 
 func TestGetQueryMap(t *testing.T) {

--- a/pkg/transport/api/utils_test.go
+++ b/pkg/transport/api/utils_test.go
@@ -486,6 +486,7 @@ func TestParsePageSize(t *testing.T) {
 		name           string
 		queryParams    map[string]string
 		expectedResult int
+		expectedError  error
 	}{
 		{
 			name: "with page size",
@@ -506,6 +507,48 @@ func TestParsePageSize(t *testing.T) {
 			},
 			expectedResult: 15, // default limit
 		},
+		{
+			name: "with max page size",
+			queryParams: map[string]string{
+				"pageSize": "100",
+			},
+			expectedResult: 100,
+		},
+		{
+			name: "with non-numeric page size",
+			queryParams: map[string]string{
+				"pageSize": "invalid",
+			},
+			expectedError: api.ErrInvalidPageSize,
+		},
+		{
+			name: "with negative page size",
+			queryParams: map[string]string{
+				"pageSize": "-1",
+			},
+			expectedError: api.ErrInvalidPageSize,
+		},
+		{
+			name: "with zero page size",
+			queryParams: map[string]string{
+				"pageSize": "0",
+			},
+			expectedError: api.ErrInvalidPageSize,
+		},
+		{
+			name: "with page size above max",
+			queryParams: map[string]string{
+				"pageSize": "101",
+			},
+			expectedError: api.ErrInvalidPageSize,
+		},
+		{
+			name: "with huge page size overflowing int32",
+			queryParams: map[string]string{
+				"pageSize": "99999999999999999999",
+			},
+			expectedError: api.ErrInvalidPageSize,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -522,30 +565,22 @@ func TestParsePageSize(t *testing.T) {
 			// Create a request with the URL
 			req, _ := http.NewRequest("GET", u.String(), nil)
 
-			// Call the function
-			result := api.ParsePageSize(req)
+			// Call the function, it must never panic
+			var result int
+			var err error
+			require.NotPanics(t, func() {
+				result, err = api.ParsePageSize(req)
+			})
 
 			// Check the result
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+				return
+			}
+			require.NoError(t, err)
 			require.Equal(t, tc.expectedResult, result)
 		})
 	}
-
-	// Test panic with invalid page size
-	t.Run("invalid page size", func(t *testing.T) {
-		// Create a URL with invalid page size
-		u, _ := url.Parse("http://example.com")
-		q := u.Query()
-		q.Set("pageSize", "invalid")
-		u.RawQuery = q.Encode()
-
-		// Create a request with the URL
-		req, _ := http.NewRequest("GET", u.String(), nil)
-
-		// Call the function and expect panic
-		require.Panics(t, func() {
-			api.ParsePageSize(req)
-		})
-	})
 }
 
 func TestReadPaginatedRequest(t *testing.T) {
@@ -571,18 +606,32 @@ func TestReadPaginatedRequest(t *testing.T) {
 	}
 
 	// Call the function
-	result := api.ReadPaginatedRequest(req, payloadExtractor)
+	result, err := api.ReadPaginatedRequest(req, payloadExtractor)
 
 	// Check the result
+	require.NoError(t, err)
 	require.Equal(t, 20, result.Limit)
 	require.Equal(t, "test-token", result.PaginationToken)
 	require.Equal(t, TestPayload{Filter: ""}, result.Payload)
 
 	// Test with nil payload extractor
-	result = api.ReadPaginatedRequest[TestPayload](req, nil)
+	result, err = api.ReadPaginatedRequest[TestPayload](req, nil)
+	require.NoError(t, err)
 	require.Equal(t, 20, result.Limit)
 	require.Equal(t, "test-token", result.PaginationToken)
 	require.Equal(t, TestPayload{}, result.Payload)
+
+	// Invalid page size must be reported as a validation error, not a panic
+	u, _ = url.Parse("http://example.com")
+	q = u.Query()
+	q.Set("pageSize", "invalid")
+	u.RawQuery = q.Encode()
+	req, _ = http.NewRequest("GET", u.String(), nil)
+
+	require.NotPanics(t, func() {
+		_, err = api.ReadPaginatedRequest(req, payloadExtractor)
+	})
+	require.ErrorIs(t, err, api.ErrInvalidPageSize)
 }
 
 func TestGetQueryMap(t *testing.T) {


### PR DESCRIPTION
## Summary

`api.ParsePageSize` panicked on any non-numeric `pageSize` query parameter (`?pageSize=abc` crashed the handler), accepted negative/zero values, and had no upper bound. This is client-triggerable with a single HTTP request.

Jira: https://formance-team.atlassian.net/browse/EN-1162

## Changes

No contract change — `ParsePageSize(r *http.Request) int` and `ReadPaginatedRequest` keep their original signatures, so downstream repos need no code changes.

- Invalid `pageSize` values (non-numeric, int32 overflow, zero, negative) no longer panic: a message is logged via the request-context logger (`logging.FromContext(r.Context())`) and the default page size (15) is returned. The logger interface has no warn level, so `Infof` is used.
- Values above the maximum are clamped to `MaxPageSize` (logged at debug level). `MaxPageSize` is a new exported constant in the `api` package, aliased to the existing `bunpaginate.MaxPageSize` (100) so both pagination helpers share the same limit.
- Absent/empty parameter still defaults to 15, valid values are unchanged.
- Updated the test that codified the panic (`utils_test.go`) and added regression tests: non-numeric, negative, zero, and int32-overflow values fall back to the default without panicking; above-max values are clamped; valid and boundary (100) values still work.

## Tests

- `go build ./...` passes
- `go test ./pkg/transport/...` passes