### PR TITLE
fix(messaging): harden circuit breaker lifecycle (EN-1185)

### DIFF
--- a/pkg/messaging/publish/circuit/circuit_breaker.go
+++ b/pkg/messaging/publish/circuit/circuit_breaker.go
@@ -37,13 +37,23 @@ type CircuitBreaker struct {
 	stateMu sync.RWMutex
 	state   State
 
+	stopOnce sync.Once
+	doneOnce sync.Once
+
+	publisherCloseOnce sync.Once
+	publisherCloseErr  error
+
+	loopMu      sync.Mutex
+	loopCancel  context.CancelFunc
+	loopStarted bool
+
 	// openInterval is the time interval for the "open" state, before switching
 	// to the "half-open" state.
 	openInterval      time.Duration
 	openIntervalTimer *time.Timer
 
 	sendChan    chan *internalMessage
-	stopChannel chan chan struct{}
+	stopChannel chan struct{}
 	stopped     chan struct{}
 }
 
@@ -61,7 +71,7 @@ func NewCircuitBreaker(
 	openIntervalDuration time.Duration,
 ) *CircuitBreaker {
 	return &CircuitBreaker{
-		stopChannel: make(chan chan struct{}),
+		stopChannel: make(chan struct{}),
 		stopped:     make(chan struct{}),
 		logger:      logger,
 		publisher:   publisher,
@@ -109,10 +119,31 @@ func (cb *CircuitBreaker) CloseState() {
 }
 
 func (cb *CircuitBreaker) Loop(ctx context.Context) {
-	defer close(cb.stopped)
+	loopCtx, cancel := context.WithCancel(ctx)
+	if !cb.startLoop(cancel) {
+		cancel()
+		return
+	}
+	defer func() {
+		cb.clearLoopCancel()
+		cancel()
+		cb.markStopped()
+	}()
+
+	select {
+	case <-loopCtx.Done():
+		return
+	case <-cb.stopChannel:
+		return
+	default:
+	}
+
 	// Start in the half open state to fetch the messages from the database
 	cb.HalfOpenState()
-	if err := cb.catchUpDatabase(ctx); err != nil {
+	if err := cb.catchUpDatabase(loopCtx, ctx); err != nil {
+		if loopCtx.Err() != nil {
+			return
+		}
 		cb.OpenState()
 		// Don't switch to closed state if there was an error
 	} else {
@@ -122,9 +153,10 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 	for {
 		select {
-		case ch := <-cb.stopChannel:
-			close(ch)
-			// context cancelled
+		case <-loopCtx.Done():
+			return
+
+		case <-cb.stopChannel:
 			return
 
 		case <-cb.openIntervalTimer.C:
@@ -132,7 +164,10 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 			cb.HalfOpenState()
 
-			if err := cb.catchUpDatabase(ctx); err != nil {
+			if err := cb.catchUpDatabase(loopCtx, ctx); err != nil {
+				if loopCtx.Err() != nil {
+					return
+				}
 				cb.OpenState()
 				continue
 			}
@@ -146,7 +181,7 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 				return
 			}
 
-			switch cb.state {
+			switch cb.GetState() {
 			case StateClose:
 				// We are in the closed state, send the message to the publisher
 
@@ -160,12 +195,7 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 					// write the message in the database
 					err = cb.store.Insert(ctx, msg.topic, msg.msg.Payload, msg.msg.Metadata)
 					if err != nil {
-						select {
-						case msg.errChan <- err:
-						case ch := <-cb.stopChannel:
-							close(ch)
-							return
-						}
+						msg.errChan <- err
 						continue
 					}
 				}
@@ -175,30 +205,24 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 				err := cb.store.Insert(ctx, msg.topic, msg.msg.Payload, msg.msg.Metadata)
 				if err != nil {
-					select {
-					case msg.errChan <- err:
-					case ch := <-cb.stopChannel:
-						close(ch)
-						return
-					}
+					msg.errChan <- err
 					continue
 				}
 			}
 
-			select {
-			case msg.errChan <- nil:
-			case ch := <-cb.stopChannel:
-				close(ch)
-				return
-			}
+			msg.errChan <- nil
 		}
 	}
 }
 
-func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
+func (cb *CircuitBreaker) catchUpDatabase(loopCtx context.Context, storeCtx context.Context) error {
 	for {
+		if err := loopCtx.Err(); err != nil {
+			return err
+		}
+
 		// fetch the oldest messages from the database
-		messages, err := cb.store.List(ctx)
+		messages, err := cb.store.List(loopCtx)
 		if err != nil {
 			// error fetching messages, let's switch back to the open state
 			return err
@@ -210,11 +234,21 @@ func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 
 		messagesToDelete := make([]uint64, 0)
 		var publishError error
+		var stopError error
 		for _, msg := range messages {
+			if err := loopCtx.Err(); err != nil {
+				stopError = err
+				break
+			}
+
+			if err := storeCtx.Err(); err != nil {
+				return err
+			}
+
 			// We need to publish the messages one by one in order to know
 			// which one failed.
 
-			message, err := newMessage(ctx, msg.Data, msg.Metadata)
+			message, err := newMessage(storeCtx, msg.Data, msg.Metadata)
 			if err != nil {
 				publishError = err
 				break
@@ -229,21 +263,32 @@ func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 			messagesToDelete = append(messagesToDelete, msg.ID)
 		}
 
-		err = cb.store.Delete(ctx, messagesToDelete)
-		if err != nil {
-			// error deleting messages, let's switch back to the open state
-			return err
+		if len(messagesToDelete) > 0 {
+			err = cb.store.Delete(storeCtx, messagesToDelete)
+			if err != nil {
+				// error deleting messages, let's switch back to the open state
+				return err
+			}
 		}
 
 		if publishError != nil {
 			// we failed to publish all the messages
 			return publishError
 		}
+		if stopError != nil {
+			return stopError
+		}
 	}
 }
 
 func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) error {
 	for _, msg := range messages {
+		select {
+		case <-cb.stopChannel:
+			return errors.New("circuit breaker closed")
+		default:
+		}
+
 		errChan := make(chan error, 1)
 
 		internalMessage := &internalMessage{
@@ -254,29 +299,92 @@ func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) er
 
 		select {
 		case cb.sendChan <- internalMessage:
+		case <-cb.stopChannel:
+			return errors.New("circuit breaker closed")
 		case <-cb.stopped:
 			return errors.New("circuit breaker closed")
 		}
 
-		select {
-		case err := <-errChan:
-			if err != nil {
-				return err
-			}
-		case <-cb.stopped:
-			return errors.New("circuit breaker closed")
+		if err := waitAcceptedMessageResult(errChan, cb.stopped); err != nil {
+			return err
 		}
 	}
 
 	return nil
 }
 
-func (cb *CircuitBreaker) Close() error {
-	ch := make(chan struct{})
-	cb.stopChannel <- ch
-	<-ch
+func waitAcceptedMessageResult(errChan <-chan error, stopped <-chan struct{}) error {
+	select {
+	case err := <-errChan:
+		return err
+	case <-stopped:
+		select {
+		case err := <-errChan:
+			return err
+		default:
+			return errors.New("circuit breaker closed")
+		}
+	}
+}
 
-	return cb.publisher.Close()
+func (cb *CircuitBreaker) Close() error {
+	cb.stopOnce.Do(func() {
+		close(cb.stopChannel)
+		cb.cancelLoop()
+	})
+
+	if cb.hasLoopStarted() {
+		<-cb.stopped
+	} else {
+		cb.markStopped()
+	}
+
+	cb.publisherCloseOnce.Do(func() {
+		cb.publisherCloseErr = cb.publisher.Close()
+	})
+
+	return cb.publisherCloseErr
+}
+
+func (cb *CircuitBreaker) startLoop(cancel context.CancelFunc) bool {
+	cb.loopMu.Lock()
+	defer cb.loopMu.Unlock()
+
+	if cb.loopStarted {
+		return false
+	}
+
+	cb.loopStarted = true
+	cb.loopCancel = cancel
+	return true
+}
+
+func (cb *CircuitBreaker) clearLoopCancel() {
+	cb.loopMu.Lock()
+	cb.loopCancel = nil
+	cb.loopMu.Unlock()
+}
+
+func (cb *CircuitBreaker) cancelLoop() {
+	cb.loopMu.Lock()
+	cancel := cb.loopCancel
+	cb.loopMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (cb *CircuitBreaker) hasLoopStarted() bool {
+	cb.loopMu.Lock()
+	defer cb.loopMu.Unlock()
+	return cb.loopStarted
+}
+
+func (cb *CircuitBreaker) markStopped() {
+	cb.doneOnce.Do(func() {
+		close(cb.stopped)
+	})
 }
 
 const (
@@ -297,7 +405,7 @@ func newMessage(ctx context.Context, data []byte, metadata map[string]string) (*
 		if err != nil {
 			return nil, err
 		}
-		otel.GetTextMapPropagator().Inject(ctx, carrier)
+		ctx = otel.GetTextMapPropagator().Extract(ctx, carrier)
 	}
 
 	msg.SetContext(ctx)

--- a/pkg/messaging/publish/circuit/circuit_breaker_test.go
+++ b/pkg/messaging/publish/circuit/circuit_breaker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,7 +12,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish/circuit/storage"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
@@ -429,4 +434,521 @@ func TestCircuitBreaker(t *testing.T) {
 			assert.Equal(c, StateOpen, circuitBreaker.GetState())
 		}, 2*time.Second, 100*time.Millisecond)
 	})
+}
+
+func TestCircuitBreakerCloseWithoutLoopIsIdempotent(t *testing.T) {
+	messages := make(chan *testMessages, 10)
+	publisher := newMockPublisher(messages)
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		publisher,
+		newMockStore(),
+		5*time.Second,
+	)
+
+	requireCloseWithin(t, circuitBreaker)
+	requireCloseWithin(t, circuitBreaker)
+	require.Equal(t, 1, publisher.CloseCount())
+}
+
+func TestCircuitBreakerCloseCancelsCatchUp(t *testing.T) {
+	store := &blockingListStore{
+		listStarted: make(chan struct{}, 1),
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(make(chan *testMessages, 10)),
+		store,
+		5*time.Second,
+	)
+
+	go circuitBreaker.Loop(context.Background())
+
+	select {
+	case <-store.listStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected catchup to start")
+	}
+
+	requireCloseWithin(t, circuitBreaker)
+}
+
+func TestCircuitBreakerCloseDrainsInFlightInsert(t *testing.T) {
+	store := &blockingInsertStore{
+		insertStarted:     make(chan struct{}, 1),
+		releaseInsert:     make(chan struct{}),
+		insertCtxCanceled: make(chan struct{}, 1),
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(make(chan *testMessages, 10)).WithPublishError(errors.New("publish failed")),
+		store,
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+
+	publishDone := make(chan error, 1)
+	go func() {
+		publishDone <- circuitBreaker.Publish("test", message.NewMessage("1", []byte("payload")))
+	}()
+
+	select {
+	case <-store.insertStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected insert to start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before insert completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	select {
+	case <-store.insertCtxCanceled:
+		t.Fatal("insert context was canceled before insert completed")
+	default:
+	}
+
+	close(store.releaseInsert)
+
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected Close to return after insert completed")
+	}
+	select {
+	case <-publishDone:
+	case <-time.After(time.Second):
+		t.Fatal("expected publish to return after close")
+	}
+	require.True(t, store.inserted)
+}
+
+func TestCircuitBreakerPublishWaitsForAcceptedMessageDuringClose(t *testing.T) {
+	publisher := &blockingPublishPublisher{
+		publishStarted: make(chan struct{}, 1),
+		releasePublish: make(chan struct{}),
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		publisher,
+		newMockStore(),
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+
+	publishDone := make(chan error, 1)
+	go func() {
+		publishDone <- circuitBreaker.Publish("test", message.NewMessage("1", []byte("payload")))
+	}()
+
+	select {
+	case <-publisher.publishStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected publish to start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-publishDone:
+		t.Fatalf("Publish returned before accepted message completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(publisher.releasePublish)
+
+	select {
+	case err := <-publishDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected Publish to return after accepted message completed")
+	}
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected Close to return after accepted message completed")
+	}
+}
+
+func TestWaitAcceptedMessageResultPrefersQueuedResultAfterStop(t *testing.T) {
+	errChan := make(chan error, 1)
+	errChan <- nil
+	stopped := make(chan struct{})
+	close(stopped)
+
+	require.NoError(t, waitAcceptedMessageResult(errChan, stopped))
+}
+
+func TestCircuitBreakerCloseDrainsInFlightReplayDelete(t *testing.T) {
+	messages := make(chan *testMessages, 10)
+	store := &blockingDeleteStore{
+		deleteStarted:     make(chan struct{}, 1),
+		releaseDelete:     make(chan struct{}),
+		deleteCtxCanceled: make(chan struct{}, 1),
+		messages: []*storage.CircuitBreakerModel{{
+			ID:    42,
+			Topic: "test",
+			Data:  []byte("payload"),
+		}},
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(messages),
+		store,
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+
+	select {
+	case <-messages:
+	case <-time.After(time.Second):
+		t.Fatal("expected replayed message")
+	}
+	select {
+	case <-store.deleteStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected delete to start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before delete completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	select {
+	case <-store.deleteCtxCanceled:
+		t.Fatal("delete context was canceled before delete completed")
+	default:
+	}
+
+	close(store.releaseDelete)
+
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected Close to return after delete completed")
+	}
+	require.Empty(t, store.messages)
+}
+
+func TestCircuitBreakerCloseStopsReplayAfterDeletingPublishedMessages(t *testing.T) {
+	publisher := &blockingReplayPublisher{
+		firstStarted:  make(chan struct{}, 1),
+		releaseFirst:  make(chan struct{}),
+		secondStarted: make(chan struct{}, 1),
+	}
+	store := &trackingReplayStore{
+		messages: []*storage.CircuitBreakerModel{
+			{ID: 1, Topic: "test", Data: []byte("first")},
+			{ID: 2, Topic: "test", Data: []byte("second")},
+		},
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		publisher,
+		store,
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+
+	select {
+	case <-publisher.firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected first replay publish to start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before first replay publish completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(publisher.releaseFirst)
+
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected Close to return after deleting published replay")
+	}
+	select {
+	case <-publisher.secondStarted:
+		t.Fatal("second replay message should not be published after close")
+	default:
+	}
+	require.Equal(t, []uint64{1}, store.deletedIDs)
+	require.Len(t, store.messages, 1)
+	require.Equal(t, uint64(2), store.messages[0].ID)
+}
+
+func TestCircuitBreakerLoopStopsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(make(chan *testMessages, 10)),
+		newMockStore(),
+		5*time.Second,
+	)
+
+	go circuitBreaker.Loop(ctx)
+	require.Eventually(t, circuitBreaker.hasLoopStarted, time.Second, 10*time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-circuitBreaker.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("expected loop to stop after context cancellation")
+	}
+
+	require.NoError(t, circuitBreaker.Close())
+}
+
+func TestCircuitBreakerCatchUpExtractsStoredTraceContext(t *testing.T) {
+	originalPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTextMapPropagator(originalPropagator)
+	})
+
+	messages := make(chan *testMessages, 10)
+	store := newMockStore()
+	require.NoError(t, store.Insert(context.Background(), "test", []byte("test"), map[string]string{
+		otelContextKey: `{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`,
+	}))
+
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(messages),
+		store,
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+	defer func() {
+		require.NoError(t, circuitBreaker.Close())
+	}()
+
+	var received *testMessages
+	select {
+	case received = <-messages:
+	case <-time.After(time.Second):
+		t.Fatal("expected replayed message")
+	}
+
+	spanContext := trace.SpanContextFromContext(received.msg.Context())
+	require.True(t, spanContext.IsValid())
+	require.True(t, spanContext.IsRemote())
+	require.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", spanContext.TraceID().String())
+	require.Equal(t, "00f067aa0ba902b7", spanContext.SpanID().String())
+}
+
+func requireCloseWithin(t *testing.T, circuitBreaker *CircuitBreaker) {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected circuit breaker close to return")
+	}
+}
+
+type blockingListStore struct {
+	listStarted chan struct{}
+}
+
+func (s *blockingListStore) Insert(ctx context.Context, topic string, data []byte, metadata map[string]string) error {
+	return nil
+}
+
+func (s *blockingListStore) List(ctx context.Context) ([]*storage.CircuitBreakerModel, error) {
+	select {
+	case s.listStarted <- struct{}{}:
+	default:
+	}
+
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *blockingListStore) Delete(ctx context.Context, ids []uint64) error {
+	return nil
+}
+
+type blockingInsertStore struct {
+	insertStarted     chan struct{}
+	releaseInsert     chan struct{}
+	insertCtxCanceled chan struct{}
+	inserted          bool
+}
+
+func (s *blockingInsertStore) Insert(ctx context.Context, topic string, data []byte, metadata map[string]string) error {
+	select {
+	case s.insertStarted <- struct{}{}:
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		select {
+		case s.insertCtxCanceled <- struct{}{}:
+		default:
+		}
+		return ctx.Err()
+	case <-s.releaseInsert:
+		s.inserted = true
+		return nil
+	}
+}
+
+func (s *blockingInsertStore) List(ctx context.Context) ([]*storage.CircuitBreakerModel, error) {
+	return nil, nil
+}
+
+func (s *blockingInsertStore) Delete(ctx context.Context, ids []uint64) error {
+	return nil
+}
+
+type blockingDeleteStore struct {
+	deleteStarted     chan struct{}
+	releaseDelete     chan struct{}
+	deleteCtxCanceled chan struct{}
+	messages          []*storage.CircuitBreakerModel
+}
+
+func (s *blockingDeleteStore) Insert(ctx context.Context, topic string, data []byte, metadata map[string]string) error {
+	return nil
+}
+
+func (s *blockingDeleteStore) List(ctx context.Context) ([]*storage.CircuitBreakerModel, error) {
+	result := make([]*storage.CircuitBreakerModel, len(s.messages))
+	copy(result, s.messages)
+	return result, nil
+}
+
+func (s *blockingDeleteStore) Delete(ctx context.Context, ids []uint64) error {
+	select {
+	case s.deleteStarted <- struct{}{}:
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		select {
+		case s.deleteCtxCanceled <- struct{}{}:
+		default:
+		}
+		return ctx.Err()
+	case <-s.releaseDelete:
+		s.messages = nil
+		return nil
+	}
+}
+
+type blockingPublishPublisher struct {
+	publishStarted chan struct{}
+	releasePublish chan struct{}
+}
+
+func (p *blockingPublishPublisher) Publish(topic string, messages ...*message.Message) error {
+	select {
+	case p.publishStarted <- struct{}{}:
+	default:
+	}
+	<-p.releasePublish
+	return nil
+}
+
+func (p *blockingPublishPublisher) Close() error {
+	return nil
+}
+
+type blockingReplayPublisher struct {
+	calls         atomic.Int32
+	firstStarted  chan struct{}
+	releaseFirst  chan struct{}
+	secondStarted chan struct{}
+}
+
+func (p *blockingReplayPublisher) Publish(topic string, messages ...*message.Message) error {
+	if p.calls.Add(1) == 1 {
+		select {
+		case p.firstStarted <- struct{}{}:
+		default:
+		}
+		<-p.releaseFirst
+		return nil
+	}
+
+	select {
+	case p.secondStarted <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (p *blockingReplayPublisher) Close() error {
+	return nil
+}
+
+type trackingReplayStore struct {
+	messages   []*storage.CircuitBreakerModel
+	deletedIDs []uint64
+}
+
+func (s *trackingReplayStore) Insert(ctx context.Context, topic string, data []byte, metadata map[string]string) error {
+	return nil
+}
+
+func (s *trackingReplayStore) List(ctx context.Context) ([]*storage.CircuitBreakerModel, error) {
+	result := make([]*storage.CircuitBreakerModel, len(s.messages))
+	copy(result, s.messages)
+	return result, nil
+}
+
+func (s *trackingReplayStore) Delete(ctx context.Context, ids []uint64) error {
+	s.deletedIDs = append(s.deletedIDs, ids...)
+
+	remaining := s.messages[:0]
+	for _, msg := range s.messages {
+		deleted := false
+		for _, id := range ids {
+			if msg.ID == id {
+				deleted = true
+				break
+			}
+		}
+		if !deleted {
+			remaining = append(remaining, msg)
+		}
+	}
+	s.messages = remaining
+	return nil
 }

--- a/pkg/messaging/publish/circuit/utils_test.go
+++ b/pkg/messaging/publish/circuit/utils_test.go
@@ -22,6 +22,7 @@ type testMessages struct {
 type mockPublisher struct {
 	mu       sync.RWMutex
 	err      error
+	closed   int
 	messages chan *testMessages
 }
 
@@ -64,7 +65,14 @@ func (p *mockPublisher) Publish(topic string, messages ...*message.Message) erro
 func (p *mockPublisher) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.closed++
 	return nil
+}
+
+func (p *mockPublisher) CloseCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.closed
 }
 
 type MockStore struct {


### PR DESCRIPTION
## Summary

- Rebased EN-1185 circuit breaker lifecycle hardening onto `main` after the first rollup merge.
- Split close cancellation from durable store operations so accepted `Insert` and replay `Delete` calls can drain safely.
- Stop replay promptly on close while deleting only messages already published during that replay pass.

## Validation

- `go test ./pkg/messaging/publish/circuit`
- GitHub checks passing: `Dirty`, `Tests`, `Analyze (go)`, `Check PR Title`, CodeRabbit
