### PR TITLE
fix(observe): InMemoryExporter race on pooled ResourceMetrics (EN-1154)

### DIFF
--- a/pkg/observe/metrics/exporter_inmemory.go
+++ b/pkg/observe/metrics/exporter_inmemory.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sync"
 
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 type InMemoryExporter struct {
-	exp     sdkmetric.Exporter
+	exp sdkmetric.Exporter
+
+	mu      sync.RWMutex
 	metrics *metricdata.ResourceMetrics
 }
 
@@ -51,14 +54,25 @@ func (e *InMemoryExporter) Export(ctx context.Context, data *metricdata.Resource
 		return err
 	}
 
-	// notes(gfyrag): copy as indicate by interface sdkmetric.Exporter
-	// I don't know if that's enough...
-	e.metrics = &(*data)
+	// The SDK reader owns *data and recycles it (via a sync.Pool) once Export
+	// returns, so we must keep a deep copy of it.
+	snapshot := copyResourceMetrics(data)
 
-	return e.exp.Export(ctx, data)
+	e.mu.Lock()
+	e.metrics = snapshot
+	e.mu.Unlock()
+
+	if e.exp != nil {
+		return e.exp.Export(ctx, data)
+	}
+
+	return nil
 }
 
 func (e *InMemoryExporter) GetMetrics() *metricdata.ResourceMetrics {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
 	return e.metrics
 }
 

