### PR TITLE
fix(authn): make licence shutdown safe (EN-1182)

### DIFF
--- a/pkg/authn/licence/jwt.go
+++ b/pkg/authn/licence/jwt.go
@@ -93,6 +93,10 @@ func ValidateToken(jwtToken string, expectedIssuer string, opts ...ValidateToken
 }
 
 func (l *Licence) validate() error {
+	if l.validateToken != nil {
+		return l.validateToken()
+	}
+
 	return ValidateToken(
 		l.jwtToken,
 		l.expectedIssuer,

--- a/pkg/authn/licence/licence.go
+++ b/pkg/authn/licence/licence.go
@@ -1,6 +1,7 @@
 package licence
 
 import (
+	"sync"
 	"time"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -12,6 +13,9 @@ type Licence struct {
 	jwtToken            string
 	licenceValidateTick time.Duration
 	appStoped           chan struct{}
+	stopOnce            sync.Once
+	wg                  sync.WaitGroup
+	validateToken       func() error
 
 	// Will be checked in claims (aud claim)
 	serviceName string
@@ -42,6 +46,7 @@ func NewLicence(
 
 func (l *Licence) run(licenceError chan error) {
 	ticker := time.NewTicker(l.licenceValidateTick)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -72,11 +77,20 @@ func (l *Licence) Start(licenceError chan error) error {
 	}
 	l.logger.Info("Licence check passed")
 
-	go l.run(licenceError)
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		l.run(licenceError)
+	}()
 
 	return nil
 }
 
 func (l *Licence) Stop() {
-	close(l.appStoped)
+	l.stopOnce.Do(func() {
+		if l.appStoped != nil {
+			close(l.appStoped)
+		}
+	})
+	l.wg.Wait()
 }

--- a/pkg/authn/licence/licence_test.go
+++ b/pkg/authn/licence/licence_test.go
@@ -6,9 +6,11 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -205,6 +207,94 @@ func TestLicence_Start(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		require.Equal(t, "Licence check stopped, app stopped", logger.getMessage())
 	})
+}
+
+func TestLicence_StopIsIdempotent(t *testing.T) {
+	privateKey, pubPEM := generateTestRSAKeyPair(t)
+	setEmbeddedKey(t, pubPEM)
+
+	logger := &mockLogger{}
+	claims := jwt.MapClaims{
+		"sub": "test-cluster",
+		"aud": "test-service",
+		"iss": "test-issuer",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	tokenString := createTokenWithRSAKey(t, claims, privateKey)
+
+	licence := NewLicence(
+		logger,
+		tokenString,
+		time.Minute,
+		"test-service",
+		"test-cluster",
+		"test-issuer",
+	)
+
+	licenceError := make(chan error, 1)
+	require.NoError(t, licence.Start(licenceError))
+	require.NotPanics(t, func() {
+		licence.Stop()
+		licence.Stop()
+	})
+}
+
+func TestLicence_StopWaitsForInFlightValidationBeforeChannelClose(t *testing.T) {
+	logger := &mockLogger{}
+	licence := NewLicence(
+		logger,
+		"unused-token",
+		10*time.Millisecond,
+		"test-service",
+		"test-cluster",
+		"test-issuer",
+	)
+
+	validateStarted := make(chan struct{})
+	releaseValidate := make(chan struct{})
+	var validateCalls atomic.Int32
+	licence.validateToken = func() error {
+		if validateCalls.Add(1) == 1 {
+			return nil
+		}
+
+		close(validateStarted)
+		<-releaseValidate
+		return errors.New("licence validation failed")
+	}
+
+	licenceError := make(chan error, 1)
+	require.NoError(t, licence.Start(licenceError))
+
+	select {
+	case <-validateStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for licence validation to start")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		licence.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned before in-flight validation completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseValidate)
+
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Stop to return")
+	}
+
+	close(licenceError)
+	err := <-licenceError
+	require.EqualError(t, err, "licence validation failed")
 }
 
 func TestValidateToken(t *testing.T) {


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1182` from EN-1136.

This PR contains the scoped change: Make licence shutdown safe.

Stack base: `feat/en-1181-generic-internal-errors`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
