### PR TITLE
fix(oidc): validate discovery issuer (EN-1167)

### DIFF
--- a/pkg/authn/jwt/module_test.go
+++ b/pkg/authn/jwt/module_test.go
@@ -30,10 +30,11 @@ func setupTestOIDCServer(t *testing.T) (*httptest.Server, string, chan bool) {
 	// Discovery endpoint
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		discoveryCalled <- true
+		issuer := "http://" + r.Host
 
 		config := oidc.DiscoveryConfiguration{
-			Issuer:  r.URL.Scheme + "://" + r.Host,
-			JwksURI: r.URL.Scheme + "://" + r.Host + "/.well-known/jwks.json",
+			Issuer:  issuer,
+			JwksURI: issuer + "/.well-known/jwks.json",
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/authn/oidc/client/discover.go
+++ b/pkg/authn/oidc/client/discover.go
@@ -3,23 +3,17 @@ package client
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
 	httphelper "github.com/formancehq/go-libs/v5/pkg/authn/oidc/http"
 )
 
-type issuerGetter interface {
-	GetIssuer() string
-}
-
 // Discover calls the discovery endpoint of the provided issuer and returns its configuration
 // It accepts an optional argument "wellknownUrl" which can be used to override the discovery endpoint url
 func Discover[V any](ctx context.Context, issuer string, httpClient *http.Client, wellKnownUrl ...string) (*V, error) {
 
-	wellKnown := strings.TrimSuffix(issuer, "/") + oidc.DiscoveryEndpoint
+	wellKnown := oidc.NormalizeIssuer(issuer) + oidc.DiscoveryEndpoint
 	if len(wellKnownUrl) == 1 && wellKnownUrl[0] != "" {
 		wellKnown = wellKnownUrl[0]
 	}
@@ -40,13 +34,9 @@ func Discover[V any](ctx context.Context, issuer string, httpClient *http.Client
 }
 
 func validateDiscoveredIssuer[V any](issuer string, discoveryConfig *V) error {
-	issuerConfig, ok := any(discoveryConfig).(issuerGetter)
+	issuerConfig, ok := any(discoveryConfig).(oidc.IssuerGetter)
 	if !ok {
 		return nil
 	}
-	discoveredIssuer := issuerConfig.GetIssuer()
-	if discoveredIssuer != issuer {
-		return fmt.Errorf("%w: Expected: %s, got: %s", oidc.ErrIssuerInvalid, issuer, discoveredIssuer)
-	}
-	return nil
+	return oidc.CheckDiscoveredIssuer(issuer, issuerConfig)
 }

--- a/pkg/authn/oidc/client/discover.go
+++ b/pkg/authn/oidc/client/discover.go
@@ -3,12 +3,17 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
 	httphelper "github.com/formancehq/go-libs/v5/pkg/authn/oidc/http"
 )
+
+type issuerGetter interface {
+	GetIssuer() string
+}
 
 // Discover calls the discovery endpoint of the provided issuer and returns its configuration
 // It accepts an optional argument "wellknownUrl" which can be used to override the discovery endpoint url
@@ -27,6 +32,21 @@ func Discover[V any](ctx context.Context, issuer string, httpClient *http.Client
 	if err != nil {
 		return nil, errors.Join(oidc.ErrDiscoveryFailed, err)
 	}
+	if err := validateDiscoveredIssuer(issuer, discoveryConfig); err != nil {
+		return nil, errors.Join(oidc.ErrDiscoveryFailed, err)
+	}
 
 	return discoveryConfig, nil
+}
+
+func validateDiscoveredIssuer[V any](issuer string, discoveryConfig *V) error {
+	issuerConfig, ok := any(discoveryConfig).(issuerGetter)
+	if !ok {
+		return nil
+	}
+	discoveredIssuer := issuerConfig.GetIssuer()
+	if discoveredIssuer != issuer {
+		return fmt.Errorf("%w: Expected: %s, got: %s", oidc.ErrIssuerInvalid, issuer, discoveredIssuer)
+	}
+	return nil
 }

--- a/pkg/authn/oidc/client/discover_test.go
+++ b/pkg/authn/oidc/client/discover_test.go
@@ -33,11 +33,11 @@ func TestDiscoverValidatesIssuer(t *testing.T) {
 		require.Equal(t, issuer, discoveryConfig.Issuer)
 	})
 