--- a/pkg/observe/metrics/exporter_inmemory_test.go
+++ b/pkg/observe/metrics/exporter_inmemory_test.go
@@ -1,0 +1,222 @@
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+func makeResourceMetrics(value int64) metricdata.ResourceMetrics {
+	now := time.Unix(1700000000, 0).UTC()
+	attrs := attribute.NewSet(attribute.String("host", "test"))
+
+	return metricdata.ResourceMetrics{
+		Resource: resource.NewSchemaless(attribute.String("service.name", "test")),
+		ScopeMetrics: []metricdata.ScopeMetrics{
+			{
+				Scope: instrumentation.Scope{Name: "test-scope"},
+				Metrics: []metricdata.Metrics{
+					{
+						Name: "gauge",
+						Data: metricdata.Gauge[int64]{
+							DataPoints: []metricdata.DataPoint[int64]{
+								{Attributes: attrs, Time: now, Value: value},
+							},
+						},
+					},
+					{
+						Name: "sum",
+						Data: metricdata.Sum[float64]{
+							Temporality: metricdata.CumulativeTemporality,
+							IsMonotonic: true,
+							DataPoints: []metricdata.DataPoint[float64]{
+								{
+									Attributes: attrs,
+									StartTime:  now,
+									Time:       now,
+									Value:      float64(value),
+									Exemplars: []metricdata.Exemplar[float64]{
+										{
+											FilteredAttributes: []attribute.KeyValue{attribute.String("k", "v")},
+											Time:               now,
+											Value:              float64(value),
+											SpanID:             []byte{1, 2, 3, 4, 5, 6, 7, 8},
+											TraceID:            []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "histogram",
+						Data: metricdata.Histogram[float64]{
+							Temporality: metricdata.CumulativeTemporality,
+							DataPoints: []metricdata.HistogramDataPoint[float64]{
+								{
+									Attributes:   attrs,
+									StartTime:    now,
+									Time:         now,
+									Count:        uint64(value),
+									Bounds:       []float64{1, 10, 100},
+									BucketCounts: []uint64{uint64(value), 0, 0, 0},
+									Min:          metricdata.NewExtrema(float64(value)),
+									Max:          metricdata.NewExtrema(float64(value)),
+									Sum:          float64(value),
+								},
+							},
+						},
+					},
+					{
+						Name: "exponential-histogram",
+						Data: metricdata.ExponentialHistogram[float64]{
+							Temporality: metricdata.CumulativeTemporality,
+							DataPoints: []metricdata.ExponentialHistogramDataPoint[float64]{
+								{
+									Attributes:     attrs,
+									StartTime:      now,
+									Time:           now,
+									Count:          uint64(value),
+									Sum:            float64(value),
+									Scale:          1,
+									ZeroCount:      0,
+									PositiveBucket: metricdata.ExponentialBucket{Offset: 0, Counts: []uint64{uint64(value)}},
+									NegativeBucket: metricdata.ExponentialBucket{Offset: 0, Counts: []uint64{0}},
+								},
+							},
+						},
+					},
+					{
+						Name: "summary",
+						Data: metricdata.Summary{
+							DataPoints: []metricdata.SummaryDataPoint{
+								{
+									Attributes: attrs,
+									StartTime:  now,
+									Time:       now,
+									Count:      uint64(value),
+									Sum:        float64(value),
+									QuantileValues: []metricdata.QuantileValue{
+										{Quantile: 0.5, Value: float64(value)},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// mutateResourceMetrics rewrites every slice-backed value reachable from rm
+// in place, mimicking the SDK reader recycling the struct for a new
+// collection.
+func mutateResourceMetrics(rm *metricdata.ResourceMetrics, value int64) {
+	for i := range rm.ScopeMetrics {
+		metrics := rm.ScopeMetrics[i].Metrics
+		for j := range metrics {
+			switch data := metrics[j].Data.(type) {
+			case metricdata.Gauge[int64]:
+				for k := range data.DataPoints {
+					data.DataPoints[k].Value = value
+				}
+			case metricdata.Sum[float64]:
+				for k := range data.DataPoints {
+					data.DataPoints[k].Value = float64(value)
+					for l := range data.DataPoints[k].Exemplars {
+						data.DataPoints[k].Exemplars[l].Value = float64(value)
+						data.DataPoints[k].Exemplars[l].FilteredAttributes[0] = attribute.Int64("k", value)
+						data.DataPoints[k].Exemplars[l].SpanID[0] = byte(value)
+						data.DataPoints[k].Exemplars[l].TraceID[0] = byte(value)
+					}
+				}
+			case metricdata.Histogram[float64]:
+				for k := range data.DataPoints {
+					data.DataPoints[k].Count = uint64(value)
+					data.DataPoints[k].Sum = float64(value)
+					data.DataPoints[k].Bounds[0] = float64(value)
+					data.DataPoints[k].BucketCounts[0] = uint64(value)
+				}
+			case metricdata.ExponentialHistogram[float64]:
+				for k := range data.DataPoints {
+					data.DataPoints[k].Count = uint64(value)
+					data.DataPoints[k].Sum = float64(value)
+					data.DataPoints[k].PositiveBucket.Counts[0] = uint64(value)
+					data.DataPoints[k].NegativeBucket.Counts[0] = uint64(value)
+				}
+			case metricdata.Summary:
+				for k := range data.DataPoints {
+					data.DataPoints[k].Count = uint64(value)
+					data.DataPoints[k].Sum = float64(value)
+					data.DataPoints[k].QuantileValues[0].Value = float64(value)
+				}
+			}
+		}
+	}
+}
+
+func TestInMemoryExporterDeepCopiesExportedData(t *testing.T) {
+	t.Parallel()
+
+	exporter := NewInMemoryExporterDecorator(nil)
+
+	exported := makeResourceMetrics(1)
+	require.NoError(t, exporter.Export(context.Background(), &exported))
+
+	// Mimic the SDK reader reusing the pooled struct for a new collection.
+	mutateResourceMetrics(&exported, 42)
+
+	got := exporter.GetMetrics()
+	require.NotNil(t, got)
+	require.NotSame(t, &exported, got)
+
+	want := makeResourceMetrics(1)
+	metricdatatest.AssertEqual(t, want, *got)
+}
+
+func TestInMemoryExporterConcurrentExportAndGetMetrics(t *testing.T) {
+	t.Parallel()
+
+	exporter := NewInMemoryExporterDecorator(nil)
+
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: reuses the same struct across Export calls, like the SDK
+	// PeriodicReader does with its sync.Pool.
+	go func() {
+		defer wg.Done()
+
+		pooled := makeResourceMetrics(0)
+		for i := range int64(iterations) {
+			mutateResourceMetrics(&pooled, i)
+			_ = exporter.Export(context.Background(), &pooled)
+		}
+	}()
+
+	// Reader: deeply walks whatever GetMetrics returns. Run with -race, this
+	// fails if the stored snapshot aliases memory still mutated by the writer.
+	go func() {
+		defer wg.Done()
+
+		for range iterations {
+			if metrics := exporter.GetMetrics(); metrics != nil {
+				_, _ = json.Marshal(metrics)
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/pkg/observe/metrics/metricdata_copy.go
+++ b/pkg/observe/metrics/metricdata_copy.go
@@ -1,0 +1,126 @@
+package metrics
+
+import (
+	"slices"
+
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// copyResourceMetrics returns a deep copy of rm.
+//
+// The OTel SDK readers (notably sdkmetric.PeriodicReader) pool the
+// *metricdata.ResourceMetrics passed to Exporter.Export and reuse it for
+// subsequent collections, so every slice reachable from it must be copied
+// before the data can be retained past the Export call.
+//
+// attribute.Set, *resource.Resource and instrumentation.Scope are immutable
+// once built and are safe to share.
+func copyResourceMetrics(rm *metricdata.ResourceMetrics) *metricdata.ResourceMetrics {
+	if rm == nil {
+		return nil
+	}
+
+	out := &metricdata.ResourceMetrics{
+		Resource:     rm.Resource,
+		ScopeMetrics: make([]metricdata.ScopeMetrics, len(rm.ScopeMetrics)),
+	}
+	for i, sm := range rm.ScopeMetrics {
+		out.ScopeMetrics[i] = metricdata.ScopeMetrics{
+			Scope:   sm.Scope,
+			Metrics: make([]metricdata.Metrics, len(sm.Metrics)),
+		}
+		for j, m := range sm.Metrics {
+			m.Data = copyAggregation(m.Data)
+			out.ScopeMetrics[i].Metrics[j] = m
+		}
+	}
+
+	return out
+}
+
+// copyAggregation deep copies any aggregation type the SDK can produce.
+// Unknown types are returned as-is.
+func copyAggregation(agg metricdata.Aggregation) metricdata.Aggregation {
+	switch data := agg.(type) {
+	case metricdata.Gauge[int64]:
+		data.DataPoints = copyDataPoints(data.DataPoints)
+		return data
+	case metricdata.Gauge[float64]:
+		data.DataPoints = copyDataPoints(data.DataPoints)
+		return data
+	case metricdata.Sum[int64]:
+		data.DataPoints = copyDataPoints(data.DataPoints)
+		return data
+	case metricdata.Sum[float64]:
+		data.DataPoints = copyDataPoints(data.DataPoints)
+		return data
+	case metricdata.Histogram[int64]:
+		data.DataPoints = copyHistogramDataPoints(data.DataPoints)
+		return data
+	case metricdata.Histogram[float64]:
+		data.DataPoints = copyHistogramDataPoints(data.DataPoints)
+		return data
+	case metricdata.ExponentialHistogram[int64]:
+		data.DataPoints = copyExponentialHistogramDataPoints(data.DataPoints)
+		return data
+	case metricdata.ExponentialHistogram[float64]:
+		data.DataPoints = copyExponentialHistogramDataPoints(data.DataPoints)
+		return data
+	case metricdata.Summary:
+		data.DataPoints = copySummaryDataPoints(data.DataPoints)
+		return data
+	default:
+		return agg
+	}
+}
+
+func copyDataPoints[N int64 | float64](dps []metricdata.DataPoint[N]) []metricdata.DataPoint[N] {
+	out := slices.Clone(dps)
+	for i := range out {
+		out[i].Exemplars = copyExemplars(out[i].Exemplars)
+	}
+
+	return out
+}
+
+func copyHistogramDataPoints[N int64 | float64](dps []metricdata.HistogramDataPoint[N]) []metricdata.HistogramDataPoint[N] {
+	out := slices.Clone(dps)
+	for i := range out {
+		out[i].Bounds = slices.Clone(out[i].Bounds)
+		out[i].BucketCounts = slices.Clone(out[i].BucketCounts)
+		out[i].Exemplars = copyExemplars(out[i].Exemplars)
+	}
+
+	return out
+}
+
+func copyExponentialHistogramDataPoints[N int64 | float64](dps []metricdata.ExponentialHistogramDataPoint[N]) []metricdata.ExponentialHistogramDataPoint[N] {
+	out := slices.Clone(dps)
+	for i := range out {
+		out[i].PositiveBucket.Counts = slices.Clone(out[i].PositiveBucket.Counts)
+		out[i].NegativeBucket.Counts = slices.Clone(out[i].NegativeBucket.Counts)
+		out[i].Exemplars = copyExemplars(out[i].Exemplars)
+	}
+
+	return out
+}
+
+func copySummaryDataPoints(dps []metricdata.SummaryDataPoint) []metricdata.SummaryDataPoint {
+	out := slices.Clone(dps)
+	for i := range out {
+		out[i].QuantileValues = slices.Clone(out[i].QuantileValues)
+	}
+
+	return out
+}
+
+func copyExemplars[N int64 | float64](exemplars []metricdata.Exemplar[N]) []metricdata.Exemplar[N] {
+	out := slices.Clone(exemplars)
+	for i := range out {
+		out[i].FilteredAttributes = slices.Clone(out[i].FilteredAttributes)
+		out[i].SpanID = slices.Clone(out[i].SpanID)
+		out[i].TraceID = slices.Clone(out[i].TraceID)
+	}
+
+	return out
+}


### PR DESCRIPTION
## Problem

`InMemoryExporter.Export` stored the `*metricdata.ResourceMetrics` it received as-is:

```go
// notes(gfyrag): copy as indicate by interface sdkmetric.Exporter
e.metrics = &(*data)
```

`&(*data)` copies nothing — it is equivalent to `e.metrics = data`. The OTel SDK's `sdkmetric.PeriodicReader` (v1.43.x) obtains that struct from a `sync.Pool` and recycles it right after `Export` returns, so:

- the stored pointer was overwritten in place by subsequent collections, and `GetMetrics()` (used by `NewInMemoryExporterHandler` and `pkg/testing/testservice`) served corrupted/torn data;
- `e.metrics` was written by the reader goroutine and read by HTTP handler goroutines with no synchronization (data race, confirmed by `-race`).

## Fix

- `Export` now stores a **deep copy** of the exported data (`metricdata_copy.go`), covering every aggregation type the SDK can produce — `Gauge`, `Sum`, `Histogram`, `ExponentialHistogram` (int64/float64) and `Summary` — including all slice-backed fields (data points, exemplars, bounds, bucket counts, quantile values, span/trace IDs). Immutable values (`attribute.Set`, `*resource.Resource`, `instrumentation.Scope`) are shared safely. The SDK exposes no public deep-copy helper, so the copy is implemented manually.
- A `sync.RWMutex` now protects `e.metrics` in both `Export` and `GetMetrics`.
- Removed the misleading comment.

## Tests

- `TestInMemoryExporterDeepCopiesExportedData`: exports a payload exercising all aggregation types, then mutates the original struct in place (mimicking pool reuse) and asserts `GetMetrics()` is unaffected.
- `TestInMemoryExporterConcurrentExportAndGetMetrics`: concurrent `Export`/`GetMetrics` with a reused (pooled-like) struct; fails under `-race` without the fix (verified by temporarily reverting the copy).

`go build ./...` and `go test -race ./pkg/observe/...` pass.

Jira: https://formance-team.atlassian.net/browse/EN-1154