### PR TITLE
fix(queue): make listener close idempotent (EN-1184)

### DIFF
--- a/pkg/messaging/queue/listener.go
+++ b/pkg/messaging/queue/listener.go
@@ -32,6 +32,7 @@ type listener struct {
 	wg         *sync.WaitGroup
 	mux        *sync.Mutex
 	hasStarted bool
+	doneClosed bool
 
 	logger logging.Logger
 
@@ -80,13 +81,19 @@ func NewListener(
 // Start polling for messages
 func (l *listener) Listen(ctx context.Context, ch <-chan *message.Message) {
 	l.mux.Lock()
+	if l.hasStarted || l.doneClosed {
+		l.mux.Unlock()
+		return
+	}
 	l.hasStarted = true
 	l.logger.WithField("listenerName", l.name).WithField("workerCount", l.workerCount).Debugf("queue listener starting listen...")
+	for i := 0; i < l.workerCount; i++ {
+		l.wg.Add(1)
+	}
 	l.mux.Unlock()
 
 	// fan out and process messages concurrently
 	for i := 0; i < l.workerCount; i++ {
-		l.wg.Add(1)
 		go func() {
 			l.startWorker(ctx, ch)
 		}()
@@ -95,7 +102,9 @@ func (l *listener) Listen(ctx context.Context, ch <-chan *message.Message) {
 	go func() {
 		l.wg.Wait()
 		l.logger.WithField("listenerName", l.name).Infof("queue listener closed")
-		close(l.done)
+		l.mux.Lock()
+		l.closeDoneLocked()
+		l.mux.Unlock()
 	}()
 	return
 }
@@ -106,9 +115,17 @@ func (l *listener) Done() <-chan struct{} {
 	defer l.mux.Unlock()
 	if !l.hasStarted {
 		// listen was never called
-		close(l.done)
+		l.closeDoneLocked()
 	}
 	return l.done
+}
+
+func (l *listener) closeDoneLocked() {
+	if l.doneClosed {
+		return
+	}
+	l.doneClosed = true
+	close(l.done)
 }
 
 func (l *listener) startWorker(ctx context.Context, messages <-chan *message.Message) {

--- a/pkg/messaging/queue/listener.go
+++ b/pkg/messaging/queue/listener.go
@@ -86,14 +86,13 @@ func (l *listener) Listen(ctx context.Context, ch <-chan *message.Message) {
 		return
 	}
 	l.hasStarted = true
-	l.logger.WithField("listenerName", l.name).WithField("workerCount", l.workerCount).Debugf("queue listener starting listen...")
-	for i := 0; i < l.workerCount; i++ {
-		l.wg.Add(1)
-	}
+	workerCount := l.workerCount
+	l.logger.WithField("listenerName", l.name).WithField("workerCount", workerCount).Debugf("queue listener starting listen...")
 	l.mux.Unlock()
 
 	// fan out and process messages concurrently
-	for i := 0; i < l.workerCount; i++ {
+	for i := 0; i < workerCount; i++ {
+		l.wg.Add(1)
 		go func() {
 			l.startWorker(ctx, ch)
 		}()

--- a/pkg/messaging/queue/listener_test.go
+++ b/pkg/messaging/queue/listener_test.go
@@ -51,6 +51,81 @@ func TestNewListenerInvalidCallback(t *testing.T) {
 	assert.Nil(t, listener)
 }
 
+func TestListenerDoneIsIdempotentBeforeListen(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	done := listener.Done()
+	requireClosed(t, done)
+	assert.Equal(t, done, listener.Done())
+	requireClosed(t, done)
+}
+
+func TestListenerDoneBeforeListenMakesLaterListenNoop(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	called := make(chan struct{}, 1)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		called <- struct{}{}
+		return nil
+	})
+	require.NoError(t, err)
+
+	done := listener.Done()
+	requireClosed(t, done)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *message.Message, 1)
+	ch <- message.NewMessage("test-uuid", []byte("test-payload"))
+	listener.Listen(ctx, ch)
+
+	select {
+	case <-called:
+		t.Fatal("callback was called after listener was already done")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestListenerListenIsIdempotent(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	processed := make(chan string, 2)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		processed <- string(msg)
+		return nil
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstCh := make(chan *message.Message, 1)
+	secondCh := make(chan *message.Message, 1)
+	listener.Listen(ctx, firstCh)
+	listener.Listen(ctx, secondCh)
+
+	secondCh <- message.NewMessage("second-uuid", []byte("second"))
+	select {
+	case got := <-processed:
+		t.Fatalf("second Listen call processed message %q", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	firstCh <- message.NewMessage("first-uuid", []byte("first"))
+	select {
+	case got := <-processed:
+		assert.Equal(t, "first", got)
+	case <-time.After(time.Second):
+		t.Fatal("first Listen call did not process message")
+	}
+
+	cancel()
+	requireClosed(t, listener.Done())
+}
+
 func TestHandleMessageInjectsLoggerAndPropagatesTraceContext(t *testing.T) {
 	// Register W3C TraceContext propagator so Extract parses traceparent from metadata
 	otel.SetTextMapPropagator(propagation.TraceContext{})
@@ -126,4 +201,14 @@ func TestCallbackDeadlineForcesCancels(t *testing.T) {
 
 	cancel()
 	<-listener.Done()
+}
+
+func requireClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("channel was not closed")
+	}
 }


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1184` from EN-1136.

This PR contains the scoped change: Make queue listener close idempotent.

Stack base: `feat/en-1183-queue-worker-count`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