-	t.Run("normalizes trailing slash before validating issuer", func(t *testing.T) {
+	t.Run("preserves trailing slash when validating issuer", func(t *testing.T) {
 		t.Parallel()
 
 		issuer := "https://issuer.example.com/"
-		discoveredIssuer := "https://issuer.example.com"
+		discoveredIssuer := issuer
 		server := httptest.NewServer(discoveryHandler(t, discoveredIssuer))
 		t.Cleanup(server.Close)
 

--- a/pkg/authn/oidc/client/discover_test.go
+++ b/pkg/authn/oidc/client/discover_test.go
@@ -33,6 +33,25 @@ func TestDiscoverValidatesIssuer(t *testing.T) {
 		require.Equal(t, issuer, discoveryConfig.Issuer)
 	})
 
+	t.Run("normalizes trailing slash before validating issuer", func(t *testing.T) {
+		t.Parallel()
+
+		issuer := "https://issuer.example.com/"
+		discoveredIssuer := "https://issuer.example.com"
+		server := httptest.NewServer(discoveryHandler(t, discoveredIssuer))
+		t.Cleanup(server.Close)
+
+		discoveryConfig, err := Discover[oidc.DiscoveryConfiguration](
+			context.Background(),
+			issuer,
+			server.Client(),
+			server.URL,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, discoveredIssuer, discoveryConfig.Issuer)
+	})
+
 	t.Run("rejects discovery configuration when issuer differs", func(t *testing.T) {
 		t.Parallel()
 
@@ -64,6 +83,8 @@ func discoveryHandler(t *testing.T, issuer string) http.Handler {
 			Issuer:  issuer,
 			JwksURI: issuer + "/.well-known/jwks.json",
 		})
-		require.NoError(t, err)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 	})
 }

--- a/pkg/authn/oidc/client/discover_test.go
+++ b/pkg/authn/oidc/client/discover_test.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
+)
+
+func TestDiscoverValidatesIssuer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns discovery configuration when issuer matches", func(t *testing.T) {
+		t.Parallel()
+
+		issuer := "https://issuer.example.com"
+		server := httptest.NewServer(discoveryHandler(t, issuer))
+		t.Cleanup(server.Close)
+
+		discoveryConfig, err := Discover[oidc.DiscoveryConfiguration](
+			context.Background(),
+			issuer,
+			server.Client(),
+			server.URL,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, issuer, discoveryConfig.Issuer)
+	})
+
+	t.Run("rejects discovery configuration when issuer differs", func(t *testing.T) {
+		t.Parallel()
+
+		issuer := "https://issuer.example.com"
+		discoveredIssuer := "https://other-issuer.example.com"
+		server := httptest.NewServer(discoveryHandler(t, discoveredIssuer))
+		t.Cleanup(server.Close)
+
+		discoveryConfig, err := Discover[oidc.DiscoveryConfiguration](
+			context.Background(),
+			issuer,
+			server.Client(),
+			server.URL,
+		)
+
+		require.Nil(t, discoveryConfig)
+		require.ErrorIs(t, err, oidc.ErrDiscoveryFailed)
+		require.ErrorIs(t, err, oidc.ErrIssuerInvalid)
+		require.ErrorContains(t, err, "Expected: "+issuer+", got: "+discoveredIssuer)
+	})
+}
+
+func discoveryHandler(t *testing.T, issuer string) http.Handler {
+	t.Helper()
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(oidc.DiscoveryConfiguration{
+			Issuer:  issuer,
+			JwksURI: issuer + "/.well-known/jwks.json",
+		})
+		require.NoError(t, err)
+	})
+}

