### PR TITLE
fix(audit): cap HTTP audit body capture (EN-1174)

### DIFF
--- a/pkg/audit/httpaudit/middleware.go
+++ b/pkg/audit/httpaudit/middleware.go
@@ -90,6 +90,8 @@ var bufPool = sync.Pool{
 	},
 }
 
+const maxCapturedBodyBytes = 64 * 1024
+
 // Middleware returns an HTTP middleware that captures request/response data
 // and publishes audit events via the given Watermill publisher.
 func Middleware(publisher message.Publisher, topicName string, appName string, opts []audit.Option, httpOpts ...HTTPOption) func(http.Handler) http.Handler {
@@ -153,14 +155,10 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 			sensitivePath := ho.isSensitivePath(r.URL.Path)
 
 			if !isStreamRequest(r) && !sensitivePath {
-				body, err = io.ReadAll(r.Body)
+				body, err = captureRequestBody(r)
 				if err != nil && !errors.Is(err, io.EOF) {
 					http.Error(w, "failed to read request body", http.StatusInternalServerError)
 					return
-				}
-				if len(body) > 0 {
-					_ = r.Body.Close()
-					r.Body = io.NopCloser(bytes.NewBuffer(body))
 				}
 			}
 
@@ -170,7 +168,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 
 			buf := bufPool.Get().(*bytes.Buffer)
 			buf.Reset()
-			defer bufPool.Put(buf)
+			defer putCaptureBuffer(buf)
 
 			rww := &responseWriterWrapper{
 				ResponseWriter: w,
@@ -219,6 +217,37 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 	}
 }
 
+func captureRequestBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxCapturedBodyBytes))
+	if len(body) > 0 {
+		r.Body = readCloser{
+			Reader: io.MultiReader(bytes.NewReader(body), r.Body),
+			Closer: r.Body,
+		}
+	}
+	return body, err
+}
+
+func putCaptureBuffer(buf *bytes.Buffer) {
+	if shouldPoolCaptureBuffer(buf) {
+		buf.Reset()
+		bufPool.Put(buf)
+	}
+}
+
+func shouldPoolCaptureBuffer(buf *bytes.Buffer) bool {
+	return buf.Cap() <= maxCapturedBodyBytes
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
 func cloneHeaderWithout(header http.Header, names ...string) http.Header {
 	clone := header.Clone()
 	for _, name := range names {
@@ -265,7 +294,14 @@ func (rww *responseWriterWrapper) Write(buf []byte) (int, error) {
 	if rww.captureBody {
 		mediaType, _, _ := mime.ParseMediaType(rww.Header().Get("Content-Type"))
 		if mediaType != "application/octet-stream" {
-			rww.body.Write(buf)
+			remaining := maxCapturedBodyBytes - rww.body.Len()
+			if remaining > 0 {
+				captured := buf
+				if len(captured) > remaining {
+					captured = captured[:remaining]
+				}
+				rww.body.Write(captured)
+			}
 		}
 	}
 	return rww.ResponseWriter.Write(buf)

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -127,6 +127,85 @@ func TestMiddleware_BasicCapture(t *testing.T) {
 	assert.Equal(t, `{"status":"ok"}`, payload.HTTP.Response.Body)
 }
 
+func TestMiddleware_CapsRequestBodyCaptureAndPassesFullBodyThrough(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	var receivedBody string
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			receivedBody = string(body)
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	capturedPrefix := strings.Repeat("a", maxCapturedBodyBytes)
+	reqBody := capturedPrefix + strings.Repeat("b", 1024)
+	req := httptest.NewRequest("POST", "/api/test", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, reqBody, receivedBody)
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	require.Len(t, payload.HTTP.Request.Body, maxCapturedBodyBytes)
+	assert.Equal(t, capturedPrefix, payload.HTTP.Request.Body)
+	assert.NotContains(t, payload.HTTP.Request.Body, "b")
+}
+
+func TestMiddleware_CapsResponseBodyCaptureAndWritesFullResponse(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	capturedPrefix := strings.Repeat("r", maxCapturedBodyBytes)
+	responseBody := capturedPrefix + strings.Repeat("s", 1024)
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(responseBody[:maxCapturedBodyBytes/2]))
+			_, _ = w.Write([]byte(responseBody[maxCapturedBodyBytes/2:]))
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, responseBody, rr.Body.String())
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	require.Len(t, payload.HTTP.Response.Body, maxCapturedBodyBytes)
+	assert.Equal(t, capturedPrefix, payload.HTTP.Response.Body)
+	assert.NotContains(t, payload.HTTP.Response.Body, "s")
+}
+
+func TestMiddleware_DoesNotPoolOversizedCaptureBuffers(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, shouldPoolCaptureBuffer(bytes.NewBuffer(make([]byte, 0, maxCapturedBodyBytes))))
+	assert.False(t, shouldPoolCaptureBuffer(bytes.NewBuffer(make([]byte, 0, maxCapturedBodyBytes+1))))
+}
+
 func TestMiddleware_AuthorizationHeaderStripped(t *testing.T) {
 	t.Parallel()
 
@@ -238,8 +317,8 @@ func TestMiddleware_SensitivePaths(t *testing.T) {
 	var payload audit.Payload
 	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
 
-	assert.Empty(t, payload.HTTP.Response.Body)
 	assert.Empty(t, payload.HTTP.Request.Body)
+	assert.Empty(t, payload.HTTP.Response.Body)
 	assert.NotContains(t, string(messages[0].Payload), "client_credentials")
 	assert.NotContains(t, string(messages[0].Payload), "access_token")
 }
@@ -285,6 +364,7 @@ func TestMiddleware_SensitivePathsMatchPrefixAndPassRequestBodyThrough(t *testin
 	var payload audit.Payload
 	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
 
+	assert.Equal(t, "/api/auth/oauth/token", payload.HTTP.Request.Path)
 	assert.Empty(t, payload.HTTP.Request.Body)
 	assert.Empty(t, payload.HTTP.Response.Body)
 	assert.NotContains(t, string(messages[0].Payload), "request-secret")
@@ -1064,6 +1144,20 @@ func TestAsyncPublisher_CloseRespectsContextTimeout(t *testing.T) {
 
 	pub.release()
 	require.NoError(t, asyncPublisher.Close(context.Background()))
+}
+
+func auditPayloadFromMessage(t *testing.T, msg *message.Message) audit.Payload {
+	t.Helper()
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(msg.Payload, &event))
+
+	payloadBytes, err := json.Marshal(event.Payload)
+	require.NoError(t, err)
+
+	var payload audit.Payload
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+	return payload
 }
 
 func serveAuditRequest(t *testing.T, handler http.Handler) {


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1174` from EN-1136.

This PR contains the scoped change: Cap audit body capture.

Stack base: `feat/en-1172-audit-redaction`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
