### PR TITLE
fix(jwt): validate not-before claims (EN-1170)

### DIFF
--- a/pkg/authn/jwt/auth.go
+++ b/pkg/authn/jwt/auth.go
@@ -129,5 +129,9 @@ func ClaimsFromRequest(r *http.Request, keySets map[string]oidc.KeySet) (*oidc.A
 		return claims, err
 	}
 
+	if err := oidc.CheckNotBefore(claims, 0); err != nil {
+		return claims, err
+	}
+
 	return claims, nil
 }

--- a/pkg/authn/jwt/auth_test.go
+++ b/pkg/authn/jwt/auth_test.go
@@ -61,6 +61,14 @@ func createAccessToken(t *testing.T, privateKey *rsa.PrivateKey, issuer string, 
 	// Set scopes
 	accessTokenClaims.Scopes = scopes
 
+	return signAccessTokenClaims(t, privateKey, accessTokenClaims)
+}
+
+func signAccessTokenClaims(t *testing.T, privateKey *rsa.PrivateKey, accessTokenClaims *oidc.AccessTokenClaims) string {
+	return signClaims(t, privateKey, accessTokenClaims)
+}
+
+func signClaims(t *testing.T, privateKey *rsa.PrivateKey, claims any) string {
 	// Create JWT using go-jose
 	signer, err := jose.NewSigner(
 		jose.SigningKey{
@@ -71,7 +79,7 @@ func createAccessToken(t *testing.T, privateKey *rsa.PrivateKey, issuer string, 
 	)
 	require.NoError(t, err)
 
-	claimsJSON, err := json.Marshal(accessTokenClaims)
+	claimsJSON, err := json.Marshal(claims)
 	require.NoError(t, err)
 
 	signed, err := signer.Sign(claimsJSON)
@@ -314,6 +322,95 @@ func TestJWTAuth_Authenticate(t *testing.T) {
 
 				authenticated, err := tt.auth.Authenticate(nil, req)
 				require.Error(t, err)
+				assert.False(t, authenticated)
+			})
+		}
+	})
+
+	t.Run("failure with token before not-before time", func(t *testing.T) {
+		t.Parallel()
+		keySet, privateKey, issuer := setupTestKeySet(t)
+		tests := []struct {
+			name string
+			auth Authenticator
+		}{
+			{
+				name: "JWTAuth",
+				auth: NewJWTAuth(map[string]oidc.KeySet{issuer: keySet}, "test-service", false, nil),
+			},
+			{
+				name: "JWTAuth with additional checks",
+				auth: NewJWTAuth(map[string]oidc.KeySet{issuer: keySet}, "test-service", false, autoPassingAdditionalChecks),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				now := stdtime.Now().UTC()
+				expirationTime := libtime.New(now.Add(2 * stdtime.Hour))
+
+				accessTokenClaims := oidc.NewAccessTokenClaims(
+					issuer,
+					"test-user",
+					[]string{"test-client"},
+					expirationTime,
+					"test-jti",
+					"test-client",
+				)
+				accessTokenClaims.NotBefore = oidc.FromTime(libtime.New(now.Add(1 * stdtime.Hour)))
+
+				token := signAccessTokenClaims(t, privateKey, accessTokenClaims)
+
+				req := httptest.NewRequest("GET", "/test", nil)
+				req.Header.Set("Authorization", "Bearer "+token)
+				req = req.WithContext(logging.TestingContext())
+
+				authenticated, err := tt.auth.Authenticate(nil, req)
+				require.Error(t, err)
+				assert.ErrorIs(t, err, oidc.ErrNotBefore)
+				assert.False(t, authenticated)
+			})
+		}
+	})
+
+	t.Run("failure with malformed not-before claim", func(t *testing.T) {
+		t.Parallel()
+		keySet, privateKey, issuer := setupTestKeySet(t)
+		tests := []struct {
+			name string
+			auth Authenticator
+		}{
+			{
+				name: "JWTAuth",
+				auth: NewJWTAuth(map[string]oidc.KeySet{issuer: keySet}, "test-service", false, nil),
+			},
+			{
+				name: "JWTAuth with additional checks",
+				auth: NewJWTAuth(map[string]oidc.KeySet{issuer: keySet}, "test-service", false, autoPassingAdditionalChecks),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				now := stdtime.Now().UTC()
+				token := signClaims(t, privateKey, map[string]any{
+					"iss":       issuer,
+					"sub":       "test-user",
+					"aud":       []string{"test-client"},
+					"exp":       now.Add(2 * stdtime.Hour).Unix(),
+					"iat":       now.Unix(),
+					"nbf":       "not-a-time",
+					"client_id": "test-client",
+					"jti":       "test-jti",
+				})
+
+				req := httptest.NewRequest("GET", "/test", nil)
+				req.Header.Set("Authorization", "Bearer "+token)
+				req = req.WithContext(logging.TestingContext())
+
+				authenticated, err := tt.auth.Authenticate(nil, req)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "oidc.Time")
 				assert.False(t, authenticated)
 			})
 		}

