### PR TITLE
[codex] Remediate go-libs backlog findings (EN-1136)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,7 @@ on:
     types: [ assigned, opened, synchronize, reopened, labeled ]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.14
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.24
 	github.com/aws/smithy-go v1.24.2
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/getkin/kin-openapi v0.134.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-jose/go-jose/v4 v4.1.4
@@ -81,6 +82,7 @@ require (
 	golang.org/x/oauth2 v0.35.0
 	golang.org/x/text v0.37.0
 	google.golang.org/grpc v1.80.0
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -126,7 +128,6 @@ require (
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-chi/render v1.0.3 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
@@ -226,6 +227,5 @@ require (
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/audit/httpaudit/middleware.go
+++ b/pkg/audit/httpaudit/middleware.go
@@ -28,7 +28,7 @@ type httpOptions struct {
 	handledHeaderSecret string
 }
 
-// WithSensitivePaths sets paths for which the response body should not be captured.
+// WithSensitivePaths sets path prefixes for which request and response bodies should not be captured.
 func WithSensitivePaths(paths ...string) HTTPOption {
 	return func(o *httpOptions) {
 		for _, p := range paths {
@@ -90,6 +90,8 @@ var bufPool = sync.Pool{
 	},
 }
 
+const maxCapturedBodyBytes = 64 * 1024
+
 // Middleware returns an HTTP middleware that captures request/response data
 // and publishes audit events via the given Watermill publisher.
 func Middleware(publisher message.Publisher, topicName string, appName string, opts []audit.Option, httpOpts ...HTTPOption) func(http.Handler) http.Handler {
@@ -150,40 +152,38 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				err  error
 			)
 
-			if !isStreamRequest(r) {
-				body, err = io.ReadAll(r.Body)
+			sensitivePath := ho.isSensitivePath(r.URL.Path)
+
+			if !isStreamRequest(r) && !sensitivePath {
+				body, err = captureRequestBody(r)
 				if err != nil && !errors.Is(err, io.EOF) {
 					http.Error(w, "failed to read request body", http.StatusInternalServerError)
 					return
 				}
-				if len(body) > 0 {
-					_ = r.Body.Close()
-					r.Body = io.NopCloser(bytes.NewBuffer(body))
-				}
 			}
 
-			requestHeaders := r.Header.Clone()
-			requestHeaders.Del("Authorization")
-			requestHeaders.Del(audit.HandledHeader)
+			requestHeaders := cloneHeaderWithout(r.Header, "Authorization", "Cookie", audit.HandledHeader)
 
 			r.Header.Set(audit.HandledHeader, handledHeaderValue)
 
 			buf := bufPool.Get().(*bytes.Buffer)
 			buf.Reset()
-			defer bufPool.Put(buf)
+			defer putCaptureBuffer(buf)
 
 			rww := &responseWriterWrapper{
 				ResponseWriter: w,
 				body:           buf,
 				statusCode:     http.StatusOK,
+				captureBody:    !sensitivePath,
 			}
 
 			next.ServeHTTP(rww, r)
 
-			responseBody := rww.body.String()
-			if _, sensitive := ho.sensitivePaths[r.URL.Path]; sensitive {
-				responseBody = ""
+			responseBody := ""
+			if !sensitivePath {
+				responseBody = rww.body.String()
 			}
+			responseHeaders := cloneHeaderWithout(rww.Header(), "Set-Cookie")
 
 			actor := audit.ExtractClaims(r, auditOpts)
 
@@ -206,7 +206,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 					},
 					Response: audit.HTTPResponse{
 						StatusCode: rww.statusCode,
-						Headers:    rww.Header(),
+						Headers:    responseHeaders,
 						Body:       responseBody,
 					},
 				},
@@ -217,6 +217,67 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 	}
 }
 
+func captureRequestBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxCapturedBodyBytes))
+	if len(body) > 0 {
+		r.Body = readCloser{
+			Reader: io.MultiReader(bytes.NewReader(body), r.Body),
+			Closer: r.Body,
+		}
+	}
+	return body, err
+}
+
+func putCaptureBuffer(buf *bytes.Buffer) {
+	if shouldPoolCaptureBuffer(buf) {
+		buf.Reset()
+		bufPool.Put(buf)
+	}
+}
+
+func shouldPoolCaptureBuffer(buf *bytes.Buffer) bool {
+	return buf.Cap() <= maxCapturedBodyBytes
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func cloneHeaderWithout(header http.Header, names ...string) http.Header {
+	clone := header.Clone()
+	for _, name := range names {
+		clone.Del(name)
+	}
+	return clone
+}
+
+func (o *httpOptions) isSensitivePath(requestPath string) bool {
+	for sensitivePath := range o.sensitivePaths {
+		if pathMatchesPrefix(requestPath, sensitivePath) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathMatchesPrefix(requestPath string, sensitivePath string) bool {
+	if sensitivePath == "" {
+		return false
+	}
+
+	sensitivePath = strings.TrimRight(sensitivePath, "/")
+	if sensitivePath == "" {
+		return strings.HasPrefix(requestPath, "/")
+	}
+
+	return requestPath == sensitivePath || strings.HasPrefix(requestPath, sensitivePath+"/")
+}
+
 func isStreamRequest(r *http.Request) bool {
 	ct := r.Header.Get("Content-Type")
 	return strings.HasPrefix(ct, "application/vnd.formance") && strings.HasSuffix(ct, "-stream")
@@ -224,14 +285,24 @@ func isStreamRequest(r *http.Request) bool {
 
 type responseWriterWrapper struct {
 	http.ResponseWriter
-	body       *bytes.Buffer
-	statusCode int
+	body        *bytes.Buffer
+	statusCode  int
+	captureBody bool
 }
 
 func (rww *responseWriterWrapper) Write(buf []byte) (int, error) {
-	mediaType, _, _ := mime.ParseMediaType(rww.Header().Get("Content-Type"))
-	if mediaType != "application/octet-stream" {
-		rww.body.Write(buf)
+	if rww.captureBody {
+		mediaType, _, _ := mime.ParseMediaType(rww.Header().Get("Content-Type"))
+		if mediaType != "application/octet-stream" {
+			remaining := maxCapturedBodyBytes - rww.body.Len()
+			if remaining > 0 {
+				captured := buf
+				if len(captured) > remaining {
+					captured = captured[:remaining]
+				}
+				rww.body.Write(captured)
+			}
+		}
 	}
 	return rww.ResponseWriter.Write(buf)
 }

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -127,6 +127,85 @@ func TestMiddleware_BasicCapture(t *testing.T) {
 	assert.Equal(t, `{"status":"ok"}`, payload.HTTP.Response.Body)
 }
 
+func TestMiddleware_CapsRequestBodyCaptureAndPassesFullBodyThrough(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	var receivedBody string
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			receivedBody = string(body)
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	capturedPrefix := strings.Repeat("a", maxCapturedBodyBytes)
+	reqBody := capturedPrefix + strings.Repeat("b", 1024)
+	req := httptest.NewRequest("POST", "/api/test", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, reqBody, receivedBody)
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	require.Len(t, payload.HTTP.Request.Body, maxCapturedBodyBytes)
+	assert.Equal(t, capturedPrefix, payload.HTTP.Request.Body)
+	assert.NotContains(t, payload.HTTP.Request.Body, "b")
+}
+
+func TestMiddleware_CapsResponseBodyCaptureAndWritesFullResponse(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	capturedPrefix := strings.Repeat("r", maxCapturedBodyBytes)
+	responseBody := capturedPrefix + strings.Repeat("s", 1024)
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(responseBody[:maxCapturedBodyBytes/2]))
+			_, _ = w.Write([]byte(responseBody[maxCapturedBodyBytes/2:]))
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, responseBody, rr.Body.String())
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	require.Len(t, payload.HTTP.Response.Body, maxCapturedBodyBytes)
+	assert.Equal(t, capturedPrefix, payload.HTTP.Response.Body)
+	assert.NotContains(t, payload.HTTP.Response.Body, "s")
+}
+
+func TestMiddleware_DoesNotPoolOversizedCaptureBuffers(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, shouldPoolCaptureBuffer(bytes.NewBuffer(make([]byte, 0, maxCapturedBodyBytes))))
+	assert.False(t, shouldPoolCaptureBuffer(bytes.NewBuffer(make([]byte, 0, maxCapturedBodyBytes+1))))
+}
+
 func TestMiddleware_AuthorizationHeaderStripped(t *testing.T) {
 	t.Parallel()
 
@@ -157,6 +236,51 @@ func TestMiddleware_AuthorizationHeaderStripped(t *testing.T) {
 	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
 
 	assert.Empty(t, payload.HTTP.Request.Header.Get("Authorization"))
+}
+
+func TestMiddleware_CookieHeadersStripped(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Response-ID", "response-id")
+			http.SetCookie(w, &http.Cookie{
+				Name:  "session",
+				Value: "response-secret",
+			})
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Cookie", "session=request-secret")
+	req.Header.Set("X-Request-ID", "request-id")
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Contains(t, rr.Header().Get("Set-Cookie"), "response-secret")
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(messages[0].Payload, &event))
+
+	payloadBytes, _ := json.Marshal(event.Payload)
+	var payload audit.Payload
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+
+	assert.Empty(t, payload.HTTP.Request.Header.Get("Cookie"))
+	assert.Equal(t, "request-id", payload.HTTP.Request.Header.Get("X-Request-ID"))
+	assert.Empty(t, payload.HTTP.Response.Headers.Get("Set-Cookie"))
+	assert.Equal(t, "response-id", payload.HTTP.Response.Headers.Get("X-Response-ID"))
+	assert.NotContains(t, string(messages[0].Payload), "request-secret")
+	assert.NotContains(t, string(messages[0].Payload), "response-secret")
 }
 
 func TestMiddleware_SensitivePaths(t *testing.T) {
@@ -193,7 +317,58 @@ func TestMiddleware_SensitivePaths(t *testing.T) {
 	var payload audit.Payload
 	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
 
+	assert.Empty(t, payload.HTTP.Request.Body)
 	assert.Empty(t, payload.HTTP.Response.Body)
+	assert.NotContains(t, string(messages[0].Payload), "client_credentials")
+	assert.NotContains(t, string(messages[0].Payload), "access_token")
+}
+
+func TestMiddleware_SensitivePathsMatchPrefixAndPassRequestBodyThrough(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	var receivedBody string
+	handler := Middleware(pub, topic, "test-app", nil,
+		WithEnabled(true),
+		WithSensitivePaths("/api/auth"),
+	)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			receivedBody = string(body)
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"access_token":"response-secret"}`))
+		}),
+	)
+
+	reqBody := `username=alice&password=request-secret`
+	req := httptest.NewRequest("POST", "/api/auth/oauth/token", strings.NewReader(reqBody))
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, reqBody, receivedBody)
+	require.Equal(t, `{"access_token":"response-secret"}`, rr.Body.String())
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(messages[0].Payload, &event))
+
+	payloadBytes, _ := json.Marshal(event.Payload)
+	var payload audit.Payload
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+
+	assert.Equal(t, "/api/auth/oauth/token", payload.HTTP.Request.Path)
+	assert.Empty(t, payload.HTTP.Request.Body)
+	assert.Empty(t, payload.HTTP.Response.Body)
+	assert.NotContains(t, string(messages[0].Payload), "request-secret")
+	assert.NotContains(t, string(messages[0].Payload), "response-secret")
 }
 
 func TestMiddleware_StreamRequestSkipsBodyCapture(t *testing.T) {
@@ -969,6 +1144,20 @@ func TestAsyncPublisher_CloseRespectsContextTimeout(t *testing.T) {
 
 	pub.release()
 	require.NoError(t, asyncPublisher.Close(context.Background()))
+}
+
+func auditPayloadFromMessage(t *testing.T, msg *message.Message) audit.Payload {
+	t.Helper()
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(msg.Payload, &event))
+
+	payloadBytes, err := json.Marshal(event.Payload)
+	require.NoError(t, err)
+
+	var payload audit.Payload
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+	return payload
 }
 
 func serveAuditRequest(t *testing.T, handler http.Handler) {

--- a/pkg/authn/jwt/auth.go
+++ b/pkg/authn/jwt/auth.go
@@ -83,13 +83,12 @@ func ClaimsFromRequest(r *http.Request, keySets map[string]oidc.KeySet) (*oidc.A
 		return nil, ErrNoAuthorizationHeader
 	}
 
-	if !strings.HasPrefix(authHeader, "bearer") &&
-		!strings.HasPrefix(authHeader, "Bearer") {
+	authParts := strings.Fields(authHeader)
+	if len(authParts) != 2 || !strings.EqualFold(authParts[0], "Bearer") {
 		return nil, ErrMalformedHeader
 	}
 
-	token := authHeader[6:]
-	token = strings.TrimSpace(token)
+	token := authParts[1]
 
 	claims := &oidc.AccessTokenClaims{}
 	decrypted, err := oidc.DecryptToken(token)
@@ -126,6 +125,10 @@ func ClaimsFromRequest(r *http.Request, keySets map[string]oidc.KeySet) (*oidc.A
 	}
 
 	if err := oidc.CheckExpiration(claims, 0); err != nil {
+		return claims, err
+	}
+
+	if err := oidc.CheckNotBefore(claims, 0); err != nil {
 		return claims, err
 	}
 

--- a/pkg/authn/jwt/auth_test.go
+++ b/pkg/authn/jwt/auth_test.go
@@ -61,6 +61,10 @@ func createAccessToken(t *testing.T, privateKey *rsa.PrivateKey, issuer string, 
 	// Set scopes
 	accessTokenClaims.Scopes = scopes
 
+	return signAccessTokenClaims(t, privateKey, accessTokenClaims)
+}
+
+func signAccessTokenClaims(t *testing.T, privateKey *rsa.PrivateKey, accessTokenClaims *oidc.AccessTokenClaims) string {
 	// Create JWT using go-jose
 	signer, err := jose.NewSigner(
 		jose.SigningKey{
@@ -200,6 +204,13 @@ func TestJWTAuth_Authenticate(t *testing.T) {
 	t.Run("failure with malformed authorization header", func(t *testing.T) {
 		t.Parallel()
 		keySet, _, issuer := setupTestKeySet(t)
+		headers := map[string]string{
+			"invalid scheme":       "Invalid token",
+			"bearer without gap":   "Bearertoken",
+			"bearer without token": "Bearer",
+			"bearer blank token":   "Bearer ",
+			"extra token segment":  "Bearer token extra",
+		}
 		tests := []struct {
 			name string
 			auth Authenticator
@@ -216,14 +227,18 @@ func TestJWTAuth_Authenticate(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				req := httptest.NewRequest("GET", "/test", nil)
-				req.Header.Set("Authorization", "Invalid token")
-				req = req.WithContext(logging.TestingContext())
+				for name, header := range headers {
+					t.Run(name, func(t *testing.T) {
+						req := httptest.NewRequest("GET", "/test", nil)
+						req.Header.Set("Authorization", header)
+						req = req.WithContext(logging.TestingContext())
 
-				authenticated, err := tt.auth.Authenticate(nil, req)
-				require.Error(t, err)
-				assert.False(t, authenticated)
-				assert.Contains(t, err.Error(), "malformed authorization header")
+						authenticated, err := tt.auth.Authenticate(nil, req)
+						require.Error(t, err)
+						assert.False(t, authenticated)
+						assert.Contains(t, err.Error(), "malformed authorization header")
+					})
+				}
 			})
 		}
 	})
@@ -314,6 +329,52 @@ func TestJWTAuth_Authenticate(t *testing.T) {
 
 				authenticated, err := tt.auth.Authenticate(nil, req)
 				require.Error(t, err)
+				assert.False(t, authenticated)
+			})
+		}
+	})
+
+	t.Run("failure with token before not-before time", func(t *testing.T) {
+		t.Parallel()
+		keySet, privateKey, issuer := setupTestKeySet(t)
+		tests := []struct {
+			name string
+			auth Authenticator
+		}{
+			{
+				name: "JWTAuth",
+				auth: NewJWTAuth(map[string]oidc.KeySet{issuer: keySet}, "test-service", false, nil),
+			},
+			{
+				name: "JWTAuth with additional checks",
+				auth: NewJWTAuth(map[string]oidc.KeySet{issuer: keySet}, "test-service", false, autoPassingAdditionalChecks),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				now := stdtime.Now().UTC()
+				expirationTime := libtime.New(now.Add(2 * stdtime.Hour))
+
+				accessTokenClaims := oidc.NewAccessTokenClaims(
+					issuer,
+					"test-user",
+					[]string{"test-client"},
+					expirationTime,
+					"test-jti",
+					"test-client",
+				)
+				accessTokenClaims.NotBefore = oidc.FromTime(libtime.New(now.Add(1 * stdtime.Hour)))
+
+				token := signAccessTokenClaims(t, privateKey, accessTokenClaims)
+
+				req := httptest.NewRequest("GET", "/test", nil)
+				req.Header.Set("Authorization", "Bearer "+token)
+				req = req.WithContext(logging.TestingContext())
+
+				authenticated, err := tt.auth.Authenticate(nil, req)
+				require.Error(t, err)
+				assert.ErrorIs(t, err, oidc.ErrNotBefore)
 				assert.False(t, authenticated)
 			})
 		}

--- a/pkg/authn/jwt/module_test.go
+++ b/pkg/authn/jwt/module_test.go
@@ -30,10 +30,11 @@ func setupTestOIDCServer(t *testing.T) (*httptest.Server, string, chan bool) {
 	// Discovery endpoint
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		discoveryCalled <- true
+		issuer := "http://" + r.Host
 
 		config := oidc.DiscoveryConfiguration{
-			Issuer:  r.URL.Scheme + "://" + r.Host,
-			JwksURI: r.URL.Scheme + "://" + r.Host + "/.well-known/jwks.json",
+			Issuer:  issuer,
+			JwksURI: issuer + "/.well-known/jwks.json",
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/authn/licence/jwt.go
+++ b/pkg/authn/licence/jwt.go
@@ -93,6 +93,10 @@ func ValidateToken(jwtToken string, expectedIssuer string, opts ...ValidateToken
 }
 
 func (l *Licence) validate() error {
+	if l.validateToken != nil {
+		return l.validateToken()
+	}
+
 	return ValidateToken(
 		l.jwtToken,
 		l.expectedIssuer,

--- a/pkg/authn/licence/licence.go
+++ b/pkg/authn/licence/licence.go
@@ -1,6 +1,7 @@
 package licence
 
 import (
+	"sync"
 	"time"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -12,6 +13,9 @@ type Licence struct {
 	jwtToken            string
 	licenceValidateTick time.Duration
 	appStoped           chan struct{}
+	stopOnce            sync.Once
+	wg                  sync.WaitGroup
+	validateToken       func() error
 
 	// Will be checked in claims (aud claim)
 	serviceName string
@@ -42,6 +46,7 @@ func NewLicence(
 
 func (l *Licence) run(licenceError chan error) {
 	ticker := time.NewTicker(l.licenceValidateTick)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -72,11 +77,20 @@ func (l *Licence) Start(licenceError chan error) error {
 	}
 	l.logger.Info("Licence check passed")
 
-	go l.run(licenceError)
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		l.run(licenceError)
+	}()
 
 	return nil
 }
 
 func (l *Licence) Stop() {
-	close(l.appStoped)
+	l.stopOnce.Do(func() {
+		if l.appStoped != nil {
+			close(l.appStoped)
+		}
+	})
+	l.wg.Wait()
 }

--- a/pkg/authn/licence/licence_test.go
+++ b/pkg/authn/licence/licence_test.go
@@ -6,9 +6,11 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -205,6 +207,94 @@ func TestLicence_Start(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		require.Equal(t, "Licence check stopped, app stopped", logger.getMessage())
 	})
+}
+
+func TestLicence_StopIsIdempotent(t *testing.T) {
+	privateKey, pubPEM := generateTestRSAKeyPair(t)
+	setEmbeddedKey(t, pubPEM)
+
+	logger := &mockLogger{}
+	claims := jwt.MapClaims{
+		"sub": "test-cluster",
+		"aud": "test-service",
+		"iss": "test-issuer",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	tokenString := createTokenWithRSAKey(t, claims, privateKey)
+
+	licence := NewLicence(
+		logger,
+		tokenString,
+		time.Minute,
+		"test-service",
+		"test-cluster",
+		"test-issuer",
+	)
+
+	licenceError := make(chan error, 1)
+	require.NoError(t, licence.Start(licenceError))
+	require.NotPanics(t, func() {
+		licence.Stop()
+		licence.Stop()
+	})
+}
+
+func TestLicence_StopWaitsForInFlightValidationBeforeChannelClose(t *testing.T) {
+	logger := &mockLogger{}
+	licence := NewLicence(
+		logger,
+		"unused-token",
+		10*time.Millisecond,
+		"test-service",
+		"test-cluster",
+		"test-issuer",
+	)
+
+	validateStarted := make(chan struct{})
+	releaseValidate := make(chan struct{})
+	var validateCalls atomic.Int32
+	licence.validateToken = func() error {
+		if validateCalls.Add(1) == 1 {
+			return nil
+		}
+
+		close(validateStarted)
+		<-releaseValidate
+		return errors.New("licence validation failed")
+	}
+
+	licenceError := make(chan error, 1)
+	require.NoError(t, licence.Start(licenceError))
+
+	select {
+	case <-validateStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for licence validation to start")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		licence.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned before in-flight validation completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseValidate)
+
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Stop to return")
+	}
+
+	close(licenceError)
+	err := <-licenceError
+	require.EqualError(t, err, "licence validation failed")
 }
 
 func TestValidateToken(t *testing.T) {

--- a/pkg/authn/oidc/client/discover.go
+++ b/pkg/authn/oidc/client/discover.go
@@ -3,12 +3,17 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
 	httphelper "github.com/formancehq/go-libs/v5/pkg/authn/oidc/http"
 )
+
+type issuerGetter interface {
+	GetIssuer() string
+}
 
 // Discover calls the discovery endpoint of the provided issuer and returns its configuration
 // It accepts an optional argument "wellknownUrl" which can be used to override the discovery endpoint url
@@ -27,6 +32,21 @@ func Discover[V any](ctx context.Context, issuer string, httpClient *http.Client
 	if err != nil {
 		return nil, errors.Join(oidc.ErrDiscoveryFailed, err)
 	}
+	if err := validateDiscoveredIssuer(issuer, discoveryConfig); err != nil {
+		return nil, errors.Join(oidc.ErrDiscoveryFailed, err)
+	}
 
 	return discoveryConfig, nil
+}
+
+func validateDiscoveredIssuer[V any](issuer string, discoveryConfig *V) error {
+	issuerConfig, ok := any(discoveryConfig).(issuerGetter)
+	if !ok {
+		return nil
+	}
+	discoveredIssuer := issuerConfig.GetIssuer()
+	if discoveredIssuer != issuer {
+		return fmt.Errorf("%w: Expected: %s, got: %s", oidc.ErrIssuerInvalid, issuer, discoveredIssuer)
+	}
+	return nil
 }

--- a/pkg/authn/oidc/client/discover_test.go
+++ b/pkg/authn/oidc/client/discover_test.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
+)
+
+func TestDiscoverValidatesIssuer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns discovery configuration when issuer matches", func(t *testing.T) {
+		t.Parallel()
+
+		issuer := "https://issuer.example.com"
+		server := httptest.NewServer(discoveryHandler(t, issuer))
+		t.Cleanup(server.Close)
+
+		discoveryConfig, err := Discover[oidc.DiscoveryConfiguration](
+			context.Background(),
+			issuer,
+			server.Client(),
+			server.URL,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, issuer, discoveryConfig.Issuer)
+	})
+
+	t.Run("rejects discovery configuration when issuer differs", func(t *testing.T) {
+		t.Parallel()
+
+		issuer := "https://issuer.example.com"
+		discoveredIssuer := "https://other-issuer.example.com"
+		server := httptest.NewServer(discoveryHandler(t, discoveredIssuer))
+		t.Cleanup(server.Close)
+
+		discoveryConfig, err := Discover[oidc.DiscoveryConfiguration](
+			context.Background(),
+			issuer,
+			server.Client(),
+			server.URL,
+		)
+
+		require.Nil(t, discoveryConfig)
+		require.ErrorIs(t, err, oidc.ErrDiscoveryFailed)
+		require.ErrorIs(t, err, oidc.ErrIssuerInvalid)
+		require.ErrorContains(t, err, "Expected: "+issuer+", got: "+discoveredIssuer)
+	})
+}
+
+func discoveryHandler(t *testing.T, issuer string) http.Handler {
+	t.Helper()
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(oidc.DiscoveryConfiguration{
+			Issuer:  issuer,
+			JwksURI: issuer + "/.well-known/jwks.json",
+		})
+		require.NoError(t, err)
+	})
+}

--- a/pkg/authn/oidc/discovery.go
+++ b/pkg/authn/oidc/discovery.go
@@ -162,6 +162,13 @@ type DiscoveryConfiguration struct {
 	BackChannelLogoutSessionSupported bool `json:"backchannel_logout_session_supported,omitempty"`
 }
 
+func (d *DiscoveryConfiguration) GetIssuer() string {
+	if d == nil {
+		return ""
+	}
+	return d.Issuer
+}
+
 type AuthMethod string
 
 const (

--- a/pkg/authn/oidc/http/marshal.go
+++ b/pkg/authn/oidc/http/marshal.go
@@ -14,7 +14,8 @@ func MarshalJSON(w http.ResponseWriter, i any) {
 
 func MarshalJSONWithStatus(w http.ResponseWriter, i any, status int) {
 	w.Header().Set("content-type", "application/json")
-	if i == nil || (reflect.ValueOf(i).Kind() == reflect.Ptr && reflect.ValueOf(i).IsNil()) {
+	if isNilJSONValue(i) {
+		w.WriteHeader(status)
 		return
 	}
 	data, err := json.Marshal(i)
@@ -25,6 +26,19 @@ func MarshalJSONWithStatus(w http.ResponseWriter, i any, status int) {
 
 	w.WriteHeader(status)
 	_, _ = w.Write(data)
+}
+
+func isNilJSONValue(i any) bool {
+	if i == nil {
+		return true
+	}
+	value := reflect.ValueOf(i)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 func ConcatenateJSON(first, second []byte) ([]byte, error) {

--- a/pkg/authn/oidc/http/marshal_test.go
+++ b/pkg/authn/oidc/http/marshal_test.go
@@ -1,0 +1,35 @@
+package http
+
+import (
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalJSONWithStatusWritesStatusForNilBody(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+
+	MarshalJSONWithStatus(recorder, nil, stdhttp.StatusNoContent)
+
+	require.Equal(t, stdhttp.StatusNoContent, recorder.Code)
+	require.Empty(t, recorder.Body.String())
+	require.Equal(t, "application/json", recorder.Header().Get("content-type"))
+}
+
+func TestMarshalJSONWithStatusWritesStatusForTypedNilBody(t *testing.T) {
+	t.Parallel()
+
+	var body *struct {
+		ID string `json:"id"`
+	}
+	recorder := httptest.NewRecorder()
+
+	MarshalJSONWithStatus(recorder, body, stdhttp.StatusAccepted)
+
+	require.Equal(t, stdhttp.StatusAccepted, recorder.Code)
+	require.Empty(t, recorder.Body.String())
+}

--- a/pkg/authn/oidc/token.go
+++ b/pkg/authn/oidc/token.go
@@ -68,6 +68,10 @@ func (c *TokenClaims) GetIssuedAt() time.Time {
 	return c.IssuedAt.AsTime()
 }
 
+func (c *TokenClaims) GetNotBefore() time.Time {
+	return c.NotBefore.AsTime()
+}
+
 func (c *TokenClaims) GetNonce() string {
 	return c.Nonce
 }

--- a/pkg/authn/oidc/verifier.go
+++ b/pkg/authn/oidc/verifier.go
@@ -27,6 +27,10 @@ type Claims interface {
 	GetAuthorizedParty() string
 }
 
+type NotBeforeClaims interface {
+	GetNotBefore() time.Time
+}
+
 type IDClaims interface {
 	Claims
 	GetAccessTokenHash() string
@@ -46,6 +50,7 @@ var (
 	ErrSignatureInvalidPayload = errors.New("signature does not match Payload")
 	ErrSignatureInvalid        = errors.New("invalid signature")
 	ErrExpired                 = errors.New("token has expired")
+	ErrNotBefore               = errors.New("token is not valid yet")
 	ErrIatMissing              = errors.New("issuedAt of token is missing")
 	ErrIatInFuture             = errors.New("issuedAt of token is in the future")
 	ErrIatToOld                = errors.New("issuedAt of token is to old")
@@ -191,6 +196,18 @@ func CheckExpiration(claims Claims, offset time.Duration) error {
 	expiration := claims.GetExpiration()
 	if !time.Now().Add(offset).Before(expiration) {
 		return ErrExpired
+	}
+	return nil
+}
+
+func CheckNotBefore(claims NotBeforeClaims, offset time.Duration) error {
+	notBefore := claims.GetNotBefore()
+	if notBefore.IsZero() {
+		return nil
+	}
+	nowWithOffset := time.Now().Add(offset).Round(time.Second)
+	if nowWithOffset.Before(notBefore) {
+		return fmt.Errorf("%w: (nbf: %v, now with offset: %v)", ErrNotBefore, notBefore, nowWithOffset)
 	}
 	return nil
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -15,7 +15,7 @@ func (e ErrorWithExitCode) Unwrap() error {
 }
 
 func (e ErrorWithExitCode) Error() string {
-	return fmt.Sprintf("error with exit code '%v': %d", e.Err, e.ExitCode)
+	return fmt.Sprintf("error with exit code '%d': %v", e.ExitCode, e.Err)
 }
 
 func (e ErrorWithExitCode) Is(err error) bool {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -59,14 +59,14 @@ func TestErrorWithExitCode(t *testing.T) {
 		errWithCode := errorsutils.NewErrorWithExitCode(originalErr, exitCode)
 		errorMsg := errWithCode.Error()
 
-		expectedMsg := fmt.Sprintf("error with exit code '%v': %d", originalErr, exitCode)
+		expectedMsg := fmt.Sprintf("error with exit code '%d': %v", exitCode, originalErr)
 		require.Equal(t, expectedMsg, errorMsg)
 
 		// Test with nil error
 		nilErr := errorsutils.NewErrorWithExitCode(nil, exitCode)
 		nilErrorMsg := nilErr.Error()
 
-		expectedNilMsg := fmt.Sprintf("error with exit code '%v': %d", nil, exitCode)
+		expectedNilMsg := fmt.Sprintf("error with exit code '%d': %v", exitCode, nil)
 		require.Equal(t, expectedNilMsg, nilErrorMsg)
 	})
 

--- a/pkg/fx/observefx/metrics.go
+++ b/pkg/fx/observefx/metrics.go
@@ -62,35 +62,38 @@ func MetricsModule(cfg metrics.ModuleConfig) fx.Option {
 
 			return ret
 		}, fx.ParamTags(metricsProviderOptionKey))),
-		fx.Invoke(func(lc fx.Lifecycle, metricProvider *sdkmetric.MeterProvider, options ...runtime.Option) {
-			otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-				b3.New(), propagation.TraceContext{}))
-			lc.Append(fx.Hook{
-				OnStart: func(ctx context.Context) error {
-					if cfg.RuntimeMetrics {
-						if err := runtime.Start(options...); err != nil {
-							return err
+		fx.Invoke(fx.Annotate(
+			func(lc fx.Lifecycle, metricProvider *sdkmetric.MeterProvider, options ...runtime.Option) {
+				otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+					b3.New(), propagation.TraceContext{}))
+				lc.Append(fx.Hook{
+					OnStart: func(ctx context.Context) error {
+						if cfg.RuntimeMetrics {
+							if err := runtime.Start(options...); err != nil {
+								return err
+							}
+							if err := host.Start(); err != nil {
+								return err
+							}
 						}
-						if err := host.Start(); err != nil {
-							return err
+						return nil
+					},
+					OnStop: func(ctx context.Context) error {
+						logging.FromContext(ctx).Infof("Flush metrics")
+						if err := metricProvider.ForceFlush(ctx); err != nil {
+							logging.FromContext(ctx).Errorf("unable to flush metrics: %s", err)
 						}
-					}
-					return nil
-				},
-				OnStop: func(ctx context.Context) error {
-					logging.FromContext(ctx).Infof("Flush metrics")
-					if err := metricProvider.ForceFlush(ctx); err != nil {
-						logging.FromContext(ctx).Errorf("unable to flush metrics: %s", err)
-					}
-					logging.FromContext(ctx).Infof("Shutting down metrics provider")
-					if err := metricProvider.Shutdown(ctx); err != nil {
-						logging.FromContext(ctx).Errorf("unable to shutdown metrics provider: %s", err)
-					}
-					logging.FromContext(ctx).Infof("Metrics provider stopped")
-					return nil
-				},
-			})
-		}),
+						logging.FromContext(ctx).Infof("Shutting down metrics provider")
+						if err := metricProvider.Shutdown(ctx); err != nil {
+							logging.FromContext(ctx).Errorf("unable to shutdown metrics provider: %s", err)
+						}
+						logging.FromContext(ctx).Infof("Metrics provider stopped")
+						return nil
+					},
+				})
+			},
+			fx.ParamTags(``, ``, metricsRuntimeOptionKey),
+		)),
 		ProvideMetricsProviderOption(sdkmetric.WithResource),
 		ProvideMetricsProviderOption(sdkmetric.WithReader),
 		fx.Provide(

--- a/pkg/fx/observefx/metrics_test.go
+++ b/pkg/fx/observefx/metrics_test.go
@@ -1,0 +1,38 @@
+package observefx_test
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/contrib/instrumentation/runtime"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"github.com/formancehq/go-libs/v5/pkg/fx/observefx"
+	"github.com/formancehq/go-libs/v5/pkg/observe"
+	"github.com/formancehq/go-libs/v5/pkg/observe/metrics"
+)
+
+func TestMetricsModuleProvidesRuntimeOptionsToRuntimeMetricsInvoke(t *testing.T) {
+	var runtimeOptionProvided atomic.Bool
+
+	app := fxtest.New(t,
+		observefx.ResourceModule(observe.Config{
+			ServiceName: "metrics-test",
+		}),
+		observefx.MetricsModule(metrics.ModuleConfig{
+			MinimumReadMemStatsInterval: time.Second,
+		}),
+		observefx.ProvideRuntimeMetricsOption(func() runtime.Option {
+			runtimeOptionProvided.Store(true)
+			return runtime.WithMinimumReadMemStatsInterval(100 * time.Millisecond)
+		}),
+		fx.NopLogger,
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	require.True(t, runtimeOptionProvided.Load())
+}

--- a/pkg/fx/workflowfx/temporal.go
+++ b/pkg/fx/workflowfx/temporal.go
@@ -2,6 +2,7 @@ package workflowfx
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel/metric"
@@ -66,25 +67,34 @@ func TemporalWorkerModule(ctx context.Context, taskQueue string, options worker.
 			}, fx.ParamTags(``, ``, `group:"workflows"`, `group:"activities"`)),
 		),
 		fx.Invoke(func(lc fx.Lifecycle, w worker.Worker) {
-			willStop := false
-			lc.Append(fx.Hook{
-				OnStart: func(ctx context.Context) error {
-					go func() {
-						err := w.Run(worker.InterruptCh())
-						if err != nil {
-							if !willStop {
-								panic(err)
-							}
-						}
-					}()
-					return nil
-				},
-				OnStop: func(ctx context.Context) error {
-					willStop = true
-					w.Stop()
-					return nil
-				},
-			})
+			registerTemporalWorkerLifecycle(lc, w)
 		}),
 	)
+}
+
+type temporalWorkerRunner interface {
+	Run(interruptCh <-chan interface{}) error
+	Stop()
+}
+
+func registerTemporalWorkerLifecycle(lc fx.Lifecycle, w temporalWorkerRunner) {
+	var willStop atomic.Bool
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			go func() {
+				err := w.Run(worker.InterruptCh())
+				if err != nil {
+					if !willStop.Load() {
+						panic(err)
+					}
+				}
+			}()
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			willStop.Store(true)
+			w.Stop()
+			return nil
+		},
+	})
 }

--- a/pkg/fx/workflowfx/temporal_test.go
+++ b/pkg/fx/workflowfx/temporal_test.go
@@ -1,0 +1,68 @@
+package workflowfx
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/fx"
+)
+
+func TestRegisterTemporalWorkerLifecycleIsRaceSafeWhenRunReturnsDuringStop(t *testing.T) {
+	lc := &lifecycleRecorder{}
+	w := &shutdownErrorWorker{
+		runErr:      errors.New("worker stopped"),
+		runReturned: make(chan struct{}),
+	}
+
+	registerTemporalWorkerLifecycle(lc, w)
+
+	if len(lc.hooks) != 1 {
+		t.Fatalf("expected 1 lifecycle hook, got %d", len(lc.hooks))
+	}
+
+	hook := lc.hooks[0]
+	if hook.OnStart == nil {
+		t.Fatal("expected OnStart hook")
+	}
+	if hook.OnStop == nil {
+		t.Fatal("expected OnStop hook")
+	}
+
+	if err := hook.OnStart(context.Background()); err != nil {
+		t.Fatalf("OnStart returned error: %v", err)
+	}
+	if err := hook.OnStop(context.Background()); err != nil {
+		t.Fatalf("OnStop returned error: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+}
+
+type lifecycleRecorder struct {
+	hooks []fx.Hook
+}
+
+func (lc *lifecycleRecorder) Append(hook fx.Hook) {
+	lc.hooks = append(lc.hooks, hook)
+}
+
+type shutdownErrorWorker struct {
+	runErr      error
+	runReturned chan struct{}
+}
+
+func (w *shutdownErrorWorker) Run(<-chan interface{}) error {
+	time.Sleep(10 * time.Millisecond)
+	close(w.runReturned)
+	return w.runErr
+}
+
+func (w *shutdownErrorWorker) Stop() {
+	select {
+	case <-w.runReturned:
+	case <-time.After(time.Second):
+		panic("worker Run did not return")
+	}
+}

--- a/pkg/messaging/publish/circuit/circuit_breaker.go
+++ b/pkg/messaging/publish/circuit/circuit_breaker.go
@@ -37,13 +37,23 @@ type CircuitBreaker struct {
 	stateMu sync.RWMutex
 	state   State
 
+	stopOnce sync.Once
+	doneOnce sync.Once
+
+	publisherCloseOnce sync.Once
+	publisherCloseErr  error
+
+	loopMu      sync.Mutex
+	loopCancel  context.CancelFunc
+	loopStarted bool
+
 	// openInterval is the time interval for the "open" state, before switching
 	// to the "half-open" state.
 	openInterval      time.Duration
 	openIntervalTimer *time.Timer
 
 	sendChan    chan *internalMessage
-	stopChannel chan chan struct{}
+	stopChannel chan struct{}
 	stopped     chan struct{}
 }
 
@@ -61,7 +71,7 @@ func NewCircuitBreaker(
 	openIntervalDuration time.Duration,
 ) *CircuitBreaker {
 	return &CircuitBreaker{
-		stopChannel: make(chan chan struct{}),
+		stopChannel: make(chan struct{}),
 		stopped:     make(chan struct{}),
 		logger:      logger,
 		publisher:   publisher,
@@ -109,10 +119,31 @@ func (cb *CircuitBreaker) CloseState() {
 }
 
 func (cb *CircuitBreaker) Loop(ctx context.Context) {
-	defer close(cb.stopped)
+	ctx, cancel := context.WithCancel(ctx)
+	if !cb.startLoop(cancel) {
+		cancel()
+		return
+	}
+	defer func() {
+		cb.clearLoopCancel()
+		cancel()
+		cb.markStopped()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-cb.stopChannel:
+		return
+	default:
+	}
+
 	// Start in the half open state to fetch the messages from the database
 	cb.HalfOpenState()
 	if err := cb.catchUpDatabase(ctx); err != nil {
+		if ctx.Err() != nil {
+			return
+		}
 		cb.OpenState()
 		// Don't switch to closed state if there was an error
 	} else {
@@ -122,9 +153,10 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 	for {
 		select {
-		case ch := <-cb.stopChannel:
-			close(ch)
-			// context cancelled
+		case <-ctx.Done():
+			return
+
+		case <-cb.stopChannel:
 			return
 
 		case <-cb.openIntervalTimer.C:
@@ -133,6 +165,9 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 			cb.HalfOpenState()
 
 			if err := cb.catchUpDatabase(ctx); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
 				cb.OpenState()
 				continue
 			}
@@ -146,7 +181,7 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 				return
 			}
 
-			switch cb.state {
+			switch cb.GetState() {
 			case StateClose:
 				// We are in the closed state, send the message to the publisher
 
@@ -162,8 +197,9 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 					if err != nil {
 						select {
 						case msg.errChan <- err:
-						case ch := <-cb.stopChannel:
-							close(ch)
+						case <-ctx.Done():
+							return
+						case <-cb.stopChannel:
 							return
 						}
 						continue
@@ -177,8 +213,9 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 				if err != nil {
 					select {
 					case msg.errChan <- err:
-					case ch := <-cb.stopChannel:
-						close(ch)
+					case <-ctx.Done():
+						return
+					case <-cb.stopChannel:
 						return
 					}
 					continue
@@ -187,8 +224,9 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 			select {
 			case msg.errChan <- nil:
-			case ch := <-cb.stopChannel:
-				close(ch)
+			case <-ctx.Done():
+				return
+			case <-cb.stopChannel:
 				return
 			}
 		}
@@ -197,6 +235,10 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		// fetch the oldest messages from the database
 		messages, err := cb.store.List(ctx)
 		if err != nil {
@@ -211,6 +253,10 @@ func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 		messagesToDelete := make([]uint64, 0)
 		var publishError error
 		for _, msg := range messages {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
 			// We need to publish the messages one by one in order to know
 			// which one failed.
 
@@ -229,6 +275,10 @@ func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 			messagesToDelete = append(messagesToDelete, msg.ID)
 		}
 
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		err = cb.store.Delete(ctx, messagesToDelete)
 		if err != nil {
 			// error deleting messages, let's switch back to the open state
@@ -244,6 +294,12 @@ func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 
 func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) error {
 	for _, msg := range messages {
+		select {
+		case <-cb.stopChannel:
+			return errors.New("circuit breaker closed")
+		default:
+		}
+
 		errChan := make(chan error, 1)
 
 		internalMessage := &internalMessage{
@@ -254,6 +310,8 @@ func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) er
 
 		select {
 		case cb.sendChan <- internalMessage:
+		case <-cb.stopChannel:
+			return errors.New("circuit breaker closed")
 		case <-cb.stopped:
 			return errors.New("circuit breaker closed")
 		}
@@ -263,6 +321,8 @@ func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) er
 			if err != nil {
 				return err
 			}
+		case <-cb.stopChannel:
+			return errors.New("circuit breaker closed")
 		case <-cb.stopped:
 			return errors.New("circuit breaker closed")
 		}
@@ -272,11 +332,63 @@ func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) er
 }
 
 func (cb *CircuitBreaker) Close() error {
-	ch := make(chan struct{})
-	cb.stopChannel <- ch
-	<-ch
+	cb.stopOnce.Do(func() {
+		close(cb.stopChannel)
+		cb.cancelLoop()
+	})
 
-	return cb.publisher.Close()
+	if cb.hasLoopStarted() {
+		<-cb.stopped
+	} else {
+		cb.markStopped()
+	}
+
+	cb.publisherCloseOnce.Do(func() {
+		cb.publisherCloseErr = cb.publisher.Close()
+	})
+
+	return cb.publisherCloseErr
+}
+
+func (cb *CircuitBreaker) startLoop(cancel context.CancelFunc) bool {
+	cb.loopMu.Lock()
+	defer cb.loopMu.Unlock()
+
+	if cb.loopStarted {
+		return false
+	}
+
+	cb.loopStarted = true
+	cb.loopCancel = cancel
+	return true
+}
+
+func (cb *CircuitBreaker) clearLoopCancel() {
+	cb.loopMu.Lock()
+	cb.loopCancel = nil
+	cb.loopMu.Unlock()
+}
+
+func (cb *CircuitBreaker) cancelLoop() {
+	cb.loopMu.Lock()
+	cancel := cb.loopCancel
+	cb.loopMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (cb *CircuitBreaker) hasLoopStarted() bool {
+	cb.loopMu.Lock()
+	defer cb.loopMu.Unlock()
+	return cb.loopStarted
+}
+
+func (cb *CircuitBreaker) markStopped() {
+	cb.doneOnce.Do(func() {
+		close(cb.stopped)
+	})
 }
 
 const (
@@ -297,7 +409,7 @@ func newMessage(ctx context.Context, data []byte, metadata map[string]string) (*
 		if err != nil {
 			return nil, err
 		}
-		otel.GetTextMapPropagator().Inject(ctx, carrier)
+		ctx = otel.GetTextMapPropagator().Extract(ctx, carrier)
 	}
 
 	msg.SetContext(ctx)

--- a/pkg/messaging/publish/circuit/circuit_breaker_test.go
+++ b/pkg/messaging/publish/circuit/circuit_breaker_test.go
@@ -11,7 +11,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish/circuit/storage"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
@@ -429,4 +433,140 @@ func TestCircuitBreaker(t *testing.T) {
 			assert.Equal(c, StateOpen, circuitBreaker.GetState())
 		}, 2*time.Second, 100*time.Millisecond)
 	})
+}
+
+func TestCircuitBreakerCloseWithoutLoopIsIdempotent(t *testing.T) {
+	messages := make(chan *testMessages, 10)
+	publisher := newMockPublisher(messages)
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		publisher,
+		newMockStore(),
+		5*time.Second,
+	)
+
+	requireCloseWithin(t, circuitBreaker)
+	requireCloseWithin(t, circuitBreaker)
+	require.Equal(t, 1, publisher.CloseCount())
+}
+
+func TestCircuitBreakerCloseCancelsCatchUp(t *testing.T) {
+	store := &blockingListStore{
+		listStarted: make(chan struct{}, 1),
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(make(chan *testMessages, 10)),
+		store,
+		5*time.Second,
+	)
+
+	go circuitBreaker.Loop(context.Background())
+
+	select {
+	case <-store.listStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected catchup to start")
+	}
+
+	requireCloseWithin(t, circuitBreaker)
+}
+
+func TestCircuitBreakerLoopStopsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(make(chan *testMessages, 10)),
+		newMockStore(),
+		5*time.Second,
+	)
+
+	go circuitBreaker.Loop(ctx)
+	require.Eventually(t, circuitBreaker.hasLoopStarted, time.Second, 10*time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-circuitBreaker.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("expected loop to stop after context cancellation")
+	}
+
+	require.NoError(t, circuitBreaker.Close())
+}
+
+func TestCircuitBreakerCatchUpExtractsStoredTraceContext(t *testing.T) {
+	originalPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTextMapPropagator(originalPropagator)
+	})
+
+	messages := make(chan *testMessages, 10)
+	store := newMockStore()
+	require.NoError(t, store.Insert(context.Background(), "test", []byte("test"), map[string]string{
+		otelContextKey: `{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`,
+	}))
+
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(messages),
+		store,
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+	defer func() {
+		require.NoError(t, circuitBreaker.Close())
+	}()
+
+	var received *testMessages
+	select {
+	case received = <-messages:
+	case <-time.After(time.Second):
+		t.Fatal("expected replayed message")
+	}
+
+	spanContext := trace.SpanContextFromContext(received.msg.Context())
+	require.True(t, spanContext.IsValid())
+	require.True(t, spanContext.IsRemote())
+	require.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", spanContext.TraceID().String())
+	require.Equal(t, "00f067aa0ba902b7", spanContext.SpanID().String())
+}
+
+func requireCloseWithin(t *testing.T, circuitBreaker *CircuitBreaker) {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected circuit breaker close to return")
+	}
+}
+
+type blockingListStore struct {
+	listStarted chan struct{}
+}
+
+func (s *blockingListStore) Insert(ctx context.Context, topic string, data []byte, metadata map[string]string) error {
+	return nil
+}
+
+func (s *blockingListStore) List(ctx context.Context) ([]*storage.CircuitBreakerModel, error) {
+	select {
+	case s.listStarted <- struct{}{}:
+	default:
+	}
+
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *blockingListStore) Delete(ctx context.Context, ids []uint64) error {
+	return nil
 }

--- a/pkg/messaging/publish/circuit/utils_test.go
+++ b/pkg/messaging/publish/circuit/utils_test.go
@@ -22,6 +22,7 @@ type testMessages struct {
 type mockPublisher struct {
 	mu       sync.RWMutex
 	err      error
+	closed   int
 	messages chan *testMessages
 }
 
@@ -64,7 +65,14 @@ func (p *mockPublisher) Publish(topic string, messages ...*message.Message) erro
 func (p *mockPublisher) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.closed++
 	return nil
+}
+
+func (p *mockPublisher) CloseCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.closed
 }
 
 type MockStore struct {

--- a/pkg/messaging/publish/flags.go
+++ b/pkg/messaging/publish/flags.go
@@ -160,6 +160,6 @@ func InitNatsCLIFlags(flags *pflag.FlagSet, serviceName string, options ...func(
 	flags.Int(PublisherNatsMaxReconnectFlag, values.PublisherNatsMaxReconnect, "Nats: set the maximum number of reconnect attempts.")
 	flags.Duration(PublisherNatsReconnectWaitFlag, values.PublisherNatsReconnectWait, "Nats: the wait time between reconnect attempts.")
 	flags.String(PublisherNatsURLFlag, values.PublisherNatsURL, "Nats url")
-	flags.Bool(PublisherNatsAutoProvisionFlag, true, "Auto create streams")
+	flags.Bool(PublisherNatsAutoProvisionFlag, values.PublisherNatsAutoProvision, "Auto create streams")
 	flags.StringArray(PublisherNatsNkeyFileFlag, []string{}, "Nats: nkey file (can be used multiple times)")
 }

--- a/pkg/messaging/publish/flags_test.go
+++ b/pkg/messaging/publish/flags_test.go
@@ -1,0 +1,24 @@
+package publish_test
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
+)
+
+func TestInitNatsCLIFlagsUsesAutoProvisionOverride(t *testing.T) {
+	t.Parallel()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+	publish.InitNatsCLIFlags(flags, "service", func(values *publish.ConfigDefault) {
+		values.PublisherNatsAutoProvision = false
+	})
+
+	autoProvision, err := flags.GetBool(publish.PublisherNatsAutoProvisionFlag)
+	require.NoError(t, err)
+	require.False(t, autoProvision)
+}

--- a/pkg/messaging/publish/logging.go
+++ b/pkg/messaging/publish/logging.go
@@ -33,7 +33,8 @@ func (w watermillLoggerAdapter) Trace(msg string, fields watermill.LogFields) {
 
 func (w watermillLoggerAdapter) With(fields watermill.LogFields) watermill.LoggerAdapter {
 	return watermillLoggerAdapter{
-		Logger: w.Logger.WithFields(fields),
+		includeTraceLogs: w.includeTraceLogs,
+		Logger:           w.Logger.WithFields(fields),
 	}
 }
 

--- a/pkg/messaging/publish/logging_test.go
+++ b/pkg/messaging/publish/logging_test.go
@@ -78,3 +78,17 @@ func TestWatermillLoggerAdapter_Trace_Disabled(t *testing.T) {
 	logger := publish.NewWatermillLoggerAdapter(mockLogger, false)
 	logger.Trace("trace message", fields)
 }
+
+func TestWatermillLoggerAdapter_WithPreservesTraceSetting(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockLogger := logging.NewMockLogger(ctrl)
+
+	mockLogger.EXPECT().WithFields(gomock.Any()).Return(mockLogger)
+	mockLogger.EXPECT().WithFields(gomock.Any()).Return(mockLogger)
+	mockLogger.EXPECT().Debug("trace message").Return()
+
+	logger := publish.NewWatermillLoggerAdapter(mockLogger, true).With(watermill.LogFields{"component": "test"})
+	logger.Trace("trace message", watermill.LogFields{"key": "value"})
+}

--- a/pkg/messaging/publish/messages.go
+++ b/pkg/messaging/publish/messages.go
@@ -3,6 +3,7 @@ package publish
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -10,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
 const (
@@ -20,11 +23,31 @@ const (
 )
 
 func NewMessage(ctx context.Context, m EventMessage) *message.Message {
-	data, err := json.Marshal(m)
-	if err != nil {
-		panic(err)
+	msg, err := NewMessageWithError(ctx, m)
+	if err == nil {
+		return msg
 	}
 
+	logging.FromContext(ctx).Errorf("failed to marshal event message: %v", err)
+	m.Payload = nil
+	msg, fallbackErr := NewMessageWithError(ctx, m)
+	if fallbackErr == nil {
+		return msg
+	}
+
+	logging.FromContext(ctx).Errorf("failed to marshal fallback event message: %v", fallbackErr)
+	return newMessage(ctx, []byte("{}"))
+}
+
+func NewMessageWithError(ctx context.Context, m EventMessage) (*message.Message, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("marshal event message: %w", err)
+	}
+	return newMessage(ctx, data), nil
+}
+
+func newMessage(ctx context.Context, data []byte) *message.Message {
 	carrier := propagation.MapCarrier{}
 	otel.GetTextMapPropagator().Inject(ctx, carrier)
 	otelContext, _ := json.Marshal(carrier)

--- a/pkg/messaging/publish/messages_test.go
+++ b/pkg/messaging/publish/messages_test.go
@@ -1,0 +1,47 @@
+package publish
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestNewMessageWithErrorReturnsMarshalError(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.ContextWithLogger(context.Background(), logging.NopZap())
+	msg, err := NewMessageWithError(ctx, EventMessage{
+		Type:    "test",
+		Payload: func() {},
+	})
+
+	require.Nil(t, msg)
+	require.ErrorContains(t, err, "marshal event message")
+}
+
+func TestNewMessageFallsBackWithoutPanicOnMarshalError(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.ContextWithLogger(context.Background(), logging.NopZap())
+	var msgPayload *EventMessage
+	var err error
+	var msgID string
+
+	require.NotPanics(t, func() {
+		msg := NewMessage(ctx, EventMessage{
+			Type:    "test",
+			Payload: func() {},
+		})
+		require.NotNil(t, msg)
+		msgID = msg.UUID
+		_, msgPayload, err = UnmarshalMessage(msg)
+	})
+
+	require.NotEmpty(t, msgID)
+	require.NoError(t, err)
+	require.Equal(t, "test", msgPayload.Type)
+	require.Nil(t, msgPayload.Payload)
+}

--- a/pkg/messaging/publish/module.go
+++ b/pkg/messaging/publish/module.go
@@ -52,7 +52,14 @@ func (m *memoryPublisher) Close() error {
 }
 
 func (m *memoryPublisher) AllMessages() map[string][]*message.Message {
-	return m.messages
+	m.Lock()
+	defer m.Unlock()
+
+	ret := make(map[string][]*message.Message, len(m.messages))
+	for topic, messages := range m.messages {
+		ret[topic] = append([]*message.Message(nil), messages...)
+	}
+	return ret
 }
 
 var _ message.Publisher = (*memoryPublisher)(nil)

--- a/pkg/messaging/publish/module_test.go
+++ b/pkg/messaging/publish/module_test.go
@@ -1,0 +1,26 @@
+package publish_test
+
+import (
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
+)
+
+func TestMemoryPublisherAllMessagesReturnsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	publisher := publish.InMemory()
+	msg := message.NewMessage("id", nil)
+	require.NoError(t, publisher.Publish("topic", msg))
+
+	snapshot := publisher.AllMessages()
+	snapshot["topic"][0] = message.NewMessage("other", nil)
+	snapshot["other"] = []*message.Message{message.NewMessage("other", nil)}
+
+	fresh := publisher.AllMessages()
+	require.Same(t, msg, fresh["topic"][0])
+	require.NotContains(t, fresh, "other")
+}

--- a/pkg/messaging/queue/listener.go
+++ b/pkg/messaging/queue/listener.go
@@ -32,6 +32,7 @@ type listener struct {
 	wg         *sync.WaitGroup
 	mux        *sync.Mutex
 	hasStarted bool
+	doneClosed bool
 
 	logger logging.Logger
 
@@ -58,7 +59,7 @@ func NewListener(
 		}
 		fn(&opts)
 	}
-	if opts.WorkerCount < 0 {
+	if opts.WorkerCount <= 0 {
 		return nil, fmt.Errorf("workerCount must be bigger than 0")
 	}
 	if callbackFn == nil {
@@ -80,13 +81,19 @@ func NewListener(
 // Start polling for messages
 func (l *listener) Listen(ctx context.Context, ch <-chan *message.Message) {
 	l.mux.Lock()
+	if l.hasStarted || l.doneClosed {
+		l.mux.Unlock()
+		return
+	}
 	l.hasStarted = true
 	l.logger.WithField("listenerName", l.name).WithField("workerCount", l.workerCount).Debugf("queue listener starting listen...")
+	for i := 0; i < l.workerCount; i++ {
+		l.wg.Add(1)
+	}
 	l.mux.Unlock()
 
 	// fan out and process messages concurrently
 	for i := 0; i < l.workerCount; i++ {
-		l.wg.Add(1)
 		go func() {
 			l.startWorker(ctx, ch)
 		}()
@@ -95,7 +102,9 @@ func (l *listener) Listen(ctx context.Context, ch <-chan *message.Message) {
 	go func() {
 		l.wg.Wait()
 		l.logger.WithField("listenerName", l.name).Infof("queue listener closed")
-		close(l.done)
+		l.mux.Lock()
+		l.closeDoneLocked()
+		l.mux.Unlock()
 	}()
 	return
 }
@@ -106,9 +115,17 @@ func (l *listener) Done() <-chan struct{} {
 	defer l.mux.Unlock()
 	if !l.hasStarted {
 		// listen was never called
-		close(l.done)
+		l.closeDoneLocked()
 	}
 	return l.done
+}
+
+func (l *listener) closeDoneLocked() {
+	if l.doneClosed {
+		return
+	}
+	l.doneClosed = true
+	close(l.done)
 }
 
 func (l *listener) startWorker(ctx context.Context, messages <-chan *message.Message) {

--- a/pkg/messaging/queue/listener_test.go
+++ b/pkg/messaging/queue/listener_test.go
@@ -35,12 +35,95 @@ func TestNewListenerNegativeWorkerCount(t *testing.T) {
 	assert.Nil(t, listener)
 }
 
+func TestNewListenerZeroWorkerCount(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error { return nil }, queue.WithWorkerCount(0))
+	require.NotNil(t, err)
+	assert.ErrorContains(t, err, "workerCount")
+	assert.Nil(t, listener)
+}
+
 func TestNewListenerInvalidCallback(t *testing.T) {
 	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
 	listener, err := queue.NewListener(logger, nil)
 	require.NotNil(t, err)
 	assert.ErrorContains(t, err, "callback")
 	assert.Nil(t, listener)
+}
+
+func TestListenerDoneIsIdempotentBeforeListen(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	done := listener.Done()
+	requireClosed(t, done)
+	assert.Equal(t, done, listener.Done())
+	requireClosed(t, done)
+}
+
+func TestListenerDoneBeforeListenMakesLaterListenNoop(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	called := make(chan struct{}, 1)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		called <- struct{}{}
+		return nil
+	})
+	require.NoError(t, err)
+
+	done := listener.Done()
+	requireClosed(t, done)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *message.Message, 1)
+	ch <- message.NewMessage("test-uuid", []byte("test-payload"))
+	listener.Listen(ctx, ch)
+
+	select {
+	case <-called:
+		t.Fatal("callback was called after listener was already done")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestListenerListenIsIdempotent(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	processed := make(chan string, 2)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		processed <- string(msg)
+		return nil
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstCh := make(chan *message.Message, 1)
+	secondCh := make(chan *message.Message, 1)
+	listener.Listen(ctx, firstCh)
+	listener.Listen(ctx, secondCh)
+
+	secondCh <- message.NewMessage("second-uuid", []byte("second"))
+	select {
+	case got := <-processed:
+		t.Fatalf("second Listen call processed message %q", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	firstCh <- message.NewMessage("first-uuid", []byte("first"))
+	select {
+	case got := <-processed:
+		assert.Equal(t, "first", got)
+	case <-time.After(time.Second):
+		t.Fatal("first Listen call did not process message")
+	}
+
+	cancel()
+	requireClosed(t, listener.Done())
 }
 
 func TestHandleMessageInjectsLoggerAndPropagatesTraceContext(t *testing.T) {
@@ -118,4 +201,14 @@ func TestCallbackDeadlineForcesCancels(t *testing.T) {
 
 	cancel()
 	<-listener.Done()
+}
+
+func requireClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("channel was not closed")
+	}
 }

--- a/pkg/observe/http_client.go
+++ b/pkg/observe/http_client.go
@@ -1,8 +1,12 @@
 package observe
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
@@ -15,25 +19,31 @@ type WithBodiesTracingHTTPTransport struct {
 }
 
 func (t WithBodiesTracingHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	rawRequest, err := httputil.DumpRequest(req, true)
-	if err != nil {
-		panic(err)
+	var rawRequest []byte
+	if t.debug {
+		var dumpErr error
+		rawRequest, dumpErr = dumpRequest(req, true)
+		if dumpErr != nil {
+			return nil, fmt.Errorf("dump http request: %w", dumpErr)
+		}
 	}
 
 	rsp, err := t.underlying.RoundTrip(req)
-	if t.debug || err != nil || rsp.StatusCode >= 400 {
+	if t.debug || err != nil {
 		span := trace.SpanFromContext(req.Context())
-		span.SetAttributes(attribute.String("raw-request", string(rawRequest)))
+		if t.debug {
+			span.SetAttributes(attribute.String("raw-request", string(rawRequest)))
+		}
 		if err != nil {
 			span.SetAttributes(attribute.String("http-error", err.Error()))
 		}
-		if rsp != nil {
-			rawResponse, err := httputil.DumpResponse(rsp, true)
+		if t.debug && rsp != nil {
+			rawResponse, err := dumpResponse(rsp, true)
 			if err != nil {
-				panic(err)
+				span.SetAttributes(attribute.String("raw-response-error", err.Error()))
+			} else {
+				span.SetAttributes(attribute.String("raw-response", string(rawResponse)))
 			}
-
-			span.SetAttributes(attribute.String("raw-response", string(rawResponse)))
 		}
 	}
 
@@ -47,4 +57,70 @@ func NewRoundTripper(httpTransport http.RoundTripper, debug bool, options ...ote
 		debug:      debug,
 	}
 	return otelhttp.NewTransport(transport, options...)
+}
+
+func dumpRequest(req *http.Request, includeBody bool) ([]byte, error) {
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	redactSensitiveHeaders(cloned.Header)
+
+	if !includeBody {
+		return httputil.DumpRequestOut(cloned, false)
+	}
+
+	if req.Body == nil || req.Body == http.NoBody {
+		cloned.Body = req.Body
+		return httputil.DumpRequestOut(cloned, true)
+	}
+
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		cloned.Body = body
+		return httputil.DumpRequestOut(cloned, true)
+	}
+
+	data, readErr := io.ReadAll(req.Body)
+	closeErr := req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(data))
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	cloned.Body = io.NopCloser(bytes.NewReader(data))
+	return httputil.DumpRequestOut(cloned, true)
+}
+
+func dumpResponse(rsp *http.Response, includeBody bool) ([]byte, error) {
+	cloned := new(http.Response)
+	*cloned = *rsp
+	cloned.Header = rsp.Header.Clone()
+	redactSensitiveHeaders(cloned.Header)
+
+	data, err := httputil.DumpResponse(cloned, includeBody)
+	rsp.Body = cloned.Body
+	rsp.ContentLength = cloned.ContentLength
+	return data, err
+}
+
+func redactSensitiveHeaders(headers http.Header) {
+	for name := range headers {
+		if isSensitiveHeader(name) {
+			headers.Set(name, "[REDACTED]")
+		}
+	}
+}
+
+func isSensitiveHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "authorization", "cookie", "proxy-authorization", "set-cookie":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/observe/http_client_test.go
+++ b/pkg/observe/http_client_test.go
@@ -1,0 +1,97 @@
+package observe
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBodiesTracingHTTPTransportDoesNotDumpSuccessfulRequestWhenDebugDisabled(t *testing.T) {
+	t.Parallel()
+
+	transport := WithBodiesTracingHTTPTransport{
+		underlying: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       http.NoBody,
+			}, nil
+		}),
+		debug: false,
+	}
+	req, err := http.NewRequest(http.MethodPost, "http://example.com", errorReadCloser{err: errors.New("body should not be read")})
+	require.NoError(t, err)
+
+	var rsp *http.Response
+	require.NotPanics(t, func() {
+		rsp, err = transport.RoundTrip(req)
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+}
+
+func TestBodiesTracingHTTPTransportReturnsRequestDumpError(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	transport := WithBodiesTracingHTTPTransport{
+		underlying: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			called = true
+			return &http.Response{StatusCode: http.StatusOK}, nil
+		}),
+		debug: true,
+	}
+	req, err := http.NewRequest(http.MethodPost, "http://example.com", errorReadCloser{err: errors.New("read failed")})
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err = transport.RoundTrip(req)
+	})
+
+	require.ErrorContains(t, err, "dump http request")
+	require.False(t, called)
+}
+
+func TestBodiesTracingHTTPTransportDoesNotPanicOnResponseDumpError(t *testing.T) {
+	t.Parallel()
+
+	transport := WithBodiesTracingHTTPTransport{
+		underlying: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       errorReadCloser{err: errors.New("read failed")},
+			}, nil
+		}),
+		debug: true,
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	var rsp *http.Response
+	require.NotPanics(t, func() {
+		rsp, err = transport.RoundTrip(req)
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, rsp.StatusCode)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errorReadCloser struct {
+	err error
+}
+
+func (r errorReadCloser) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (r errorReadCloser) Close() error {
+	return nil
+}

--- a/pkg/observe/log/adapter_logrus.go
+++ b/pkg/observe/log/adapter_logrus.go
@@ -17,6 +17,8 @@ type LogrusLogger struct {
 		Debug(args ...any)
 		Infof(format string, args ...any)
 		Info(args ...any)
+		Warnf(format string, args ...any)
+		Warn(args ...any)
 		Errorf(format string, args ...any)
 		Error(args ...any)
 		WithFields(fields logrus.Fields) *logrus.Entry
@@ -55,6 +57,12 @@ func (l *LogrusLogger) Infof(fmt string, args ...any) {
 }
 func (l *LogrusLogger) Info(args ...any) {
 	l.entry.Info(args...)
+}
+func (l *LogrusLogger) Warnf(fmt string, args ...any) {
+	l.entry.Warnf(fmt, args...)
+}
+func (l *LogrusLogger) Warn(args ...any) {
+	l.entry.Warn(args...)
 }
 func (l *LogrusLogger) Errorf(fmt string, args ...any) {
 	l.entry.Errorf(fmt, args...)

--- a/pkg/observe/log/adapter_zap_logger.go
+++ b/pkg/observe/log/adapter_zap_logger.go
@@ -42,9 +42,11 @@ func (z *ZapLogger) Tracef(format string, args ...any) {
 func (z *ZapLogger) Trace(args ...any)                 { z.sugar.Log(zapTraceLevel, args...) }
 func (z *ZapLogger) Debugf(format string, args ...any) { z.sugar.Debugf(format, args...) }
 func (z *ZapLogger) Infof(format string, args ...any)  { z.sugar.Infof(format, args...) }
+func (z *ZapLogger) Warnf(format string, args ...any)  { z.sugar.Warnf(format, args...) }
 func (z *ZapLogger) Errorf(format string, args ...any) { z.sugar.Errorf(format, args...) }
 func (z *ZapLogger) Debug(args ...any)                 { z.sugar.Debug(args...) }
 func (z *ZapLogger) Info(args ...any)                  { z.sugar.Info(args...) }
+func (z *ZapLogger) Warn(args ...any)                  { z.sugar.Warn(args...) }
 func (z *ZapLogger) Error(args ...any)                 { z.sugar.Error(args...) }
 
 func (z *ZapLogger) Enabled(level Level) bool {

--- a/pkg/service/flags.go
+++ b/pkg/service/flags.go
@@ -21,6 +21,10 @@ func BindEnvToFlagSet(set *pflag.FlagSet) {
 	set.VisitAll(func(flag *pflag.Flag) {
 		envVar := strings.ToUpper(flag.Name)
 		envVar = strings.Replace(envVar, "-", "_", -1)
+		// DEBUG is commonly set by tooling and shells; keep debug mode explicit.
+		if flag.Name == DebugFlag && envVar == "DEBUG" {
+			return
+		}
 		value := os.Getenv(envVar)
 		if value == "" {
 			return
@@ -33,9 +37,8 @@ func BindEnvToFlagSet(set *pflag.FlagSet) {
 			}
 		}
 
-		err := set.Set(flag.Name, value)
-		if err != nil {
-			panic(err)
+		if err := set.Set(flag.Name, value); err != nil {
+			return
 		}
 	})
 }

--- a/pkg/service/flags_test.go
+++ b/pkg/service/flags_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFlags(t *testing.T) {
@@ -42,4 +44,45 @@ func TestFlags(t *testing.T) {
 	}
 
 	fmt.Println(command.Flags().GetString("root1"))
+}
+
+func TestBindEnvToFlagSetDoesNotEnableDebugFromBareDebugEnv(t *testing.T) {
+	t.Setenv("DEBUG", "1")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool(DebugFlag, false, "")
+
+	BindEnvToFlagSet(flags)
+
+	debug, err := flags.GetBool(DebugFlag)
+	require.NoError(t, err)
+	require.False(t, debug)
+}
+
+func TestBindEnvToFlagSetStillBindsNonDebugEnv(t *testing.T) {
+	t.Setenv("ROOT1", "changed")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("root1", "default", "")
+
+	BindEnvToFlagSet(flags)
+
+	root1, err := flags.GetString("root1")
+	require.NoError(t, err)
+	require.Equal(t, "changed", root1)
+}
+
+func TestBindEnvToFlagSetIgnoresInvalidEnvValue(t *testing.T) {
+	t.Setenv("ENABLED", "not-a-bool")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool("enabled", false, "")
+
+	require.NotPanics(t, func() {
+		BindEnvToFlagSet(flags)
+	})
+
+	enabled, err := flags.GetBool("enabled")
+	require.NoError(t, err)
+	require.False(t, enabled)
 }

--- a/pkg/service/health/controller.go
+++ b/pkg/service/health/controller.go
@@ -3,7 +3,6 @@ package health
 import (
 	"encoding/json"
 	"net/http"
-	"sync"
 )
 
 type HealthController struct {
@@ -11,34 +10,30 @@ type HealthController struct {
 }
 
 type result struct {
+	Index int
 	Check NamedCheck
 	Err   error
 }
 
 func (ctrl *HealthController) Check(w http.ResponseWriter, r *http.Request) {
-	sg := sync.WaitGroup{}
-	sg.Add(len(ctrl.Checks))
-
+	ctx := r.Context()
 	results := make(chan result, len(ctrl.Checks))
-	for _, ch := range ctrl.Checks {
-		go func(ch NamedCheck) {
-			defer sg.Done()
-			select {
-			case <-r.Context().Done():
-				return
-			case results <- result{
+	for index, ch := range ctrl.Checks {
+		go func(index int, ch NamedCheck) {
+			results <- result{
+				Index: index,
 				Check: ch,
-				Err:   ch.Do(r.Context()),
-			}:
+				Err:   ch.Do(ctx),
 			}
-		}(ch)
+		}(index, ch)
 	}
-	sg.Wait()
-	close(results)
 
 	response := map[string]string{}
+	completed := make([]bool, len(ctrl.Checks))
 	hasError := false
-	for r := range results {
+
+	recordResult := func(r result) {
+		completed[r.Index] = true
 		if r.Err != nil {
 			hasError = true
 			response[r.Check.Name()] = r.Err.Error()
@@ -47,6 +42,36 @@ func (ctrl *HealthController) Check(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	completedCount := 0
+	for completedCount < len(ctrl.Checks) {
+		select {
+		case r := <-results:
+			recordResult(r)
+			completedCount++
+		case <-ctx.Done():
+			for completedCount < len(ctrl.Checks) {
+				select {
+				case r := <-results:
+					recordResult(r)
+					completedCount++
+				default:
+					hasError = true
+					for index, ch := range ctrl.Checks {
+						if !completed[index] {
+							response[ch.Name()] = ctx.Err().Error()
+						}
+					}
+					writeResponse(w, response, hasError)
+					return
+				}
+			}
+		}
+	}
+
+	writeResponse(w, response, hasError)
+}
+
+func writeResponse(w http.ResponseWriter, response map[string]string, hasError bool) {
 	if hasError {
 		w.WriteHeader(http.StatusInternalServerError)
 	} else {

--- a/pkg/service/health/controller_test.go
+++ b/pkg/service/health/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
@@ -86,4 +87,53 @@ func TestHealthController(t *testing.T) {
 		app := fx.New(options...)
 		require.NoError(t, app.Err())
 	}
+}
+
+func TestHealthControllerReturnsWhenContextCanceledDuringHungCheck(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	ctrl := health.NewHealthController(
+		health.NewNamedCheck("hung", health.CheckFn(func(ctx context.Context) error {
+			close(started)
+			<-release
+			return nil
+		})),
+	)
+	t.Cleanup(func() {
+		close(release)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/_health", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		ctrl.Check(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("health check did not start")
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("health controller did not return after request context cancellation")
+	}
+
+	require.Equal(t, http.StatusInternalServerError, rec.Result().StatusCode)
+
+	ret := make(map[string]string)
+	require.NoError(t, json.NewDecoder(rec.Result().Body).Decode(&ret))
+	require.Equal(t, map[string]string{
+		"hung": context.Canceled.Error(),
+	}, ret)
 }

--- a/pkg/storage/bun/connect/connect_test.go
+++ b/pkg/storage/bun/connect/connect_test.go
@@ -1,11 +1,16 @@
 package connect
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
 func TestObfuscateDSN(t *testing.T) {
@@ -84,5 +89,26 @@ func TestBuildPGXConnectorDefaultsToReadWriteTargetSessionAttrs(t *testing.T) {
 	want := reflect.ValueOf(pgconn.ValidateConnectTargetSessionAttrsReadWrite).Pointer()
 	if got != want {
 		t.Fatalf("unexpected ValidateConnect func pointer: got %x, want %x", got, want)
+	}
+}
+
+func TestIAMConnectorReturnsBuildAuthTokenError(t *testing.T) {
+	expectedErr := errors.New("retrieve aws credentials")
+	connector := &iamConnector{
+		dsn: "postgres://db-user@localhost:5432/mydb?sslmode=disable",
+		driver: &iamDriver{
+			awsConfig: aws.Config{
+				Region: "us-east-1",
+				Credentials: aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+					return aws.Credentials{}, expectedErr
+				}),
+			},
+		},
+		logger: logging.Testing(),
+	}
+
+	_, err := connector.Connect(context.Background())
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected BuildAuthToken error %q, got %v", expectedErr, err)
 	}
 }

--- a/pkg/storage/bun/connect/iam.go
+++ b/pkg/storage/bun/connect/iam.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
@@ -49,7 +50,7 @@ type iamConnector struct {
 }
 
 func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
-	url, err := dburl.Parse(i.dsn)
+	databaseURL, err := dburl.Parse(i.dsn)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing dsn: %s", i.dsn)
 	}
@@ -60,36 +61,24 @@ func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
 
 		ret, err := auth.BuildAuthToken(
 			ctx,
-			url.Host,
+			databaseURL.Host,
 			i.driver.awsConfig.Region,
-			url.User.Username(),
+			databaseURL.User.Username(),
 			i.driver.awsConfig.Credentials,
 		)
 		if err != nil {
 			otlp.RecordError(ctx, err)
 		}
 
-		return ret, nil
+		return ret, err
 	}()
 	if err != nil {
 		return nil, errors.Wrap(err, "building aws auth token")
 	}
 
-	dsn := fmt.Sprintf(
-		"host=%s port=%s user=%s password=%s dbname=%s",
-		url.Hostname(),
-		url.Port(),
-		url.User.Username(),
-		authenticationToken,
-		url.Path[1:],
-	)
-	for key, strings := range url.Query() {
-		for _, value := range strings {
-			dsn = fmt.Sprintf("%s %s=%s", dsn, key, value)
-		}
-	}
+	dsn := buildIAMAuthDSN(&databaseURL.URL, authenticationToken)
 
-	i.logger.Debugf("IAM: Connect using dsn '%s'", dsn)
+	i.logger.Debugf("IAM: Connect using dsn '%s'", obfuscateDSN(dsn))
 
 	config, err := pgx.ParseConfig(dsn)
 	if err != nil {
@@ -107,3 +96,9 @@ func (i iamConnector) Driver() driver.Driver {
 }
 
 var _ driver.Connector = &iamConnector{}
+
+func buildIAMAuthDSN(databaseURL *url.URL, authenticationToken string) string {
+	dsnURL := *databaseURL
+	dsnURL.User = url.UserPassword(databaseURL.User.Username(), authenticationToken)
+	return dsnURL.String()
+}

--- a/pkg/storage/bun/connect/iam_test.go
+++ b/pkg/storage/bun/connect/iam_test.go
@@ -1,0 +1,62 @@
+package connect
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/xo/dburl"
+)
+
+func TestBuildIAMAuthDSNEscapesAuthTokenAndQueryValues(t *testing.T) {
+	databaseURL, err := dburl.Parse("postgres://iam%20user:old%20password@db.example.com:5432/service%20db?sslmode=require&application_name=worker%20one%2Bblue%26green%3Dtrue&search_path=tenant%3Done%2Cpublic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := "db.example.com:5432/?Action=connect&DBUser=iam user&X-Amz-Credential=AKIA/20260614/eu-west-1/rds-db/aws4_request&X-Amz-Signature=a+b=c=="
+
+	dsn := buildIAMAuthDSN(&databaseURL.URL, token)
+	if strings.Contains(dsn, token) {
+		t.Fatalf("expected auth token to be URL-escaped, got raw token in %q", dsn)
+	}
+
+	config, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("failed to parse generated IAM DSN: %v", err)
+	}
+
+	if config.User != "iam user" {
+		t.Fatalf("unexpected user: got %q", config.User)
+	}
+	if config.Password != token {
+		t.Fatalf("unexpected password token: got %q, want %q", config.Password, token)
+	}
+	if config.Database != "service db" {
+		t.Fatalf("unexpected database: got %q", config.Database)
+	}
+	if got := config.RuntimeParams["application_name"]; got != "worker one+blue&green=true" {
+		t.Fatalf("unexpected application_name: got %q", got)
+	}
+	if got := config.RuntimeParams["search_path"]; got != "tenant=one,public" {
+		t.Fatalf("unexpected search_path: got %q", got)
+	}
+}
+
+func TestBuildIAMAuthDSNObfuscatesAuthToken(t *testing.T) {
+	databaseURL, err := dburl.Parse("postgres://iam-user@db.example.com:5432/app?sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := "db.example.com:5432/?Action=connect&DBUser=iam-user&X-Amz-Credential=AKIA/20260614/eu-west-1/rds-db/aws4_request&X-Amz-Signature=a+b=c=="
+
+	loggedDSN := obfuscateDSN(buildIAMAuthDSN(&databaseURL.URL, token))
+	if loggedDSN != "postgres://iam-user:%2A%2A%2A%2A@db.example.com:5432/app?sslmode=disable" {
+		t.Fatalf("unexpected obfuscated DSN: got %q", loggedDSN)
+	}
+
+	for _, sensitive := range []string{token, "X-Amz-Credential", "X-Amz-Signature", "AKIA"} {
+		if strings.Contains(loggedDSN, sensitive) {
+			t.Fatalf("obfuscated DSN leaked %q in %q", sensitive, loggedDSN)
+		}
+	}
+}

--- a/pkg/storage/migrations/migrator.go
+++ b/pkg/storage/migrations/migrator.go
@@ -319,88 +319,9 @@ func (m *Migrator) upByOne(ctx context.Context, db bun.IDB) error {
 
 	switch conn := actualDB.(type) {
 	case bun.Conn:
-		listeningContext, cancel := context.WithCancel(ctx)
-		listenerStopped := make(chan struct{})
-		defer func() {
-			cancel()
-			<-listenerStopped
-		}()
-
-		if err := conn.Raw(func(driverConn any) error {
-			channel := "migrations-" + m.GetSchema()
-			logging.FromContext(ctx).Debugf("Listening for migrations notifications on " + channel)
-
-			listener := pgxlisten.Listener{
-				Connect: func(ctx context.Context) (*pgx.Conn, error) {
-					return pgx.Connect(ctx, driverConn.(*stdlib.Conn).Conn().Config().ConnString())
-				},
-				LogError: func(ctx context.Context, err error) {
-					if !errors.Is(err, context.Canceled) {
-						logging.FromContext(ctx).Errorf("pgxlisten error: %v", err)
-					}
-				},
-			}
-			listener.Handle(channel, pgxlisten.HandlerFunc(func(ctx context.Context, notification *pgconn.Notification, conn *pgx.Conn) error {
-
-				logging.FromContext(ctx).Debugf("Received notification: %s", notification.Payload)
-
-				switch {
-				case strings.HasPrefix(notification.Payload, "init: "):
-					value := strings.TrimPrefix(notification.Payload, "init: ")
-					maxCounter, err := strconv.ParseInt(value, 10, 64)
-					if err != nil {
-						logging.FromContext(ctx).Errorf("failed to parse max counter: %v", err)
-						return nil
-					}
-
-					_, err = conn.Exec(ctx, `
-						update `+m.getVersionsTable()+`
-						set max_counter = $1
-						where version_id = $2 and max_counter is null
-					`, maxCounter, lastVersion+1)
-					if err != nil {
-						logging.FromContext(ctx).Debugf("failed to update max counter: %v", err)
-						return nil
-					}
-				case strings.HasPrefix(notification.Payload, "continue: "):
-					value := strings.TrimPrefix(notification.Payload, "continue: ")
-					increment, err := strconv.ParseInt(value, 10, 64)
-					if err != nil {
-						logging.FromContext(ctx).Errorf("failed to parse actual counter: %v", err)
-						return nil
-					}
-
-					_, err = conn.Exec(ctx, `
-						update `+m.getVersionsTable()+`
-						set actual_counter = coalesce(actual_counter, 0) + $1
-						where version_id = $2
-					`, increment, lastVersion+1)
-					if err != nil {
-						return err
-					}
-					if err != nil {
-						logging.FromContext(ctx).Debugf("failed to update actual counter: %v", err)
-						return nil
-					}
-				default:
-					logging.FromContext(ctx).Errorf("unknown notification: %s", notification.Payload)
-				}
-
-				return nil
-			}))
-			go func() {
-				if err := listener.Listen(listeningContext); err != nil {
-					if errors.Is(err, context.Canceled) {
-						close(listenerStopped)
-						return
-					}
-					panic(err)
-				}
-			}()
-
-			return nil
-		}); err != nil {
-			logging.FromContext(ctx).Errorf("Failed so setup migrations listener: %v", err)
+		stopMigrationProgressListener := m.startMigrationProgressListener(ctx, conn, lastVersion)
+		if stopMigrationProgressListener != nil {
+			defer stopMigrationProgressListener()
 		}
 	}
 
@@ -422,6 +343,103 @@ func (m *Migrator) upByOne(ctx context.Context, db bun.IDB) error {
 	}
 
 	return nil
+}
+
+type migrationProgressRawConn interface {
+	Raw(func(driverConn any) error) error
+}
+
+func (m *Migrator) startMigrationProgressListener(ctx context.Context, conn migrationProgressRawConn, lastVersion int) func() {
+	var stopMigrationProgressListener func()
+
+	if err := conn.Raw(func(driverConn any) error {
+		channel := "migrations-" + m.GetSchema()
+		logging.FromContext(ctx).Debugf("Listening for migrations notifications on " + channel)
+
+		listener := pgxlisten.Listener{
+			Connect: func(ctx context.Context) (*pgx.Conn, error) {
+				return pgx.Connect(ctx, driverConn.(*stdlib.Conn).Conn().Config().ConnString())
+			},
+			LogError: func(ctx context.Context, err error) {
+				if !errors.Is(err, context.Canceled) {
+					logging.FromContext(ctx).Errorf("pgxlisten error: %v", err)
+				}
+			},
+		}
+		listener.Handle(channel, pgxlisten.HandlerFunc(func(ctx context.Context, notification *pgconn.Notification, conn *pgx.Conn) error {
+
+			logging.FromContext(ctx).Debugf("Received notification: %s", notification.Payload)
+
+			switch {
+			case strings.HasPrefix(notification.Payload, "init: "):
+				value := strings.TrimPrefix(notification.Payload, "init: ")
+				maxCounter, err := strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					logging.FromContext(ctx).Errorf("failed to parse max counter: %v", err)
+					return nil
+				}
+
+				_, err = conn.Exec(ctx, `
+					update `+m.getVersionsTable()+`
+					set max_counter = $1
+					where version_id = $2 and max_counter is null
+				`, maxCounter, lastVersion+1)
+				if err != nil {
+					logging.FromContext(ctx).Debugf("failed to update max counter: %v", err)
+					return nil
+				}
+			case strings.HasPrefix(notification.Payload, "continue: "):
+				value := strings.TrimPrefix(notification.Payload, "continue: ")
+				increment, err := strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					logging.FromContext(ctx).Errorf("failed to parse actual counter: %v", err)
+					return nil
+				}
+
+				_, err = conn.Exec(ctx, `
+					update `+m.getVersionsTable()+`
+					set actual_counter = coalesce(actual_counter, 0) + $1
+					where version_id = $2
+				`, increment, lastVersion+1)
+				if err != nil {
+					return err
+				}
+				if err != nil {
+					logging.FromContext(ctx).Debugf("failed to update actual counter: %v", err)
+					return nil
+				}
+			default:
+				logging.FromContext(ctx).Errorf("unknown notification: %s", notification.Payload)
+			}
+
+			return nil
+		}))
+		stopMigrationProgressListener = runMigrationProgressListener(ctx, listener.Listen)
+
+		return nil
+	}); err != nil {
+		logging.FromContext(ctx).Errorf("failed to set up migrations listener: %v", err)
+	}
+
+	return stopMigrationProgressListener
+}
+
+func runMigrationProgressListener(ctx context.Context, listen func(context.Context) error) func() {
+	listeningContext, cancel := context.WithCancel(ctx)
+	listenerStopped := make(chan struct{})
+
+	go func() {
+		defer close(listenerStopped)
+
+		if err := listen(listeningContext); err != nil && !errors.Is(err, context.Canceled) {
+			logging.FromContext(ctx).Errorf("migrations listener stopped with error: %v", err)
+		}
+	}()
+
+	return func() {
+		cancel()
+		<-listenerStopped
+	}
 }
 
 func (m *Migrator) UpByOne(ctx context.Context) error {

--- a/pkg/storage/migrations/migrator_test.go
+++ b/pkg/storage/migrations/migrator_test.go
@@ -29,6 +29,12 @@ var (
 	bunDB      *bun.DB
 )
 
+type rawConnFunc func(func(driverConn any) error) error
+
+func (f rawConnFunc) Raw(fn func(driverConn any) error) error {
+	return f(fn)
+}
+
 func TestMain(m *testing.M) {
 	utils.WithTestMain(func(t *utils.TestingTForMain) int {
 		var err error
@@ -53,6 +59,39 @@ func TestMain(m *testing.M) {
 
 		return m.Run()
 	})
+}
+
+func TestMigrationProgressListenerRawErrorDoesNotRequireCleanup(t *testing.T) {
+	t.Parallel()
+
+	rawErr := errors.New("raw failed")
+	migrator := &Migrator{}
+
+	stop := migrator.startMigrationProgressListener(logging.TestingContext(), rawConnFunc(func(func(driverConn any) error) error {
+		return rawErr
+	}), 0)
+
+	require.Nil(t, stop)
+}
+
+func TestMigrationProgressListenerListenErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	stop := runMigrationProgressListener(logging.TestingContext(), func(context.Context) error {
+		return errors.New("listen failed")
+	})
+
+	done := make(chan struct{})
+	go func() {
+		stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("listener cleanup blocked")
+	}
 }
 
 func TestMigrationsListen(t *testing.T) {

--- a/pkg/transport/api/utils.go
+++ b/pkg/transport/api/utils.go
@@ -21,6 +21,8 @@ const (
 	ErrorInternal       = "INTERNAL"
 	ErrorCodeForbidden  = "FORBIDDEN"
 	ErrorCodeValidation = "VALIDATION"
+
+	internalServerErrorMessage = "internal server error"
 )
 
 func writeJSON(w http.ResponseWriter, statusCode int, v any) {
@@ -66,7 +68,10 @@ func BadRequestWithDetails(w http.ResponseWriter, code string, err error, detail
 
 func InternalServerError(w http.ResponseWriter, r *http.Request, err error) {
 	logging.FromContext(r.Context()).Error(err)
-	WriteErrorResponse(w, http.StatusInternalServerError, ErrorInternal, err)
+	writeJSON(w, http.StatusInternalServerError, ErrorResponse{
+		ErrorCode:    ErrorInternal,
+		ErrorMessage: internalServerErrorMessage,
+	})
 }
 
 func Accepted(w http.ResponseWriter, v any) {

--- a/pkg/transport/api/utils_test.go
+++ b/pkg/transport/api/utils_test.go
@@ -208,7 +208,7 @@ func TestInternalServerError(t *testing.T) {
 
 	// Create a response recorder
 	rr := httptest.NewRecorder()
-	testErr := errors.New("internal server error")
+	testErr := errors.New(`pq: duplicate key value violates unique constraint "accounts_pkey" at /srv/app/internal/storage/accounts.go:42`)
 
 	// Call the function
 	api.InternalServerError(rr, req, testErr)
@@ -220,15 +220,19 @@ func TestInternalServerError(t *testing.T) {
 	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 
 	// Check the response body
+	rawBody := rr.Body.String()
 	var response api.ErrorResponse
-	decodeErr := json.NewDecoder(rr.Body).Decode(&response)
+	decodeErr := json.NewDecoder(bytes.NewBufferString(rawBody)).Decode(&response)
 	require.NoError(t, decodeErr)
 	require.Equal(t, api.ErrorInternal, response.ErrorCode)
-	require.Equal(t, testErr.Error(), response.ErrorMessage)
+	require.Equal(t, "internal server error", response.ErrorMessage)
+	require.NotContains(t, rawBody, "accounts_pkey")
+	require.NotContains(t, rawBody, "/srv/app/internal/storage/accounts.go")
 
 	// Verify that the error was logged
 	logOutput := buf.String()
-	require.Contains(t, logOutput, testErr.Error())
+	require.Contains(t, logOutput, "accounts_pkey")
+	require.Contains(t, logOutput, "/srv/app/internal/storage/accounts.go")
 }
 
 func TestAccepted(t *testing.T) {

--- a/pkg/transport/grpcserver/serverport.go
+++ b/pkg/transport/grpcserver/serverport.go
@@ -39,9 +39,20 @@ func startServer(ctx context.Context, s *serverport.Server, serverOptions []grpc
 	}()
 
 	return func(ctx context.Context) error {
-		grpcServer.GracefulStop()
+		stopped := make(chan struct{})
+		go func() {
+			grpcServer.GracefulStop()
+			close(stopped)
+		}()
 
-		return nil
+		select {
+		case <-stopped:
+			return nil
+		case <-ctx.Done():
+			grpcServer.Stop()
+			<-stopped
+			return ctx.Err()
+		}
 	}, nil
 }
 

--- a/pkg/transport/grpcserver/serverport_test.go
+++ b/pkg/transport/grpcserver/serverport_test.go
@@ -1,0 +1,106 @@
+package grpcserver
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/transport/serverport"
+)
+
+func TestStartServerStopContextForcesGracefulStop(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := serverport.NewServer(serverPortDiscr, serverport.WithListener(listener))
+	streamStarted := make(chan struct{})
+	var closeStarted sync.Once
+
+	stop, err := startServer(
+		logging.TestingContext(),
+		server,
+		nil,
+		[]func(*grpc.Server){
+			func(grpcServer *grpc.Server) {
+				grpcServer.RegisterService(&grpc.ServiceDesc{
+					ServiceName: "test.Blocking",
+					HandlerType: (*any)(nil),
+					Streams: []grpc.StreamDesc{
+						{
+							StreamName: "Watch",
+							Handler: func(_ any, stream grpc.ServerStream) error {
+								closeStarted.Do(func() {
+									close(streamStarted)
+								})
+								<-stream.Context().Done()
+								return stream.Context().Err()
+							},
+							ServerStreams: true,
+							ClientStreams: true,
+						},
+					},
+				}, &struct{}{})
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	connCtx, cancelConn := context.WithTimeout(context.Background(), time.Second)
+	defer cancelConn()
+	conn, err := grpc.DialContext(
+		connCtx,
+		listener.Addr().String(),
+		grpc.WithBlock(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	defer cancelStream()
+
+	stream, err := conn.NewStream(
+		streamCtx,
+		&grpc.StreamDesc{
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+		"/test.Blocking/Watch",
+	)
+	require.NoError(t, err)
+	require.NoError(t, stream.SendMsg(&emptypb.Empty{}))
+
+	select {
+	case <-streamStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stream handler did not start")
+	}
+
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelStop()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- stop(stopCtx)
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		cancelStream()
+		t.Fatal("stop did not return after context deadline")
+	}
+}

--- a/pkg/transport/httpclient/debug.go
+++ b/pkg/transport/httpclient/debug.go
@@ -1,8 +1,12 @@
 package httpclient
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
@@ -12,22 +16,29 @@ type httpTransport struct {
 }
 
 func (h httpTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	data, err := httputil.DumpRequest(request, true)
-	if err != nil {
-		panic(err)
+	logger := logging.FromContext(request.Context())
+	debugEnabled := logger.Enabled(logging.DebugLevel)
+	if debugEnabled {
+		data, err := dumpRequest(request, true)
+		if err != nil {
+			return nil, fmt.Errorf("dump http request: %w", err)
+		}
+		logger.Debug(string(data))
 	}
-	logging.FromContext(request.Context()).Debug(string(data))
 
 	rsp, err := h.underlying.RoundTrip(request)
 	if err != nil {
 		return nil, err
 	}
 
-	data, err = httputil.DumpResponse(rsp, true)
-	if err != nil {
-		panic(err)
+	if debugEnabled {
+		data, err := dumpResponse(rsp, true)
+		if err != nil {
+			logger.Debugf("failed to dump HTTP response: %v", err)
+			return rsp, nil
+		}
+		logger.Debug(string(data))
 	}
-	logging.FromContext(request.Context()).Debug(string(data))
 
 	return rsp, nil
 }
@@ -37,5 +48,71 @@ var _ http.RoundTripper = &httpTransport{}
 func NewDebugHTTPTransport(underlying http.RoundTripper) *httpTransport {
 	return &httpTransport{
 		underlying: underlying,
+	}
+}
+
+func dumpRequest(req *http.Request, includeBody bool) ([]byte, error) {
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	redactSensitiveHeaders(cloned.Header)
+
+	if !includeBody {
+		return httputil.DumpRequestOut(cloned, false)
+	}
+
+	if req.Body == nil || req.Body == http.NoBody {
+		cloned.Body = req.Body
+		return httputil.DumpRequestOut(cloned, true)
+	}
+
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		cloned.Body = body
+		return httputil.DumpRequestOut(cloned, true)
+	}
+
+	data, readErr := io.ReadAll(req.Body)
+	closeErr := req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(data))
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	cloned.Body = io.NopCloser(bytes.NewReader(data))
+	return httputil.DumpRequestOut(cloned, true)
+}
+
+func dumpResponse(rsp *http.Response, includeBody bool) ([]byte, error) {
+	cloned := new(http.Response)
+	*cloned = *rsp
+	cloned.Header = rsp.Header.Clone()
+	redactSensitiveHeaders(cloned.Header)
+
+	data, err := httputil.DumpResponse(cloned, includeBody)
+	rsp.Body = cloned.Body
+	rsp.ContentLength = cloned.ContentLength
+	return data, err
+}
+
+func redactSensitiveHeaders(headers http.Header) {
+	for name := range headers {
+		if isSensitiveHeader(name) {
+			headers.Set(name, "[REDACTED]")
+		}
+	}
+}
+
+func isSensitiveHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "authorization", "cookie", "proxy-authorization", "set-cookie":
+		return true
+	default:
+		return false
 	}
 }

--- a/pkg/transport/httpclient/debug_test.go
+++ b/pkg/transport/httpclient/debug_test.go
@@ -1,0 +1,136 @@
+package httpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestDebugHTTPTransportSkipsDumpWhenDebugDisabled(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", errorReadCloser{err: errors.New("body should not be read")})
+	require.NoError(t, err)
+
+	rsp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.Empty(t, logger.debugMessages)
+}
+
+func TestDebugHTTPTransportRedactsAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{debugEnabled: true}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("response body")),
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", strings.NewReader("request body"))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer secret-token")
+
+	rsp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "response body", string(body))
+
+	logs := strings.Join(logger.debugMessages, "\n")
+	require.Contains(t, logs, "Authorization: [REDACTED]")
+	require.NotContains(t, logs, "Bearer secret-token")
+}
+
+func TestDebugHTTPTransportDoesNotPanicOnResponseDumpError(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{debugEnabled: true}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       errorReadCloser{err: errors.New("read failed")},
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	var rsp *http.Response
+	require.NotPanics(t, func() {
+		rsp, err = transport.RoundTrip(req)
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.Contains(t, strings.Join(logger.debugMessages, "\n"), "failed to dump HTTP response")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errorReadCloser struct {
+	err error
+}
+
+func (r errorReadCloser) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (r errorReadCloser) Close() error {
+	return nil
+}
+
+type recordingLogger struct {
+	debugEnabled  bool
+	debugMessages []string
+}
+
+func (l *recordingLogger) Tracef(string, ...any) {}
+func (l *recordingLogger) Debugf(format string, args ...any) {
+	l.debugMessages = append(l.debugMessages, fmt.Sprintf(format, args...))
+}
+func (l *recordingLogger) Infof(string, ...any)  {}
+func (l *recordingLogger) Errorf(string, ...any) {}
+func (l *recordingLogger) Trace(...any)          {}
+func (l *recordingLogger) Debug(args ...any) {
+	l.debugMessages = append(l.debugMessages, fmt.Sprint(args...))
+}
+func (l *recordingLogger) Info(...any)  {}
+func (l *recordingLogger) Error(...any) {}
+func (l *recordingLogger) WithFields(map[string]any) logging.Logger {
+	return l
+}
+func (l *recordingLogger) WithField(string, any) logging.Logger {
+	return l
+}
+func (l *recordingLogger) WithContext(context.Context) logging.Logger {
+	return l
+}
+func (l *recordingLogger) Writer() io.Writer {
+	return io.Discard
+}
+func (l *recordingLogger) Enabled(level logging.Level) bool {
+	return l.debugEnabled && level == logging.DebugLevel
+}

--- a/pkg/transport/httpserver/middlewares.go
+++ b/pkg/transport/httpserver/middlewares.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/felixge/httpsnoop"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
@@ -14,6 +15,10 @@ type loggingResponseWriter struct {
 
 func NewLoggingResponseWriter(w http.ResponseWriter) *loggingResponseWriter {
 	return &loggingResponseWriter{w, http.StatusOK}
+}
+
+func (lrw *loggingResponseWriter) Unwrap() http.ResponseWriter {
+	return lrw.ResponseWriter
 }
 
 func (lrw *loggingResponseWriter) WriteHeader(statusCode int) {
@@ -28,12 +33,12 @@ func LoggerMiddleware(l logging.Logger) func(h http.Handler) http.Handler {
 			r = r.WithContext(logging.ContextWithLogger(r.Context(), l))
 			logger := logging.FromContext(r.Context())
 
-			rec := NewLoggingResponseWriter(w)
 			// copy
 			method := r.Method
 			path := r.URL.Path
 
-			h.ServeHTTP(rec, r)
+			metrics := httpsnoop.CaptureMetrics(h, w, r)
+			statusCode := metrics.Code
 			latency := time.Since(start)
 
 			logger = logger.WithFields(map[string]interface{}{
@@ -41,9 +46,9 @@ func LoggerMiddleware(l logging.Logger) func(h http.Handler) http.Handler {
 				"path":       path,
 				"latency":    latency,
 				"user_agent": r.UserAgent(),
-				"status":     rec.statusCode,
+				"status":     statusCode,
 			})
-			if rec.statusCode >= 400 {
+			if statusCode >= 400 {
 				logger.Error("Request")
 			} else {
 				logger.Info("Request")

--- a/pkg/transport/httpserver/otlp_middleware.go
+++ b/pkg/transport/httpserver/otlp_middleware.go
@@ -5,53 +5,196 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
+	"github.com/felixge/httpsnoop"
 	"github.com/riandyrn/otelchi"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	debugBodyAttributeLimit   = 64 * 1024
+	debugHeaderAttributeLimit = 8 * 1024
+	debugRedactedValue        = "[REDACTED]"
+)
+
 type responseWriter struct {
-	http.ResponseWriter
-	data        []byte
-	statusCode  int
-	captureBody bool
+	data          []byte
+	statusCode    int
+	captureBody   bool
+	bodyLimit     int
+	bodyTruncated bool
+	wroteHeader   bool
 }
 
-func (w *responseWriter) WriteHeader(code int) {
+func (w *responseWriter) wrap(writer http.ResponseWriter) http.ResponseWriter {
+	return httpsnoop.Wrap(writer, httpsnoop.Hooks{
+		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(code int) {
+				if w.writeHeader(code) {
+					next(code)
+				}
+			}
+		},
+		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(data []byte) (int, error) {
+				w.write()
+
+				n, err := next(data)
+				if w.captureBody && n > 0 {
+					w.capture(data[:n])
+				}
+				return n, err
+			}
+		},
+		Flush: func(next httpsnoop.FlushFunc) httpsnoop.FlushFunc {
+			return func() {
+				w.write()
+				next()
+			}
+		},
+		ReadFrom: func(next httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+			return func(src io.Reader) (int64, error) {
+				w.write()
+				if w.captureBody {
+					src = &captureReader{
+						reader:  src,
+						capture: w.capture,
+					}
+				}
+				return next(src)
+			}
+		},
+	})
+}
+
+func (w *responseWriter) writeHeader(code int) bool {
+	if code >= 100 && code <= 199 {
+		return true
+	}
+	if w.wroteHeader {
+		return false
+	}
+
+	w.wroteHeader = true
 	w.statusCode = code
-	if !w.captureBody {
-		w.ResponseWriter.WriteHeader(code)
+	return true
+}
+
+func (w *responseWriter) write() {
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		w.statusCode = http.StatusOK
 	}
 }
 
-func (w *responseWriter) Write(data []byte) (int, error) {
-	if !w.captureBody {
-		return w.ResponseWriter.Write(data)
+func (w *responseWriter) capture(data []byte) {
+	if len(data) == 0 {
+		return
 	}
+
+	remaining := w.bodyLimit - len(w.data)
+	if remaining <= 0 {
+		w.bodyTruncated = true
+		return
+	}
+
+	if len(data) > remaining {
+		w.data = append(w.data, data[:remaining]...)
+		w.bodyTruncated = true
+		return
+	}
+
 	w.data = append(w.data, data...)
-	return len(data), nil
 }
 
-func (w *responseWriter) finalize() {
-	if !w.captureBody {
-		return
+type captureReader struct {
+	reader  io.Reader
+	capture func([]byte)
+}
+
+func (r *captureReader) Read(data []byte) (int, error) {
+	n, err := r.reader.Read(data)
+	if n > 0 {
+		r.capture(data[:n])
 	}
-	if w.statusCode != 0 {
-		w.ResponseWriter.WriteHeader(w.statusCode)
-	}
-	if len(w.data) == 0 {
-		return
-	}
-	_, err := w.ResponseWriter.Write(w.data)
-	if err != nil {
-		panic(err)
-	}
+	return n, err
 }
 
 func isJSONContent(contentType string) bool {
 	return strings.Contains(strings.ToLower(contentType), "application/json")
+}
+
+func formatDebugHeaders(headers http.Header, limit int) (string, bool) {
+	names := make([]string, 0, len(headers))
+	for name := range headers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var builder strings.Builder
+	for _, name := range names {
+		value := strings.Join(headers[name], ", ")
+		if isSensitiveHeader(name) {
+			value = debugRedactedValue
+		}
+
+		part := fmt.Sprintf("%s: %s", name, value)
+		if builder.Len() > 0 {
+			part = "\n" + part
+		}
+		if appendLimitedString(&builder, part, limit) {
+			return builder.String(), true
+		}
+	}
+
+	return builder.String(), false
+}
+
+func isSensitiveHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "authorization", "cookie", "proxy-authorization", "set-cookie":
+		return true
+	default:
+		return false
+	}
+}
+
+func appendLimitedString(builder *strings.Builder, value string, limit int) bool {
+	remaining := limit - builder.Len()
+	if remaining <= 0 {
+		return len(value) > 0
+	}
+	if len(value) > remaining {
+		builder.WriteString(value[:remaining])
+		return true
+	}
+	builder.WriteString(value)
+	return false
+}
+
+type bodyReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func captureDebugBody(body io.ReadCloser, limit int) ([]byte, bool, io.ReadCloser, error) {
+	data, err := io.ReadAll(io.LimitReader(body, int64(limit)+1))
+	replacement := &bodyReadCloser{
+		Reader: io.MultiReader(bytes.NewReader(data), body),
+		Closer: body,
+	}
+	if err != nil {
+		return nil, false, replacement, err
+	}
+
+	if len(data) > limit {
+		return data[:limit], true, replacement, nil
+	}
+
+	return data, false, replacement, nil
 }
 
 func OTLPMiddleware(serverName string, debug bool) func(h http.Handler) http.Handler {
@@ -72,30 +215,43 @@ func OTLPMiddleware(serverName string, debug bool) func(h http.Handler) http.Han
 
 			if debug {
 				// Debug: request headers
-				headerParts := make([]string, 0, len(r.Header))
-				for name, values := range r.Header {
-					headerParts = append(headerParts, fmt.Sprintf("%s: %s", name, strings.Join(values, ", ")))
+				headers, truncated := formatDebugHeaders(r.Header, debugHeaderAttributeLimit)
+				span.SetAttributes(attribute.String("http.request.headers", headers))
+				if truncated {
+					span.SetAttributes(attribute.Bool("http.request.headers.truncated", true))
 				}
-				span.SetAttributes(attribute.String("http.request.headers", strings.Join(headerParts, "\n")))
 
 				// Debug: request body (JSON only)
 				if captureBody && r.Body != nil {
-					body, err := io.ReadAll(r.Body)
+					body, truncated, replacement, err := captureDebugBody(r.Body, debugBodyAttributeLimit)
+					r.Body = replacement
 					if err == nil {
 						span.SetAttributes(attribute.String("http.request.body", string(body)))
-						r.Body = io.NopCloser(bytes.NewReader(body))
+						if truncated {
+							span.SetAttributes(attribute.Bool("http.request.body.truncated", true))
+						}
 					}
 				}
 			}
 
-			rw := &responseWriter{
-				ResponseWriter: w,
-				data:           make([]byte, 0, 1024),
-				captureBody:    captureBody,
+			if !debug {
+				metrics := httpsnoop.Metrics{Code: http.StatusOK}
+				defer func() {
+					span.SetAttributes(attribute.Int("http.response.status_code", metrics.Code))
+				}()
+				metrics.CaptureMetrics(w, func(w http.ResponseWriter) {
+					h.ServeHTTP(w, r)
+				})
+				return
 			}
-			defer func() {
-				rw.finalize()
 
+			rw := &responseWriter{
+				data:        make([]byte, 0, 1024),
+				captureBody: captureBody,
+				bodyLimit:   debugBodyAttributeLimit,
+			}
+			ww := rw.wrap(w)
+			defer func() {
 				// Always log status code
 				statusCode := rw.statusCode
 				if statusCode == 0 {
@@ -105,20 +261,23 @@ func OTLPMiddleware(serverName string, debug bool) func(h http.Handler) http.Han
 
 				if debug {
 					// Debug: response headers
-					respHeaderParts := make([]string, 0, len(rw.Header()))
-					for name, values := range rw.Header() {
-						respHeaderParts = append(respHeaderParts, fmt.Sprintf("%s: %s", name, strings.Join(values, ", ")))
+					headers, truncated := formatDebugHeaders(ww.Header(), debugHeaderAttributeLimit)
+					span.SetAttributes(attribute.String("http.response.headers", headers))
+					if truncated {
+						span.SetAttributes(attribute.Bool("http.response.headers.truncated", true))
 					}
-					span.SetAttributes(attribute.String("http.response.headers", strings.Join(respHeaderParts, "\n")))
 
 					// Debug: response body (only if we captured it, i.e. JSON content)
 					if captureBody && len(rw.data) > 0 {
 						span.SetAttributes(attribute.String("http.response.body", string(rw.data)))
+						if rw.bodyTruncated {
+							span.SetAttributes(attribute.Bool("http.response.body.truncated", true))
+						}
 					}
 				}
 			}()
 
-			h.ServeHTTP(rw, r)
+			h.ServeHTTP(ww, r)
 		}))
 	}
 }

--- a/pkg/transport/httpserver/otlp_middleware_test.go
+++ b/pkg/transport/httpserver/otlp_middleware_test.go
@@ -1,0 +1,291 @@
+package httpserver
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestOTLPMiddlewareDebugRedactsAndCapsTraceAttributes(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	previousTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(tracerProvider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousTracerProvider)
+		require.NoError(t, tracerProvider.Shutdown(context.Background()))
+	})
+
+	requestBody := `{"body":"` + strings.Repeat("a", debugBodyAttributeLimit+128) + `"}`
+	responseBody := `{"body":"` + strings.Repeat("b", debugBodyAttributeLimit+128) + `"}`
+
+	handler := OTLPMiddleware("test-server", true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, requestBody, string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Set-Cookie", "session=secret")
+		w.Header().Set("X-Large-Response", strings.Repeat("r", debugHeaderAttributeLimit))
+		w.WriteHeader(http.StatusAccepted)
+		_, err = w.Write([]byte(responseBody))
+		require.NoError(t, err)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test?debug=true", strings.NewReader(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Cookie", "session=secret")
+	req.Header.Set("X-Debug", "visible")
+	req.Header.Set("X-Large", strings.Repeat("h", debugHeaderAttributeLimit))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	require.Equal(t, responseBody, rec.Body.String())
+
+	attrs := recordedSpanAttributes(t, spanRecorder)
+
+	requestHeaders := attrs["http.request.headers"].AsString()
+	require.LessOrEqual(t, len(requestHeaders), debugHeaderAttributeLimit)
+	require.Contains(t, requestHeaders, "Authorization: "+debugRedactedValue)
+	require.Contains(t, requestHeaders, "Cookie: "+debugRedactedValue)
+	require.Contains(t, requestHeaders, "X-Debug: visible")
+	require.NotContains(t, requestHeaders, "Bearer secret")
+	require.NotContains(t, requestHeaders, "session=secret")
+	require.True(t, attrs["http.request.headers.truncated"].AsBool())
+
+	responseHeaders := attrs["http.response.headers"].AsString()
+	require.LessOrEqual(t, len(responseHeaders), debugHeaderAttributeLimit)
+	require.Contains(t, responseHeaders, "Set-Cookie: "+debugRedactedValue)
+	require.NotContains(t, responseHeaders, "session=secret")
+	require.True(t, attrs["http.response.headers.truncated"].AsBool())
+
+	require.Equal(t, requestBody[:debugBodyAttributeLimit], attrs["http.request.body"].AsString())
+	require.True(t, attrs["http.request.body.truncated"].AsBool())
+	require.Equal(t, responseBody[:debugBodyAttributeLimit], attrs["http.response.body"].AsString())
+	require.True(t, attrs["http.response.body.truncated"].AsBool())
+}
+
+func TestOTLPMiddlewareDebugDoesNotPanicOnResponseWriteError(t *testing.T) {
+	handler := OTLPMiddleware("test-server", true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"ok":true}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	require.NotPanics(t, func() {
+		handler.ServeHTTP(&failingResponseWriter{header: make(http.Header)}, req)
+	})
+}
+
+func TestOTLPMiddlewarePreservesResponseWriterInterfaces(t *testing.T) {
+	for _, debug := range []bool{false, true} {
+		t.Run(debugName(debug), func(t *testing.T) {
+			base := newOptionalResponseWriter()
+			handler := OTLPMiddleware("test-server", debug)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertOptionalResponseWriterInterfaces(t, w)
+			}))
+
+			handler.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+			require.Equal(t, 1, base.flushes)
+			require.Equal(t, 1, base.pushes)
+			require.Equal(t, "/events", base.pushTarget)
+			require.Equal(t, 1, base.hijacks)
+			require.Equal(t, testWriteDeadline, base.writeDeadline)
+		})
+	}
+}
+
+func TestOTLPMiddlewareDoesNotAdvertiseUnsupportedResponseWriterInterfaces(t *testing.T) {
+	for _, debug := range []bool{false, true} {
+		t.Run(debugName(debug), func(t *testing.T) {
+			handler := OTLPMiddleware("test-server", debug)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertNoOptionalResponseWriterInterfaces(t, w)
+			}))
+
+			handler.ServeHTTP(newPlainResponseWriter(), httptest.NewRequest(http.MethodGet, "/test", nil))
+		})
+	}
+}
+
+func TestLoggerMiddlewarePreservesResponseWriterInterfaces(t *testing.T) {
+	base := newOptionalResponseWriter()
+	handler := LoggerMiddleware(logging.Testing())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertOptionalResponseWriterInterfaces(t, w)
+	}))
+
+	handler.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	require.Equal(t, 1, base.flushes)
+	require.Equal(t, 1, base.pushes)
+	require.Equal(t, "/events", base.pushTarget)
+	require.Equal(t, 1, base.hijacks)
+	require.Equal(t, testWriteDeadline, base.writeDeadline)
+}
+
+func TestLoggingResponseWriterUnwrapsForResponseController(t *testing.T) {
+	base := newOptionalResponseWriter()
+	controller := http.NewResponseController(NewLoggingResponseWriter(base))
+
+	require.NoError(t, controller.Flush())
+	require.NoError(t, controller.SetWriteDeadline(testWriteDeadline))
+
+	require.Equal(t, 1, base.flushes)
+	require.Equal(t, testWriteDeadline, base.writeDeadline)
+}
+
+func recordedSpanAttributes(t *testing.T, spanRecorder *tracetest.SpanRecorder) map[string]attribute.Value {
+	t.Helper()
+
+	for _, span := range spanRecorder.Ended() {
+		attrs := make(map[string]attribute.Value, len(span.Attributes()))
+		for _, attr := range span.Attributes() {
+			attrs[string(attr.Key)] = attr.Value
+		}
+		if _, ok := attrs["http.request.headers"]; ok {
+			return attrs
+		}
+	}
+
+	t.Fatalf("recorded span with OTLP debug attributes not found")
+	return nil
+}
+
+func debugName(debug bool) string {
+	if debug {
+		return "debug=true"
+	}
+	return "debug=false"
+}
+
+func assertOptionalResponseWriterInterfaces(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+
+	flusher, ok := w.(http.Flusher)
+	require.True(t, ok)
+	flusher.Flush()
+
+	pusher, ok := w.(http.Pusher)
+	require.True(t, ok)
+	require.NoError(t, pusher.Push("/events", nil))
+
+	require.NoError(t, http.NewResponseController(w).SetWriteDeadline(testWriteDeadline))
+
+	hijacker, ok := w.(http.Hijacker)
+	require.True(t, ok)
+	_, _, err := hijacker.Hijack()
+	require.ErrorIs(t, err, errTestHijack)
+}
+
+func assertNoOptionalResponseWriterInterfaces(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+
+	_, ok := w.(http.Flusher)
+	require.False(t, ok)
+	_, ok = w.(http.Hijacker)
+	require.False(t, ok)
+	_, ok = w.(http.Pusher)
+	require.False(t, ok)
+}
+
+var (
+	errTestHijack     = errors.New("test hijack")
+	testWriteDeadline = time.Unix(123, 0)
+)
+
+type optionalResponseWriter struct {
+	header        http.Header
+	flushes       int
+	hijacks       int
+	pushes        int
+	pushTarget    string
+	writeDeadline time.Time
+}
+
+func newOptionalResponseWriter() *optionalResponseWriter {
+	return &optionalResponseWriter{
+		header: make(http.Header),
+	}
+}
+
+func (w *optionalResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *optionalResponseWriter) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (w *optionalResponseWriter) WriteHeader(int) {}
+
+func (w *optionalResponseWriter) Flush() {
+	w.flushes++
+}
+
+func (w *optionalResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	w.hijacks++
+	return nil, nil, errTestHijack
+}
+
+func (w *optionalResponseWriter) Push(target string, _ *http.PushOptions) error {
+	w.pushes++
+	w.pushTarget = target
+	return nil
+}
+
+func (w *optionalResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	w.writeDeadline = deadline
+	return nil
+}
+
+type plainResponseWriter struct {
+	header http.Header
+}
+
+func newPlainResponseWriter() *plainResponseWriter {
+	return &plainResponseWriter{
+		header: make(http.Header),
+	}
+}
+
+func (w *plainResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *plainResponseWriter) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (w *plainResponseWriter) WriteHeader(int) {}
+
+type failingResponseWriter struct {
+	header http.Header
+}
+
+func (w *failingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingResponseWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func (w *failingResponseWriter) WriteHeader(int) {}

--- a/pkg/transport/httpserver/serverport.go
+++ b/pkg/transport/httpserver/serverport.go
@@ -38,6 +38,9 @@ func startServer(ctx context.Context, s *serverport.Server, handler http.Handler
 	srv := &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 	for _, option := range options {
 		option(srv)

--- a/pkg/transport/httpserver/serverport_test.go
+++ b/pkg/transport/httpserver/serverport_test.go
@@ -88,3 +88,31 @@ func TestStartServerGracefulShutdownDoesNotLogError(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	require.NotContains(t, buf.String(), "failed to serve")
 }
+
+func TestStartServerSetsDefaultTimeouts(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := serverport.NewServer(serverPortDiscr, serverport.WithListener(listener))
+	var configured http.Server
+
+	stop, err := startServer(
+		logging.TestingContext(),
+		server,
+		http.NewServeMux(),
+		func(server *http.Server) {
+			configured = *server
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = stop(context.Background())
+	})
+
+	require.Equal(t, 10*time.Second, configured.ReadHeaderTimeout)
+	require.Equal(t, 30*time.Second, configured.ReadTimeout)
+	require.Equal(t, 30*time.Second, configured.WriteTimeout)
+	require.Equal(t, 120*time.Second, configured.IdleTimeout)
+}

--- a/pkg/transport/serverport/serverport.go
+++ b/pkg/transport/serverport/serverport.go
@@ -51,7 +51,11 @@ func StartedServer(ctx context.Context, listener net.Listener, discr string) {
 
 	si.address = listener.Addr().String()
 
-	close(si.started)
+	select {
+	case <-si.started:
+	default:
+		close(si.started)
+	}
 }
 
 type Server struct {

--- a/pkg/transport/serverport/serverport_test.go
+++ b/pkg/transport/serverport/serverport_test.go
@@ -1,0 +1,32 @@
+package serverport
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartedServerCanBeCalledMoreThanOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := ContextWithServerInfo(context.Background(), "test")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	require.NotPanics(t, func() {
+		StartedServer(ctx, listener, "test")
+		StartedServer(ctx, listener, "test")
+	})
+
+	select {
+	case <-Started(ctx, "test"):
+	default:
+		t.Fatal("server start channel was not closed")
+	}
+	require.Equal(t, listener.Addr().String(), Address(ctx, "test"))
+}

--- a/pkg/types/collections/linked_list.go
+++ b/pkg/types/collections/linked_list.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"reflect"
 	"sync"
 )
 
@@ -19,6 +20,13 @@ func (n *LinkedListNode[T]) Value() T {
 }
 
 func (n *LinkedListNode[T]) Remove() {
+	n.list.mu.Lock()
+	defer n.list.mu.Unlock()
+
+	n.remove()
+}
+
+func (n *LinkedListNode[T]) remove() {
 	if n.previousNode != nil {
 		n.previousNode.nextNode = n.nextNode
 	}
@@ -67,7 +75,7 @@ func (r *LinkedList[T]) RemoveFirst(cmp func(T) bool) *LinkedListNode[T] {
 	node := r.firstNode
 	for node != nil {
 		if cmp(node.object) {
-			node.Remove()
+			node.remove()
 			return node
 		}
 		node = node.nextNode
@@ -78,11 +86,14 @@ func (r *LinkedList[T]) RemoveFirst(cmp func(T) bool) *LinkedListNode[T] {
 
 func (r *LinkedList[T]) RemoveValue(t T) *LinkedListNode[T] {
 	return r.RemoveFirst(func(t2 T) bool {
-		return (any)(t) == (any)(t2)
+		return comparableEqual(t, t2)
 	})
 }
 
 func (r *LinkedList[T]) TakeFirst() T {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	var t T
 	if r.firstNode == nil {
 		return t
@@ -90,6 +101,7 @@ func (r *LinkedList[T]) TakeFirst() T {
 	ret := r.firstNode.object
 	if r.firstNode.nextNode == nil {
 		r.firstNode = nil
+		r.lastNode = nil
 	} else {
 		r.firstNode = r.firstNode.nextNode
 		r.firstNode.previousNode = nil
@@ -124,6 +136,9 @@ func (r *LinkedList[T]) ForEach(f func(t T)) {
 }
 
 func (r *LinkedList[T]) Slice() []T {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	ret := make([]T, 0)
 	node := r.firstNode
 	for node != nil {
@@ -134,9 +149,34 @@ func (r *LinkedList[T]) Slice() []T {
 }
 
 func (r *LinkedList[T]) FirstNode() *LinkedListNode[T] {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	return r.firstNode
 }
 
 func NewLinkedList[T any]() *LinkedList[T] {
 	return &LinkedList[T]{}
+}
+
+func comparableEqual[T any](a, b T) (equal bool) {
+	aAny := any(a)
+	bAny := any(b)
+
+	aType := reflect.TypeOf(aAny)
+	bType := reflect.TypeOf(bAny)
+	if aType == nil || bType == nil {
+		return aType == bType
+	}
+	if aType != bType || !aType.Comparable() {
+		return false
+	}
+
+	defer func() {
+		if recover() != nil {
+			equal = false
+		}
+	}()
+
+	return aAny == bAny
 }

--- a/pkg/types/collections/linked_list_internal_test.go
+++ b/pkg/types/collections/linked_list_internal_test.go
@@ -1,0 +1,17 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinkedListTakeFirstClearsLastNodeWhenListBecomesEmpty(t *testing.T) {
+	t.Parallel()
+	list := NewLinkedList[int]()
+	list.Append(1)
+
+	require.Equal(t, 1, list.TakeFirst())
+	require.Nil(t, list.firstNode)
+	require.Nil(t, list.lastNode)
+}

--- a/pkg/types/collections/linked_list_test.go
+++ b/pkg/types/collections/linked_list_test.go
@@ -118,6 +118,43 @@ func TestLinkedList(t *testing.T) {
 		require.Equal(t, 4, list.Length())
 	})
 
+	t.Run("RemoveValueNonComparable", func(t *testing.T) {
+		t.Parallel()
+		list := collectionutils.NewLinkedList[[]int]()
+		list.Append([]int{1}, []int{2})
+
+		require.NotPanics(t, func() {
+			node := list.RemoveValue([]int{1})
+			require.Nil(t, node)
+		})
+		require.Equal(t, [][]int{{1}, {2}}, list.Slice())
+
+		interfaceList := collectionutils.NewLinkedList[any]()
+		interfaceList.Append([]int{1}, "match")
+
+		require.NotPanics(t, func() {
+			node := interfaceList.RemoveValue([]int{1})
+			require.Nil(t, node)
+		})
+
+		node := interfaceList.RemoveValue("match")
+		require.NotNil(t, node)
+		require.Equal(t, "match", node.Value())
+		require.Equal(t, []any{[]int{1}}, interfaceList.Slice())
+
+		type interfaceField struct {
+			value any
+		}
+		structList := collectionutils.NewLinkedList[interfaceField]()
+		structList.Append(interfaceField{value: []int{1}})
+
+		require.NotPanics(t, func() {
+			node := structList.RemoveValue(interfaceField{value: []int{1}})
+			require.Nil(t, node)
+		})
+		require.Equal(t, []interfaceField{{value: []int{1}}}, structList.Slice())
+	})
+
 	t.Run("TakeFirst", func(t *testing.T) {
 		t.Parallel()
 		list := collectionutils.NewLinkedList[int]()
@@ -303,5 +340,36 @@ func TestLinkedList(t *testing.T) {
 		// Sum should be 10 * sum of numbers from 0 to 99
 		expectedSum := 10 * (99 * 100 / 2)
 		require.Equal(t, expectedSum, sum)
+	})
+
+	t.Run("ConcurrentTakeFirstSliceAndFirstNode", func(t *testing.T) {
+		t.Parallel()
+		list := collectionutils.NewLinkedList[int]()
+		list.Append(1, 2, 3, 4, 5)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func(base int) {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					list.Append(base*1000 + j)
+					_ = list.TakeFirst()
+				}
+			}(i)
+		}
+
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					_ = list.Slice()
+					_ = list.FirstNode()
+				}
+			}()
+		}
+
+		wg.Wait()
 	})
 }

--- a/pkg/types/time/time.go
+++ b/pkg/types/time/time.go
@@ -45,18 +45,24 @@ func New(t time.Time) Time {
 func (t *Time) Scan(src interface{}) (err error) {
 	switch src := src.(type) {
 	case time.Time:
-		*t = Time{
-			Time: src.UTC(),
-		}
+		*t = New(src)
 		return nil
 	case string:
 		*t = Time{}
-		t.Time, err = time.ParseInLocation(DateFormat, src, time.UTC)
-		return err
+		parsed, err := ParseTime(src)
+		if err != nil {
+			return err
+		}
+		*t = parsed
+		return nil
 	case []byte:
 		*t = Time{}
-		t.Time, err = time.ParseInLocation(DateFormat, string(src), time.UTC)
-		return err
+		parsed, err := ParseTime(string(src))
+		if err != nil {
+			return err
+		}
+		*t = parsed
+		return nil
 	case nil:
 		*t = Time{}
 		t.Time = time.Time{}
@@ -109,7 +115,7 @@ func (t Time) MarshalJSON() ([]byte, error) {
 }
 
 func (t *Time) UnmarshalJSON(data []byte) error {
-	if len(data) == 0 {
+	if len(data) == 0 || string(data) == "null" {
 		*t = Time{}
 		return nil
 	}

--- a/pkg/types/time/time_test.go
+++ b/pkg/types/time/time_test.go
@@ -28,8 +28,8 @@ func TestScan(t *testing.T) {
 	}{
 		{
 			name:     "time.Time",
-			input:    time.Date(2023, 1, 2, 3, 4, 5, 6, time.FixedZone("UTC+2", 2*60*60)),
-			expected: time.Date(2023, 1, 2, 1, 4, 5, 6, time.UTC), // 3:04:05 UTC+2 -> 1:04:05 UTC
+			input:    time.Date(2023, 1, 2, 3, 4, 5, 1600, time.FixedZone("UTC+2", 2*60*60)),
+			expected: time.Date(2023, 1, 2, 1, 4, 5, 2000, time.UTC), // 3:04:05 UTC+2 -> 1:04:05 UTC, rounded to microsecond
 		},
 		{
 			name:     "string",
@@ -40,6 +40,11 @@ func TestScan(t *testing.T) {
 			name:     "[]byte",
 			input:    []byte("2023-01-02T03:04:05.000006Z"),
 			expected: time.Date(2023, 1, 2, 3, 4, 5, 6000, time.UTC),
+		},
+		{
+			name:     "string rounded to precision",
+			input:    "2023-01-02T03:04:05.0000066Z",
+			expected: time.Date(2023, 1, 2, 3, 4, 5, 7000, time.UTC),
 		},
 		{
 			name:     "nil",
@@ -169,6 +174,11 @@ func TestUnmarshalJSON(t *testing.T) {
 			name:        "invalid date",
 			input:       `"not-a-date"`,
 			expectError: true,
+		},
+		{
+			name:     "null",
+			input:    `null`,
+			expected: time.Time{},
 		},
 		// Empty string case is handled differently in the implementation
 		// The test for this case is removed as it's causing issues

--- a/pkg/workflow/temporal/client.go
+++ b/pkg/workflow/temporal/client.go
@@ -100,7 +100,7 @@ func CreateSearchAttributes(ctx context.Context, c client.Client, namespace stri
 			Namespace: namespace,
 		})
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("list temporal search attributes: %w", err)
 		}
 
 		done := true

--- a/pkg/workflow/temporal/client_test.go
+++ b/pkg/workflow/temporal/client_test.go
@@ -1,0 +1,87 @@
+package temporal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/operatorservice/v1"
+	temporalmocks "go.temporal.io/sdk/mocks"
+	"google.golang.org/grpc"
+)
+
+func TestCreateSearchAttributesReturnsListSearchAttributesError(t *testing.T) {
+	t.Parallel()
+
+	operator := &fakeOperatorService{
+		listErr: errors.New("temporarily unavailable"),
+	}
+	c := &temporalmocks.Client{}
+	c.On("OperatorService").Return(operator)
+
+	err := CreateSearchAttributes(context.Background(), c, "default", map[string]enums.IndexedValueType{
+		"CustomKeyword": enums.INDEXED_VALUE_TYPE_KEYWORD,
+	})
+
+	require.ErrorContains(t, err, "list temporal search attributes")
+	require.ErrorContains(t, err, "temporarily unavailable")
+}
+
+type fakeOperatorService struct {
+	addErr  error
+	listErr error
+	listRsp *operatorservice.ListSearchAttributesResponse
+}
+
+func (f *fakeOperatorService) AddSearchAttributes(context.Context, *operatorservice.AddSearchAttributesRequest, ...grpc.CallOption) (*operatorservice.AddSearchAttributesResponse, error) {
+	return &operatorservice.AddSearchAttributesResponse{}, f.addErr
+}
+
+func (f *fakeOperatorService) RemoveSearchAttributes(context.Context, *operatorservice.RemoveSearchAttributesRequest, ...grpc.CallOption) (*operatorservice.RemoveSearchAttributesResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) ListSearchAttributes(context.Context, *operatorservice.ListSearchAttributesRequest, ...grpc.CallOption) (*operatorservice.ListSearchAttributesResponse, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listRsp, nil
+}
+
+func (f *fakeOperatorService) DeleteNamespace(context.Context, *operatorservice.DeleteNamespaceRequest, ...grpc.CallOption) (*operatorservice.DeleteNamespaceResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) AddOrUpdateRemoteCluster(context.Context, *operatorservice.AddOrUpdateRemoteClusterRequest, ...grpc.CallOption) (*operatorservice.AddOrUpdateRemoteClusterResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) RemoveRemoteCluster(context.Context, *operatorservice.RemoveRemoteClusterRequest, ...grpc.CallOption) (*operatorservice.RemoveRemoteClusterResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) ListClusters(context.Context, *operatorservice.ListClustersRequest, ...grpc.CallOption) (*operatorservice.ListClustersResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) GetNexusEndpoint(context.Context, *operatorservice.GetNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.GetNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) CreateNexusEndpoint(context.Context, *operatorservice.CreateNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.CreateNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) UpdateNexusEndpoint(context.Context, *operatorservice.UpdateNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.UpdateNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) DeleteNexusEndpoint(context.Context, *operatorservice.DeleteNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.DeleteNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) ListNexusEndpoints(context.Context, *operatorservice.ListNexusEndpointsRequest, ...grpc.CallOption) (*operatorservice.ListNexusEndpointsResponse, error) {
+	return nil, errors.New("not implemented")
+}

--- a/pkg/workflow/temporal/logger.go
+++ b/pkg/workflow/temporal/logger.go
@@ -1,6 +1,8 @@
 package temporal
 
 import (
+	"fmt"
+
 	"go.temporal.io/sdk/log"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -8,14 +10,18 @@ import (
 
 func keyvalsToMap(keyvals ...interface{}) map[string]any {
 	ret := make(map[string]any)
-	for i := 0; i < len(keyvals); i += 2 {
-		ret[keyvals[i].(string)] = keyvals[i+1]
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		ret[fmt.Sprint(keyvals[i])] = keyvals[i+1]
 	}
 	return ret
 }
 
 type logger struct {
 	logger logging.Logger
+}
+
+type warnLogger interface {
+	Warnf(format string, args ...any)
 }
 
 func (l logger) Debug(msg string, keyvals ...interface{}) {
@@ -27,7 +33,12 @@ func (l logger) Info(msg string, keyvals ...interface{}) {
 }
 
 func (l logger) Warn(msg string, keyvals ...interface{}) {
-	l.logger.WithFields(keyvalsToMap(keyvals...)).Errorf(msg)
+	logger := l.logger.WithFields(keyvalsToMap(keyvals...))
+	if warnLogger, ok := logger.(warnLogger); ok {
+		warnLogger.Warnf(msg)
+		return
+	}
+	logger.Infof(msg)
 }
 
 func (l logger) Error(msg string, keyvals ...interface{}) {

--- a/pkg/workflow/temporal/logger_test.go
+++ b/pkg/workflow/temporal/logger_test.go
@@ -1,0 +1,142 @@
+package temporal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestKeyvalsToMapHandlesOddAndNonStringKeys(t *testing.T) {
+	t.Parallel()
+
+	var got map[string]any
+	require.NotPanics(t, func() {
+		got = keyvalsToMap("workflow", "payment", 42, "answer", "dangling")
+	})
+
+	require.Equal(t, map[string]any{
+		"workflow": "payment",
+		"42":       "answer",
+	}, got)
+}
+
+func TestLoggerWarnUsesWarnLevel(t *testing.T) {
+	t.Parallel()
+
+	recorder := newRecordingLogger()
+
+	newLogger(recorder).Warn("temporal warning", "attempt", 3)
+
+	require.Len(t, recorder.state.entries, 1)
+	require.Equal(t, recordedLogEntry{
+		level:  "warn",
+		msg:    "temporal warning",
+		fields: map[string]any{"attempt": 3},
+	}, recorder.state.entries[0])
+}
+
+type recordedLogEntry struct {
+	level  string
+	msg    string
+	fields map[string]any
+}
+
+type recordingLoggerState struct {
+	entries []recordedLogEntry
+}
+
+type recordingLogger struct {
+	state  *recordingLoggerState
+	fields map[string]any
+}
+
+func newRecordingLogger() *recordingLogger {
+	return &recordingLogger{
+		state:  &recordingLoggerState{},
+		fields: map[string]any{},
+	}
+}
+
+func (l *recordingLogger) Tracef(format string, args ...any) {
+	l.record("trace", fmt.Sprintf(format, args...))
+}
+
+func (l *recordingLogger) Debugf(format string, args ...any) {
+	l.record("debug", fmt.Sprintf(format, args...))
+}
+
+func (l *recordingLogger) Infof(format string, args ...any) {
+	l.record("info", fmt.Sprintf(format, args...))
+}
+
+func (l *recordingLogger) Warnf(format string, args ...any) {
+	l.record("warn", fmt.Sprintf(format, args...))
+}
+
+func (l *recordingLogger) Errorf(format string, args ...any) {
+	l.record("error", fmt.Sprintf(format, args...))
+}
+
+func (l *recordingLogger) Trace(args ...any) {
+	l.record("trace", fmt.Sprint(args...))
+}
+
+func (l *recordingLogger) Debug(args ...any) {
+	l.record("debug", fmt.Sprint(args...))
+}
+
+func (l *recordingLogger) Info(args ...any) {
+	l.record("info", fmt.Sprint(args...))
+}
+
+func (l *recordingLogger) Error(args ...any) {
+	l.record("error", fmt.Sprint(args...))
+}
+
+func (l *recordingLogger) WithFields(fields map[string]any) logging.Logger {
+	merged := l.cloneFields()
+	for key, value := range fields {
+		merged[key] = value
+	}
+	return &recordingLogger{
+		state:  l.state,
+		fields: merged,
+	}
+}
+
+func (l *recordingLogger) WithField(key string, value any) logging.Logger {
+	return l.WithFields(map[string]any{key: value})
+}
+
+func (l *recordingLogger) WithContext(context.Context) logging.Logger {
+	return l
+}
+
+func (l *recordingLogger) Writer() io.Writer {
+	return io.Discard
+}
+
+func (l *recordingLogger) Enabled(logging.Level) bool {
+	return true
+}
+
+func (l *recordingLogger) record(level, msg string) {
+	l.state.entries = append(l.state.entries, recordedLogEntry{
+		level:  level,
+		msg:    msg,
+		fields: l.cloneFields(),
+	})
+}
+
+func (l *recordingLogger) cloneFields() map[string]any {
+	fields := make(map[string]any, len(l.fields))
+	for key, value := range l.fields {
+		fields[key] = value
+	}
+	return fields
+}


### PR DESCRIPTION
## Summary

Remediates the EN-1136 go-libs backlog findings across authn, audit, messaging, storage, transport, observability, workflow, collections, and CI.

Highlights:
- Validate OIDC discovery issuer and JWT `nbf`, and tighten bearer parsing.
- Redact/cap audited and traced HTTP data, avoid credential leaks, and preserve response-writer optional interfaces.
- Fix shutdown/lifecycle hazards in licence checks, queues, circuit breaker, health checks, gRPC, migrations, Temporal workers, and started servers.
- Replace several hot-path panics with returned/logged errors.
- Fix IAM DSN/token handling, CI permissions, Fx runtime metrics option injection, Temporal logging keyvals, linked list locking, selected LOW findings, and add focused regression tests.

## Validation

- `go mod tidy`
- `go generate ./...`
- `gofmt` on modified Go files
- `git diff --check`
- `go test ./...`

`golangci-lint run --fix --build-tags it --timeout 5m` could not complete because the installed golangci-lint binary is built with Go 1.25 and panics on files requiring Go 1.26; local `go version` is `go1.26.1 darwin/arm64` and `go test ./...` passes.

## Notes

EN-1196 was handled for the low-risk LOW subitems only; broader deferred/testing and heavily-coupled low-severity items were intentionally left out rather than making risky cross-cutting changes in this PR.