### PR TITLE
fix(queue): reject zero queue workers (EN-1183)

### DIFF
--- a/pkg/messaging/queue/listener.go
+++ b/pkg/messaging/queue/listener.go
@@ -58,7 +58,7 @@ func NewListener(
 		}
 		fn(&opts)
 	}
-	if opts.WorkerCount < 0 {
+	if opts.WorkerCount <= 0 {
 		return nil, fmt.Errorf("workerCount must be bigger than 0")
 	}
 	if callbackFn == nil {

--- a/pkg/messaging/queue/listener_test.go
+++ b/pkg/messaging/queue/listener_test.go
@@ -35,6 +35,14 @@ func TestNewListenerNegativeWorkerCount(t *testing.T) {
 	assert.Nil(t, listener)
 }
 
+func TestNewListenerZeroWorkerCount(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error { return nil }, queue.WithWorkerCount(0))
+	require.NotNil(t, err)
+	assert.ErrorContains(t, err, "workerCount")
+	assert.Nil(t, listener)
+}
+
 func TestNewListenerInvalidCallback(t *testing.T) {
 	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
 	listener, err := queue.NewListener(logger, nil)


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1183` from EN-1136.

This PR contains the scoped change: Reject zero queue workers.

Stack base: `feat/en-1182-licence-shutdown`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
