### PR TITLE
fix(api): hide internal server error details (EN-1181)

### DIFF
--- a/pkg/transport/api/utils.go
+++ b/pkg/transport/api/utils.go
@@ -36,9 +36,13 @@ func writeJSON(w http.ResponseWriter, statusCode int, v any) {
 }
 
 func WriteErrorResponse(w http.ResponseWriter, statusCode int, errorCode string, err error) {
+	writeErrorResponse(w, statusCode, errorCode, err.Error())
+}
+
+func writeErrorResponse(w http.ResponseWriter, statusCode int, errorCode string, errorMessage string) {
 	writeJSON(w, statusCode, ErrorResponse{
 		ErrorCode:    errorCode,
-		ErrorMessage: err.Error(),
+		ErrorMessage: errorMessage,
 	})
 }
 
@@ -68,10 +72,7 @@ func BadRequestWithDetails(w http.ResponseWriter, code string, err error, detail
 
 func InternalServerError(w http.ResponseWriter, r *http.Request, err error) {
 	logging.FromContext(r.Context()).Error(err)
-	writeJSON(w, http.StatusInternalServerError, ErrorResponse{
-		ErrorCode:    ErrorInternal,
-		ErrorMessage: internalServerErrorMessage,
-	})
+	writeErrorResponse(w, http.StatusInternalServerError, ErrorInternal, internalServerErrorMessage)
 }
 
 func Accepted(w http.ResponseWriter, v any) {

--- a/pkg/transport/api/utils.go
+++ b/pkg/transport/api/utils.go
@@ -21,6 +21,8 @@ const (
 	ErrorInternal       = "INTERNAL"
 	ErrorCodeForbidden  = "FORBIDDEN"
 	ErrorCodeValidation = "VALIDATION"
+
+	internalServerErrorMessage = "internal server error"
 )
 
 func writeJSON(w http.ResponseWriter, statusCode int, v any) {
@@ -66,7 +68,10 @@ func BadRequestWithDetails(w http.ResponseWriter, code string, err error, detail
 
 func InternalServerError(w http.ResponseWriter, r *http.Request, err error) {
 	logging.FromContext(r.Context()).Error(err)
-	WriteErrorResponse(w, http.StatusInternalServerError, ErrorInternal, err)
+	writeJSON(w, http.StatusInternalServerError, ErrorResponse{
+		ErrorCode:    ErrorInternal,
+		ErrorMessage: internalServerErrorMessage,
+	})
 }
 
 func Accepted(w http.ResponseWriter, v any) {

--- a/pkg/transport/api/utils_test.go
+++ b/pkg/transport/api/utils_test.go
@@ -208,7 +208,7 @@ func TestInternalServerError(t *testing.T) {
 
 	// Create a response recorder
 	rr := httptest.NewRecorder()
-	testErr := errors.New("internal server error")
+	testErr := errors.New(`pq: duplicate key value violates unique constraint "accounts_pkey" at /srv/app/internal/storage/accounts.go:42`)
 
 	// Call the function
 	api.InternalServerError(rr, req, testErr)
@@ -220,15 +220,19 @@ func TestInternalServerError(t *testing.T) {
 	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 
 	// Check the response body
+	rawBody := rr.Body.String()
 	var response api.ErrorResponse
-	decodeErr := json.NewDecoder(rr.Body).Decode(&response)
+	decodeErr := json.NewDecoder(bytes.NewBufferString(rawBody)).Decode(&response)
 	require.NoError(t, decodeErr)
 	require.Equal(t, api.ErrorInternal, response.ErrorCode)
-	require.Equal(t, testErr.Error(), response.ErrorMessage)
+	require.Equal(t, "internal server error", response.ErrorMessage)
+	require.NotContains(t, rawBody, "accounts_pkey")
+	require.NotContains(t, rawBody, "/srv/app/internal/storage/accounts.go")
 
 	// Verify that the error was logged
 	logOutput := buf.String()
-	require.Contains(t, logOutput, testErr.Error())
+	require.Contains(t, logOutput, "accounts_pkey")
+	require.Contains(t, logOutput, "/srv/app/internal/storage/accounts.go")
 }
 
 func TestAccepted(t *testing.T) {


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1181` from EN-1136.

This PR contains the scoped change: Hide internal server error details.

Stack base: `feat/en-1179-iam-dsn-redaction`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
