### PR TITLE
fix(storage): return IAM auth token errors (EN-1177)

### DIFF
--- a/pkg/storage/bun/connect/connect_test.go
+++ b/pkg/storage/bun/connect/connect_test.go
@@ -1,11 +1,16 @@
 package connect
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
 func TestObfuscateDSN(t *testing.T) {
@@ -84,5 +89,26 @@ func TestBuildPGXConnectorDefaultsToReadWriteTargetSessionAttrs(t *testing.T) {
 	want := reflect.ValueOf(pgconn.ValidateConnectTargetSessionAttrsReadWrite).Pointer()
 	if got != want {
 		t.Fatalf("unexpected ValidateConnect func pointer: got %x, want %x", got, want)
+	}
+}
+
+func TestIAMConnectorReturnsBuildAuthTokenError(t *testing.T) {
+	expectedErr := errors.New("retrieve aws credentials")
+	connector := &iamConnector{
+		dsn: "postgres://db-user@localhost:5432/mydb?sslmode=disable",
+		driver: &iamDriver{
+			awsConfig: aws.Config{
+				Region: "us-east-1",
+				Credentials: aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+					return aws.Credentials{}, expectedErr
+				}),
+			},
+		},
+		logger: logging.Testing(),
+	}
+
+	_, err := connector.Connect(context.Background())
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected BuildAuthToken error %q, got %v", expectedErr, err)
 	}
 }

--- a/pkg/storage/bun/connect/iam.go
+++ b/pkg/storage/bun/connect/iam.go
@@ -69,7 +69,7 @@ func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
 			otlp.RecordError(ctx, err)
 		}
 
-		return ret, nil
+		return ret, err
 	}()
 	if err != nil {
 		return nil, errors.Wrap(err, "building aws auth token")


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1177` from EN-1136.

This PR contains the scoped change: Return IAM auth token errors.

Stack base: `feat/en-1174-audit-body-caps`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
