### PR TITLE
fix(storage): build safe IAM DSNs and redact logs (EN-1179)

### DIFF
--- a/pkg/storage/bun/connect/iam.go
+++ b/pkg/storage/bun/connect/iam.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
@@ -49,7 +50,7 @@ type iamConnector struct {
 }
 
 func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
-	url, err := dburl.Parse(i.dsn)
+	databaseURL, err := dburl.Parse(i.dsn)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing dsn: %s", i.dsn)
 	}
@@ -60,9 +61,9 @@ func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
 
 		ret, err := auth.BuildAuthToken(
 			ctx,
-			url.Host,
+			databaseURL.Host,
 			i.driver.awsConfig.Region,
-			url.User.Username(),
+			databaseURL.User.Username(),
 			i.driver.awsConfig.Credentials,
 		)
 		if err != nil {
@@ -75,21 +76,9 @@ func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
 		return nil, errors.Wrap(err, "building aws auth token")
 	}
 
-	dsn := fmt.Sprintf(
-		"host=%s port=%s user=%s password=%s dbname=%s",
-		url.Hostname(),
-		url.Port(),
-		url.User.Username(),
-		authenticationToken,
-		url.Path[1:],
-	)
-	for key, strings := range url.Query() {
-		for _, value := range strings {
-			dsn = fmt.Sprintf("%s %s=%s", dsn, key, value)
-		}
-	}
+	dsn := buildIAMAuthDSN(&databaseURL.URL, authenticationToken)
 
-	i.logger.Debugf("IAM: Connect using dsn '%s'", dsn)
+	i.logger.Debugf("IAM: Connect using dsn '%s'", obfuscateDSN(dsn))
 
 	config, err := pgx.ParseConfig(dsn)
 	if err != nil {
@@ -107,3 +96,9 @@ func (i iamConnector) Driver() driver.Driver {
 }
 
 var _ driver.Connector = &iamConnector{}
+
+func buildIAMAuthDSN(databaseURL *url.URL, authenticationToken string) string {
+	dsnURL := *databaseURL
+	dsnURL.User = url.UserPassword(databaseURL.User.Username(), authenticationToken)
+	return dsnURL.String()
+}

--- a/pkg/storage/bun/connect/iam_test.go
+++ b/pkg/storage/bun/connect/iam_test.go
@@ -1,0 +1,62 @@
+package connect
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/xo/dburl"
+)
+
+func TestBuildIAMAuthDSNEscapesAuthTokenAndQueryValues(t *testing.T) {
+	databaseURL, err := dburl.Parse("postgres://iam%20user:old%20password@db.example.com:5432/service%20db?sslmode=require&application_name=worker%20one%2Bblue%26green%3Dtrue&search_path=tenant%3Done%2Cpublic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := "db.example.com:5432/?Action=connect&DBUser=iam user&X-Amz-Credential=AKIA/20260614/eu-west-1/rds-db/aws4_request&X-Amz-Signature=a+b=c=="
+
+	dsn := buildIAMAuthDSN(&databaseURL.URL, token)
+	if strings.Contains(dsn, token) {
+		t.Fatalf("expected auth token to be URL-escaped, got raw token in %q", dsn)
+	}
+
+	config, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("failed to parse generated IAM DSN: %v", err)
+	}
+
+	if config.User != "iam user" {
+		t.Fatalf("unexpected user: got %q", config.User)
+	}
+	if config.Password != token {
+		t.Fatalf("unexpected password token: got %q, want %q", config.Password, token)
+	}
+	if config.Database != "service db" {
+		t.Fatalf("unexpected database: got %q", config.Database)
+	}
+	if got := config.RuntimeParams["application_name"]; got != "worker one+blue&green=true" {
+		t.Fatalf("unexpected application_name: got %q", got)
+	}
+	if got := config.RuntimeParams["search_path"]; got != "tenant=one,public" {
+		t.Fatalf("unexpected search_path: got %q", got)
+	}
+}
+
+func TestBuildIAMAuthDSNObfuscatesAuthToken(t *testing.T) {
+	databaseURL, err := dburl.Parse("postgres://iam-user@db.example.com:5432/app?sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := "db.example.com:5432/?Action=connect&DBUser=iam-user&X-Amz-Credential=AKIA/20260614/eu-west-1/rds-db/aws4_request&X-Amz-Signature=a+b=c=="
+
+	loggedDSN := obfuscateDSN(buildIAMAuthDSN(&databaseURL.URL, token))
+	if loggedDSN != "postgres://iam-user:%2A%2A%2A%2A@db.example.com:5432/app?sslmode=disable" {
+		t.Fatalf("unexpected obfuscated DSN: got %q", loggedDSN)
+	}
+
+	for _, sensitive := range []string{token, "X-Amz-Credential", "X-Amz-Signature", "AKIA"} {
+		if strings.Contains(loggedDSN, sensitive) {
+			t.Fatalf("obfuscated DSN leaked %q in %q", sensitive, loggedDSN)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1179` from EN-1136.

This PR contains the scoped change: Build safe IAM DSNs and redact logs.

Stack base: `feat/en-1177-iam-auth-token-error`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