--- a/pkg/authn/oidc/client/verifier.go
+++ b/pkg/authn/oidc/client/verifier.go
@@ -67,6 +67,10 @@ func VerifyIDToken[C oidc.Claims](ctx context.Context, token string, v *Verifier
 		return nilClaims, "", err
 	}
 
+	if err = oidc.CheckNotBeforePayload(payload, v.Offset); err != nil {
+		return nilClaims, "", err
+	}
+
 	if err = oidc.CheckIssuedAt(claims, v.MaxAgeIAT, v.Offset); err != nil {
 		return nilClaims, "", err
 	}

--- a/pkg/authn/oidc/client/verifier_test.go
+++ b/pkg/authn/oidc/client/verifier_test.go
@@ -1,0 +1,161 @@
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"testing"
+	stdtime "time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
+	libtime "github.com/formancehq/go-libs/v5/pkg/types/time"
+)
+
+func TestVerifyIDTokenRejectsTokenBeforeNotBeforeTime(t *testing.T) {
+	t.Parallel()
+
+	keySet, privateKey := setupVerifierTestKeySet(t)
+	now := stdtime.Now().UTC()
+	issuer := "https://test-issuer.example.com"
+	clientID := "test-client"
+	claims := oidc.NewIDTokenClaims(
+		"test-session",
+		issuer,
+		"test-subject",
+		[]string{clientID},
+		libtime.New(now.Add(stdtime.Hour)),
+		libtime.New(now),
+		clientID,
+	)
+	claims.NotBefore = oidc.FromTime(libtime.New(now.Add(30 * stdtime.Minute)))
+
+	token := signIDTokenClaims(t, privateKey, claims)
+	verifier := NewIDTokenVerifier(
+		clientID,
+		keySet,
+		WithIssuer(func(value string) bool { return value == issuer }),
+		WithNonce(nil),
+	)
+
+	_, _, err := VerifyIDToken[*oidc.IDTokenClaims](context.Background(), token, verifier)
+
+	require.ErrorIs(t, err, oidc.ErrNotBefore)
+}
+
+func TestVerifyIDTokenRejectsCustomClaimsBeforeNotBeforeTime(t *testing.T) {
+	t.Parallel()
+
+	keySet, privateKey := setupVerifierTestKeySet(t)
+	now := stdtime.Now().UTC()
+	issuer := "https://test-issuer.example.com"
+	clientID := "test-client"
+	claims := &customIDTokenClaims{
+		Issuer:     issuer,
+		Subject:    "test-subject",
+		Audience:   []string{clientID},
+		Expiration: oidc.FromTime(libtime.New(now.Add(stdtime.Hour))),
+		IssuedAt:   oidc.FromTime(libtime.New(now)),
+		NotBefore:  oidc.FromTime(libtime.New(now.Add(30 * stdtime.Minute))),
+	}
+
+	token := signIDTokenClaims(t, privateKey, claims)
+	verifier := NewIDTokenVerifier(
+		clientID,
+		keySet,
+		WithIssuer(func(value string) bool { return value == issuer }),
+		WithNonce(nil),
+	)
+
+	_, _, err := VerifyIDToken[*customIDTokenClaims](context.Background(), token, verifier)
+
+	require.ErrorIs(t, err, oidc.ErrNotBefore)
+}
+
+func setupVerifierTestKeySet(t *testing.T) (oidc.KeySet, *rsa.PrivateKey) {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	jwk := jose.JSONWebKey{
+		Key:       &privateKey.PublicKey,
+		KeyID:     "test-key-id",
+		Algorithm: string(jose.RS256),
+		Use:       oidc.KeyUseSignature,
+	}
+
+	return oidc.NewStaticKeySet(jwk), privateKey
+}
+
+func signIDTokenClaims(t *testing.T, privateKey *rsa.PrivateKey, claims any) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{
+			Algorithm: jose.RS256,
+			Key:       privateKey,
+		},
+		(&jose.SignerOptions{}).WithHeader("kid", "test-key-id"),
+	)
+	require.NoError(t, err)
+
+	claimsJSON, err := json.Marshal(claims)
+	require.NoError(t, err)
+
+	signed, err := signer.Sign(claimsJSON)
+	require.NoError(t, err)
+
+	token, err := signed.CompactSerialize()
+	require.NoError(t, err)
+
+	return token
+}
+
+type customIDTokenClaims struct {
+	Issuer     string        `json:"iss,omitempty"`
+	Subject    string        `json:"sub,omitempty"`
+	Audience   oidc.Audience `json:"aud,omitempty"`
+	Expiration oidc.Time     `json:"exp,omitempty"`
+	IssuedAt   oidc.Time     `json:"iat,omitempty"`
+	NotBefore  oidc.Time     `json:"nbf,omitempty"`
+}
+
+func (c *customIDTokenClaims) GetIssuer() string {
+	return c.Issuer
+}
+
+func (c *customIDTokenClaims) GetSubject() string {
+	return c.Subject
+}
+
+func (c *customIDTokenClaims) GetAudience() []string {
+	return c.Audience
+}
+
+func (c *customIDTokenClaims) GetExpiration() libtime.Time {
+	return c.Expiration.AsTime()
+}
+
+func (c *customIDTokenClaims) GetIssuedAt() libtime.Time {
+	return c.IssuedAt.AsTime()
+}
+
+func (c *customIDTokenClaims) GetNonce() string {
+	return ""
+}
+
+func (c *customIDTokenClaims) GetAuthenticationContextClassReference() string {
+	return ""
+}
+
+func (c *customIDTokenClaims) GetAuthTime() libtime.Time {
+	return libtime.Time{}
+}
+
+func (c *customIDTokenClaims) GetAuthorizedParty() string {
+	return ""
+}

