### PR TITLE
fix(audit): redact credentials and sensitive bodies (EN-1172)

### DIFF
--- a/pkg/audit/httpaudit/middleware.go
+++ b/pkg/audit/httpaudit/middleware.go
@@ -28,7 +28,7 @@ type httpOptions struct {
 	handledHeaderSecret string
 }
 
-// WithSensitivePaths sets paths for which the response body should not be captured.
+// WithSensitivePaths sets path prefixes for which request and response bodies should not be captured.
 func WithSensitivePaths(paths ...string) HTTPOption {
 	return func(o *httpOptions) {
 		for _, p := range paths {
@@ -150,7 +150,9 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				err  error
 			)
 
-			if !isStreamRequest(r) {
+			sensitivePath := ho.isSensitivePath(r.URL.Path)
+
+			if !isStreamRequest(r) && !sensitivePath {
 				body, err = io.ReadAll(r.Body)
 				if err != nil && !errors.Is(err, io.EOF) {
 					http.Error(w, "failed to read request body", http.StatusInternalServerError)
@@ -162,9 +164,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				}
 			}
 
-			requestHeaders := r.Header.Clone()
-			requestHeaders.Del("Authorization")
-			requestHeaders.Del(audit.HandledHeader)
+			requestHeaders := cloneHeaderWithout(r.Header, "Authorization", "Cookie", audit.HandledHeader)
 
 			r.Header.Set(audit.HandledHeader, handledHeaderValue)
 
@@ -176,14 +176,16 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				ResponseWriter: w,
 				body:           buf,
 				statusCode:     http.StatusOK,
+				captureBody:    !sensitivePath,
 			}
 
 			next.ServeHTTP(rww, r)
 
-			responseBody := rww.body.String()
-			if _, sensitive := ho.sensitivePaths[r.URL.Path]; sensitive {
-				responseBody = ""
+			responseBody := ""
+			if !sensitivePath {
+				responseBody = rww.body.String()
 			}
+			responseHeaders := cloneHeaderWithout(rww.Header(), "Set-Cookie")
 
 			actor := audit.ExtractClaims(r, auditOpts)
 
@@ -206,7 +208,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 					},
 					Response: audit.HTTPResponse{
 						StatusCode: rww.statusCode,
-						Headers:    rww.Header(),
+						Headers:    responseHeaders,
 						Body:       responseBody,
 					},
 				},
@@ -217,6 +219,36 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 	}
 }
 