--- a/pkg/authn/oidc/discovery.go
+++ b/pkg/authn/oidc/discovery.go
@@ -180,7 +180,7 @@ func NormalizeIssuer(issuer string) string {
 }
 
 func CheckDiscoveredIssuer(issuer string, discovered IssuerGetter) error {
-	expectedIssuer := NormalizeIssuer(issuer)
+	expectedIssuer := issuer
 	discoveredIssuer := discovered.GetIssuer()
 	if discoveredIssuer != expectedIssuer {
 		return fmt.Errorf("%w: Expected: %s, got: %s", ErrIssuerInvalid, expectedIssuer, discoveredIssuer)

--- a/pkg/authn/oidc/discovery.go
+++ b/pkg/authn/oidc/discovery.go
@@ -181,9 +181,9 @@ func NormalizeIssuer(issuer string) string {
 
 func CheckDiscoveredIssuer(issuer string, discovered IssuerGetter) error {
 	expectedIssuer := NormalizeIssuer(issuer)
-	discoveredIssuer := NormalizeIssuer(discovered.GetIssuer())
+	discoveredIssuer := discovered.GetIssuer()
 	if discoveredIssuer != expectedIssuer {
-		return fmt.Errorf("%w: Expected: %s, got: %s", ErrIssuerInvalid, expectedIssuer, discovered.GetIssuer())
+		return fmt.Errorf("%w: Expected: %s, got: %s", ErrIssuerInvalid, expectedIssuer, discoveredIssuer)
 	}
 	return nil
 }

--- a/pkg/authn/oidc/discovery.go
+++ b/pkg/authn/oidc/discovery.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 )
 
 const (
@@ -169,6 +171,23 @@ func (d *DiscoveryConfiguration) GetIssuer() string {
 	return d.Issuer
 }
 
+type IssuerGetter interface {
+	GetIssuer() string
+}
+
+func NormalizeIssuer(issuer string) string {
+	return strings.TrimRight(issuer, "/")
+}
+
+func CheckDiscoveredIssuer(issuer string, discovered IssuerGetter) error {
+	expectedIssuer := NormalizeIssuer(issuer)
+	discoveredIssuer := NormalizeIssuer(discovered.GetIssuer())
+	if discoveredIssuer != expectedIssuer {
+		return fmt.Errorf("%w: Expected: %s, got: %s", ErrIssuerInvalid, expectedIssuer, discovered.GetIssuer())
+	}
+	return nil
+}
+
 type AuthMethod string
 
 const (
@@ -179,7 +198,7 @@ const (
 )
 
 func Discover(ctx context.Context, issuer, discoveryPath string) (*DiscoveryConfiguration, error) {
-	discoveryURL := issuer + discoveryPath
+	discoveryURL := NormalizeIssuer(issuer) + discoveryPath
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
 	if err != nil {
@@ -200,6 +219,9 @@ func Discover(ctx context.Context, issuer, discoveryPath string) (*DiscoveryConf
 	}
 
 	if err := json.NewDecoder(rsp.Body).Decode(discoveryConfig); err != nil {
+		return nil, errors.Join(ErrDiscoveryFailed, err)
+	}
+	if err := CheckDiscoveredIssuer(issuer, discoveryConfig); err != nil {
 		return nil, errors.Join(ErrDiscoveryFailed, err)
 	}
 

--- a/pkg/authn/oidc/discovery.go
+++ b/pkg/authn/oidc/discovery.go
@@ -162,6 +162,13 @@ type DiscoveryConfiguration struct {
 	BackChannelLogoutSessionSupported bool `json:"backchannel_logout_session_supported,omitempty"`
 }
 
+func (d *DiscoveryConfiguration) GetIssuer() string {
+	if d == nil {
+		return ""
+	}
+	return d.Issuer
+}
+
 type AuthMethod string
 
 const (

--- a/pkg/authn/oidc/discovery_test.go
+++ b/pkg/authn/oidc/discovery_test.go
@@ -41,6 +41,22 @@ func TestDiscoverValidatesIssuer(t *testing.T) {
 		require.ErrorIs(t, err, ErrIssuerInvalid)
 		require.ErrorContains(t, err, "Expected: "+server.URL+", got: "+discoveredIssuer)
 	})
+
+	t.Run("rejects discovery issuer that only matches after trimming", func(t *testing.T) {
+		t.Parallel()
+
+		var discoveredIssuer string
+		server := httptest.NewServer(discoveryConfigurationHandler(&discoveredIssuer))
+		t.Cleanup(server.Close)
+		discoveredIssuer = server.URL + "/"
+
+		discoveryConfig, err := Discover(context.Background(), server.URL, DiscoveryEndpoint)
+
+		require.Nil(t, discoveryConfig)
+		require.ErrorIs(t, err, ErrDiscoveryFailed)
+		require.ErrorIs(t, err, ErrIssuerInvalid)
+		require.ErrorContains(t, err, "Expected: "+server.URL+", got: "+discoveredIssuer)
+	})
 }
 
 func discoveryConfigurationHandler(issuer *string) http.Handler {

--- a/pkg/authn/oidc/discovery_test.go
+++ b/pkg/authn/oidc/discovery_test.go
@@ -1,0 +1,57 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverValidatesIssuer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns discovery configuration when issuer matches", func(t *testing.T) {
+		t.Parallel()
+
+		var discoveredIssuer string
+		server := httptest.NewServer(discoveryConfigurationHandler(&discoveredIssuer))
+		t.Cleanup(server.Close)
+		discoveredIssuer = server.URL
+
+		discoveryConfig, err := Discover(context.Background(), server.URL+"/", DiscoveryEndpoint)
+
+		require.NoError(t, err)
+		require.Equal(t, discoveredIssuer, discoveryConfig.Issuer)
+	})
+
+	t.Run("rejects discovery configuration when issuer differs", func(t *testing.T) {
+		t.Parallel()
+
+		discoveredIssuer := "https://other-issuer.example.com"
+		server := httptest.NewServer(discoveryConfigurationHandler(&discoveredIssuer))
+		t.Cleanup(server.Close)
+
+		discoveryConfig, err := Discover(context.Background(), server.URL, DiscoveryEndpoint)
+
+		require.Nil(t, discoveryConfig)
+		require.ErrorIs(t, err, ErrDiscoveryFailed)
+		require.ErrorIs(t, err, ErrIssuerInvalid)
+		require.ErrorContains(t, err, "Expected: "+server.URL+", got: "+discoveredIssuer)
+	})
+}
+
+func discoveryConfigurationHandler(issuer *string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(DiscoveryConfiguration{
+			Issuer:  *issuer,
+			JwksURI: *issuer + "/.well-known/jwks.json",
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+}

--- a/pkg/authn/oidc/discovery_test.go
+++ b/pkg/authn/oidc/discovery_test.go
@@ -19,7 +19,7 @@ func TestDiscoverValidatesIssuer(t *testing.T) {
 		var discoveredIssuer string
 		server := httptest.NewServer(discoveryConfigurationHandler(&discoveredIssuer))
 		t.Cleanup(server.Close)
-		discoveredIssuer = server.URL
+		discoveredIssuer = server.URL + "/"
 
 		discoveryConfig, err := Discover(context.Background(), server.URL+"/", DiscoveryEndpoint)
 


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1167` from EN-1136.

This PR contains the scoped change: Validate OIDC discovery issuer.

Stack base: `main`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