--- a/pkg/authn/oidc/token.go
+++ b/pkg/authn/oidc/token.go
@@ -68,6 +68,10 @@ func (c *TokenClaims) GetIssuedAt() time.Time {
 	return c.IssuedAt.AsTime()
 }
 
+func (c *TokenClaims) GetNotBefore() time.Time {
+	return c.NotBefore.AsTime()
+}
+
 func (c *TokenClaims) GetNonce() string {
 	return c.Nonce
 }
@@ -139,6 +143,10 @@ type IDTokenClaims struct {
 // GetAccessTokenHash implements the IDTokenClaims interface
 func (t *IDTokenClaims) GetAccessTokenHash() string {
 	return t.AccessTokenHash
+}
+
+func (t *IDTokenClaims) GetNotBefore() time.Time {
+	return t.NotBefore.AsTime()
 }
 
 func (t *IDTokenClaims) SetUserInfo(i *UserInfo) {

--- a/pkg/authn/oidc/verifier.go
+++ b/pkg/authn/oidc/verifier.go
@@ -27,6 +27,10 @@ type Claims interface {
 	GetAuthorizedParty() string
 }
 
+type NotBeforeClaims interface {
+	GetNotBefore() time.Time
+}
+
 type IDClaims interface {
 	Claims
 	GetAccessTokenHash() string
@@ -46,6 +50,7 @@ var (
 	ErrSignatureInvalidPayload = errors.New("signature does not match Payload")
 	ErrSignatureInvalid        = errors.New("invalid signature")
 	ErrExpired                 = errors.New("token has expired")
+	ErrNotBefore               = errors.New("token is not valid yet")
 	ErrIatMissing              = errors.New("issuedAt of token is missing")
 	ErrIatInFuture             = errors.New("issuedAt of token is in the future")
 	ErrIatToOld                = errors.New("issuedAt of token is to old")
@@ -193,6 +198,38 @@ func CheckExpiration(claims Claims, offset time.Duration) error {
 		return ErrExpired
 	}
 	return nil
+}
+
+func CheckNotBefore(claims NotBeforeClaims, offset time.Duration) error {
+	return checkNotBeforeAt(claims, offset, time.Now())
+}
+
+func checkNotBeforeAt(claims NotBeforeClaims, offset time.Duration, now time.Time) error {
+	notBefore := claims.GetNotBefore()
+	if notBefore.IsZero() {
+		return nil
+	}
+	nowWithOffset := now.Add(offset)
+	if nowWithOffset.Before(notBefore) {
+		return fmt.Errorf("%w: (nbf: %v, now with offset: %v)", ErrNotBefore, notBefore, nowWithOffset)
+	}
+	return nil
+}
+
+func CheckNotBeforePayload(payload []byte, offset time.Duration) error {
+	var claims payloadNotBeforeClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return err
+	}
+	return CheckNotBefore(claims, offset)
+}
+
+type payloadNotBeforeClaims struct {
+	NotBefore Time `json:"nbf,omitempty"`
+}
+
+func (c payloadNotBeforeClaims) GetNotBefore() time.Time {
+	return c.NotBefore.AsTime()
 }
 
 func CheckIssuedAt(claims Claims, maxAgeIAT, offset time.Duration) error {

--- a/pkg/authn/oidc/verifier_test.go
+++ b/pkg/authn/oidc/verifier_test.go
@@ -1,0 +1,54 @@
+package oidc
+
+import (
+	"encoding/json"
+	"testing"
+	stdtime "time"
+
+	"github.com/stretchr/testify/require"
+
+	libtime "github.com/formancehq/go-libs/v5/pkg/types/time"
+)
+
+func TestCheckNotBeforeUsesDecodedIDTokenClaimsNotBefore(t *testing.T) {
+	t.Parallel()
+
+	payload, err := json.Marshal(map[string]int64{
+		"nbf": stdtime.Now().Add(stdtime.Hour).Unix(),
+	})
+	require.NoError(t, err)
+
+	var claims IDTokenClaims
+	require.NoError(t, json.Unmarshal(payload, &claims))
+	require.True(t, claims.TokenClaims.NotBefore.AsTime().IsZero())
+	require.False(t, claims.NotBefore.AsTime().IsZero())
+
+	require.ErrorIs(t, CheckNotBefore(&claims, 0), ErrNotBefore)
+}
+
+func TestCheckNotBeforePayloadReturnsMalformedNotBeforeError(t *testing.T) {
+	t.Parallel()
+
+	err := CheckNotBeforePayload([]byte(`{"nbf":"not-a-time"}`), 0)
+
+	require.ErrorContains(t, err, "oidc.Time")
+}
+
+func TestCheckNotBeforeDoesNotRoundCurrentTimeForward(t *testing.T) {
+	t.Parallel()
+
+	now := libtime.New(stdtime.Unix(100, int64(600*stdtime.Millisecond)))
+	notBefore := libtime.New(stdtime.Unix(101, 0))
+
+	err := checkNotBeforeAt(testNotBeforeClaims{notBefore: notBefore}, 0, now)
+
+	require.ErrorIs(t, err, ErrNotBefore)
+}
+
+type testNotBeforeClaims struct {
+	notBefore libtime.Time
+}
+
+func (c testNotBeforeClaims) GetNotBefore() libtime.Time {
+	return c.notBefore
+}


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1170` from EN-1136.

This PR contains the scoped change: Validate JWT not-before claims.

Stack base: `feat/en-1167-oidc-discovery`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