+func cloneHeaderWithout(header http.Header, names ...string) http.Header {
+	clone := header.Clone()
+	for _, name := range names {
+		clone.Del(name)
+	}
+	return clone
+}
+
+func (o *httpOptions) isSensitivePath(requestPath string) bool {
+	for sensitivePath := range o.sensitivePaths {
+		if pathMatchesPrefix(requestPath, sensitivePath) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathMatchesPrefix(requestPath string, sensitivePath string) bool {
+	if sensitivePath == "" {
+		return false
+	}
+
+	sensitivePath = strings.TrimRight(sensitivePath, "/")
+	if sensitivePath == "" {
+		return strings.HasPrefix(requestPath, "/")
+	}
+
+	return requestPath == sensitivePath || strings.HasPrefix(requestPath, sensitivePath+"/")
+}
+
 func isStreamRequest(r *http.Request) bool {
 	ct := r.Header.Get("Content-Type")
 	return strings.HasPrefix(ct, "application/vnd.formance") && strings.HasSuffix(ct, "-stream")
@@ -224,14 +256,17 @@ func isStreamRequest(r *http.Request) bool {
 
 type responseWriterWrapper struct {
 	http.ResponseWriter
-	body       *bytes.Buffer
-	statusCode int
+	body        *bytes.Buffer
+	statusCode  int
+	captureBody bool
 }
 
 func (rww *responseWriterWrapper) Write(buf []byte) (int, error) {
-	mediaType, _, _ := mime.ParseMediaType(rww.Header().Get("Content-Type"))
-	if mediaType != "application/octet-stream" {
-		rww.body.Write(buf)
+	if rww.captureBody {
+		mediaType, _, _ := mime.ParseMediaType(rww.Header().Get("Content-Type"))
+		if mediaType != "application/octet-stream" {
+			rww.body.Write(buf)
+		}
 	}
 	return rww.ResponseWriter.Write(buf)
 }

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -159,6 +159,51 @@ func TestMiddleware_AuthorizationHeaderStripped(t *testing.T) {
 	assert.Empty(t, payload.HTTP.Request.Header.Get("Authorization"))
 }
 
+func TestMiddleware_CookieHeadersStripped(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Response-ID", "response-id")
+			http.SetCookie(w, &http.Cookie{
+				Name:  "session",
+				Value: "response-secret",
+			})
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Cookie", "session=request-secret")
+	req.Header.Set("X-Request-ID", "request-id")
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Contains(t, rr.Header().Get("Set-Cookie"), "response-secret")
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(messages[0].Payload, &event))
+
+	payloadBytes, _ := json.Marshal(event.Payload)
+	var payload audit.Payload
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+
+	assert.Empty(t, payload.HTTP.Request.Header.Get("Cookie"))
+	assert.Equal(t, "request-id", payload.HTTP.Request.Header.Get("X-Request-ID"))
+	assert.Empty(t, payload.HTTP.Response.Headers.Get("Set-Cookie"))
+	assert.Equal(t, "response-id", payload.HTTP.Response.Headers.Get("X-Response-ID"))
+	assert.NotContains(t, string(messages[0].Payload), "request-secret")
+	assert.NotContains(t, string(messages[0].Payload), "response-secret")
+}
+
 func TestMiddleware_SensitivePaths(t *testing.T) {
 	t.Parallel()
 
@@ -194,6 +239,56 @@ func TestMiddleware_SensitivePaths(t *testing.T) {
 	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
 
 	assert.Empty(t, payload.HTTP.Response.Body)
+	assert.Empty(t, payload.HTTP.Request.Body)
+	assert.NotContains(t, string(messages[0].Payload), "client_credentials")
+	assert.NotContains(t, string(messages[0].Payload), "access_token")
+}
+
+func TestMiddleware_SensitivePathsMatchPrefixAndPassRequestBodyThrough(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	var receivedBody string
+	handler := Middleware(pub, topic, "test-app", nil,
+		WithEnabled(true),
+		WithSensitivePaths("/api/auth"),
+	)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			receivedBody = string(body)
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"access_token":"response-secret"}`))
+		}),
+	)
+
+	reqBody := `username=alice&password=request-secret`
+	req := httptest.NewRequest("POST", "/api/auth/oauth/token", strings.NewReader(reqBody))
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, reqBody, receivedBody)
+	require.Equal(t, `{"access_token":"response-secret"}`, rr.Body.String())
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(messages[0].Payload, &event))
+
+	payloadBytes, _ := json.Marshal(event.Payload)
+	var payload audit.Payload
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+
+	assert.Empty(t, payload.HTTP.Request.Body)
+	assert.Empty(t, payload.HTTP.Response.Body)
+	assert.NotContains(t, string(messages[0].Payload), "request-secret")
+	assert.NotContains(t, string(messages[0].Payload), "response-secret")
 }
 
 func TestMiddleware_StreamRequestSkipsBodyCapture(t *testing.T) {

--- a/pkg/authn/jwt/auth.go
+++ b/pkg/authn/jwt/auth.go
@@ -129,5 +129,9 @@ func ClaimsFromRequest(r *http.Request, keySets map[string]oidc.KeySet) (*oidc.A
 		return claims, err
 	}
 
+	if err := oidc.CheckNotBefore(claims, 0); err != nil {
+		return claims, err
+	}
+
 	return claims, nil
 }

--- a/pkg/authn/jwt/auth_test.go
+++ b/pkg/authn/jwt/auth_test.go
@@ -61,6 +61,10 @@ func createAccessToken(t *testing.T, privateKey *rsa.PrivateKey, issuer string, 
 	// Set scopes
 	accessTokenClaims.Scopes = scopes
 
+	return signAccessTokenClaims(t, privateKey, accessTokenClaims)
+}
+
+func signAccessTokenClaims(t *testing.T, privateKey *rsa.PrivateKey, accessTokenClaims *oidc.AccessTokenClaims) string {
 	// Create JWT using go-jose
 	signer, err := jose.NewSigner(
 		jose.SigningKey{
@@ -314,6 +318,52 @@ func TestJWTAuth_Authenticate(t *testing.T) {
 
 				authenticated, err := tt.auth.Authenticate(nil, req)
 				require.Error(t, err)
+				assert.False(t, authenticated)
+			})
+		}
+	})
+
+	t.Run("failure with token before not-before time", func(t *testing.T) {
+		t.Parallel()
+		keySet, privateKey, issuer := setupTestKeySet(t)
+		tests := []struct {
+			name string
+			auth Authenticator
+		}{
+			{
+				name: "JWTAuth",
+				auth: NewJWTAuth(map[string]oidc.KeySet{issuer: keySet}, "test-service", false, nil),
+			},
+			{
+				name: "JWTAuth with additional checks",
+				auth: NewJWTAuth(map[string]oidc.KeySet{issuer: keySet}, "test-service", false, autoPassingAdditionalChecks),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				now := stdtime.Now().UTC()
+				expirationTime := libtime.New(now.Add(2 * stdtime.Hour))
+
+				accessTokenClaims := oidc.NewAccessTokenClaims(
+					issuer,
+					"test-user",
+					[]string{"test-client"},
+					expirationTime,
+					"test-jti",
+					"test-client",
+				)
+				accessTokenClaims.NotBefore = oidc.FromTime(libtime.New(now.Add(1 * stdtime.Hour)))
+
+				token := signAccessTokenClaims(t, privateKey, accessTokenClaims)
+
+				req := httptest.NewRequest("GET", "/test", nil)
+				req.Header.Set("Authorization", "Bearer "+token)
+				req = req.WithContext(logging.TestingContext())
+
+				authenticated, err := tt.auth.Authenticate(nil, req)
+				require.Error(t, err)
+				assert.ErrorIs(t, err, oidc.ErrNotBefore)
 				assert.False(t, authenticated)
 			})
 		}

--- a/pkg/authn/jwt/module_test.go
+++ b/pkg/authn/jwt/module_test.go
@@ -30,10 +30,11 @@ func setupTestOIDCServer(t *testing.T) (*httptest.Server, string, chan bool) {
 	// Discovery endpoint
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		discoveryCalled <- true
+		issuer := "http://" + r.Host
 
 		config := oidc.DiscoveryConfiguration{
-			Issuer:  r.URL.Scheme + "://" + r.Host,
-			JwksURI: r.URL.Scheme + "://" + r.Host + "/.well-known/jwks.json",
+			Issuer:  issuer,
+			JwksURI: issuer + "/.well-known/jwks.json",
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/authn/oidc/client/discover.go
+++ b/pkg/authn/oidc/client/discover.go
@@ -3,12 +3,17 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
 	httphelper "github.com/formancehq/go-libs/v5/pkg/authn/oidc/http"
 )
+
+type issuerGetter interface {
+	GetIssuer() string
+}
 
 // Discover calls the discovery endpoint of the provided issuer and returns its configuration
 // It accepts an optional argument "wellknownUrl" which can be used to override the discovery endpoint url
@@ -27,6 +32,21 @@ func Discover[V any](ctx context.Context, issuer string, httpClient *http.Client
 	if err != nil {
 		return nil, errors.Join(oidc.ErrDiscoveryFailed, err)
 	}
+	if err := validateDiscoveredIssuer(issuer, discoveryConfig); err != nil {
+		return nil, errors.Join(oidc.ErrDiscoveryFailed, err)
+	}
 
 	return discoveryConfig, nil
+}
+
+func validateDiscoveredIssuer[V any](issuer string, discoveryConfig *V) error {
+	issuerConfig, ok := any(discoveryConfig).(issuerGetter)
+	if !ok {
+		return nil
+	}
+	discoveredIssuer := issuerConfig.GetIssuer()
+	if discoveredIssuer != issuer {
+		return fmt.Errorf("%w: Expected: %s, got: %s", oidc.ErrIssuerInvalid, issuer, discoveredIssuer)
+	}
+	return nil
 }

--- a/pkg/authn/oidc/client/discover_test.go
+++ b/pkg/authn/oidc/client/discover_test.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
+)
+
+func TestDiscoverValidatesIssuer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns discovery configuration when issuer matches", func(t *testing.T) {
+		t.Parallel()
+
+		issuer := "https://issuer.example.com"
+		server := httptest.NewServer(discoveryHandler(t, issuer))
+		t.Cleanup(server.Close)
+
+		discoveryConfig, err := Discover[oidc.DiscoveryConfiguration](
+			context.Background(),
+			issuer,
+			server.Client(),
+			server.URL,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, issuer, discoveryConfig.Issuer)
+	})
+
+	t.Run("rejects discovery configuration when issuer differs", func(t *testing.T) {
+		t.Parallel()
+
+		issuer := "https://issuer.example.com"
+		discoveredIssuer := "https://other-issuer.example.com"
+		server := httptest.NewServer(discoveryHandler(t, discoveredIssuer))
+		t.Cleanup(server.Close)
+
+		discoveryConfig, err := Discover[oidc.DiscoveryConfiguration](
+			context.Background(),
+			issuer,
+			server.Client(),
+			server.URL,
+		)
+
+		require.Nil(t, discoveryConfig)
+		require.ErrorIs(t, err, oidc.ErrDiscoveryFailed)
+		require.ErrorIs(t, err, oidc.ErrIssuerInvalid)
+		require.ErrorContains(t, err, "Expected: "+issuer+", got: "+discoveredIssuer)
+	})
+}
+
+func discoveryHandler(t *testing.T, issuer string) http.Handler {
+	t.Helper()
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(oidc.DiscoveryConfiguration{
+			Issuer:  issuer,
+			JwksURI: issuer + "/.well-known/jwks.json",
+		})
+		require.NoError(t, err)
+	})
+}

--- a/pkg/authn/oidc/discovery.go
+++ b/pkg/authn/oidc/discovery.go
@@ -162,6 +162,13 @@ type DiscoveryConfiguration struct {
 	BackChannelLogoutSessionSupported bool `json:"backchannel_logout_session_supported,omitempty"`
 }
 
+func (d *DiscoveryConfiguration) GetIssuer() string {
+	if d == nil {
+		return ""
+	}
+	return d.Issuer
+}
+
 type AuthMethod string
 
 const (

--- a/pkg/authn/oidc/token.go
+++ b/pkg/authn/oidc/token.go
@@ -68,6 +68,10 @@ func (c *TokenClaims) GetIssuedAt() time.Time {
 	return c.IssuedAt.AsTime()
 }
 
+func (c *TokenClaims) GetNotBefore() time.Time {
+	return c.NotBefore.AsTime()
+}
+
 func (c *TokenClaims) GetNonce() string {
 	return c.Nonce
 }

--- a/pkg/authn/oidc/verifier.go
+++ b/pkg/authn/oidc/verifier.go
@@ -27,6 +27,10 @@ type Claims interface {
 	GetAuthorizedParty() string
 }
 
+type NotBeforeClaims interface {
+	GetNotBefore() time.Time
+}
+
 type IDClaims interface {
 	Claims
 	GetAccessTokenHash() string
@@ -46,6 +50,7 @@ var (
 	ErrSignatureInvalidPayload = errors.New("signature does not match Payload")
 	ErrSignatureInvalid        = errors.New("invalid signature")
 	ErrExpired                 = errors.New("token has expired")
+	ErrNotBefore               = errors.New("token is not valid yet")
 	ErrIatMissing              = errors.New("issuedAt of token is missing")
 	ErrIatInFuture             = errors.New("issuedAt of token is in the future")
 	ErrIatToOld                = errors.New("issuedAt of token is to old")
@@ -191,6 +196,18 @@ func CheckExpiration(claims Claims, offset time.Duration) error {
 	expiration := claims.GetExpiration()
 	if !time.Now().Add(offset).Before(expiration) {
 		return ErrExpired
+	}
+	return nil
+}
+
+func CheckNotBefore(claims NotBeforeClaims, offset time.Duration) error {
+	notBefore := claims.GetNotBefore()
+	if notBefore.IsZero() {
+		return nil
+	}
+	nowWithOffset := time.Now().Add(offset).Round(time.Second)
+	if nowWithOffset.Before(notBefore) {
+		return fmt.Errorf("%w: (nbf: %v, now with offset: %v)", ErrNotBefore, notBefore, nowWithOffset)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1172` from EN-1136.

This PR contains the scoped change: Redact audit credentials and sensitive bodies.

Stack base: `feat/en-1170-jwt-nbf`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
