### PR TITLE
fix(health): honor check context cancellation (EN-1186)

### DIFF
--- a/pkg/audit/httpaudit/middleware.go
+++ b/pkg/audit/httpaudit/middleware.go
@@ -28,7 +28,7 @@ type httpOptions struct {
 	handledHeaderSecret string
 }
 
-// WithSensitivePaths sets paths for which the response body should not be captured.
+// WithSensitivePaths sets path prefixes for which request and response bodies should not be captured.
 func WithSensitivePaths(paths ...string) HTTPOption {
 	return func(o *httpOptions) {
 		for _, p := range paths {
@@ -150,7 +150,9 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				err  error
 			)
 
-			if !isStreamRequest(r) {
+			sensitivePath := ho.isSensitivePath(r.URL.Path)
+
+			if !isStreamRequest(r) && !sensitivePath {
 				body, err = io.ReadAll(r.Body)
 				if err != nil && !errors.Is(err, io.EOF) {
 					http.Error(w, "failed to read request body", http.StatusInternalServerError)
@@ -162,9 +164,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				}
 			}
 
-			requestHeaders := r.Header.Clone()
-			requestHeaders.Del("Authorization")
-			requestHeaders.Del(audit.HandledHeader)
+			requestHeaders := cloneHeaderWithout(r.Header, "Authorization", "Cookie", audit.HandledHeader)
 
 			r.Header.Set(audit.HandledHeader, handledHeaderValue)
 
@@ -176,14 +176,16 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				ResponseWriter: w,
 				body:           buf,
 				statusCode:     http.StatusOK,
+				captureBody:    !sensitivePath,
 			}
 
 			next.ServeHTTP(rww, r)
 
-			responseBody := rww.body.String()
-			if _, sensitive := ho.sensitivePaths[r.URL.Path]; sensitive {
-				responseBody = ""
+			responseBody := ""
+			if !sensitivePath {
+				responseBody = rww.body.String()
 			}
+			responseHeaders := cloneHeaderWithout(rww.Header(), "Set-Cookie")
 
 			actor := audit.ExtractClaims(r, auditOpts)
 
@@ -206,7 +208,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 					},
 					Response: audit.HTTPResponse{
 						StatusCode: rww.statusCode,
-						Headers:    rww.Header(),
+						Headers:    responseHeaders,
 						Body:       responseBody,
 					},
 				},
@@ -217,6 +219,36 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 	}
 }
 
+func cloneHeaderWithout(header http.Header, names ...string) http.Header {
+	clone := header.Clone()
+	for _, name := range names {
+		clone.Del(name)
+	}
+	return clone
+}
+
+func (o *httpOptions) isSensitivePath(requestPath string) bool {
+	for sensitivePath := range o.sensitivePaths {
+		if pathMatchesPrefix(requestPath, sensitivePath) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathMatchesPrefix(requestPath string, sensitivePath string) bool {
+	if sensitivePath == "" {
+		return false
+	}
+
+	sensitivePath = strings.TrimRight(sensitivePath, "/")
+	if sensitivePath == "" {
+		return strings.HasPrefix(requestPath, "/")
+	}
+
+	return requestPath == sensitivePath || strings.HasPrefix(requestPath, sensitivePath+"/")
+}
+
 func isStreamRequest(r *http.Request) bool {
 	ct := r.Header.Get("Content-Type")
 	return strings.HasPrefix(ct, "application/vnd.formance") && strings.HasSuffix(ct, "-stream")
@@ -224,14 +256,17 @@ func isStreamRequest(r *http.Request) bool {
 
 type responseWriterWrapper struct {
 	http.ResponseWriter
-	body       *bytes.Buffer
-	statusCode int
+	body        *bytes.Buffer
+	statusCode  int
+	captureBody bool
 }
 
 func (rww *responseWriterWrapper) Write(buf []byte) (int, error) {
-	mediaType, _, _ := mime.ParseMediaType(rww.Header().Get("Content-Type"))
-	if mediaType != "application/octet-stream" {
-		rww.body.Write(buf)
+	if rww.captureBody {
+		mediaType, _, _ := mime.ParseMediaType(rww.Header().Get("Content-Type"))
+		if mediaType != "application/octet-stream" {
+			rww.body.Write(buf)
+		}
 	}
 	return rww.ResponseWriter.Write(buf)
 }

--- a/pkg/audit/httpaudit/middleware.go
+++ b/pkg/audit/httpaudit/middleware.go
@@ -90,6 +90,8 @@ var bufPool = sync.Pool{
 	},
 }
 
+const maxCapturedBodyBytes = 64 * 1024
+
 // Middleware returns an HTTP middleware that captures request/response data
 // and publishes audit events via the given Watermill publisher.
 func Middleware(publisher message.Publisher, topicName string, appName string, opts []audit.Option, httpOpts ...HTTPOption) func(http.Handler) http.Handler {
@@ -153,14 +155,10 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 			sensitivePath := ho.isSensitivePath(r.URL.Path)
 
 			if !isStreamRequest(r) && !sensitivePath {
-				body, err = io.ReadAll(r.Body)
+				body, err = captureRequestBody(r)
 				if err != nil && !errors.Is(err, io.EOF) {
 					http.Error(w, "failed to read request body", http.StatusInternalServerError)
 					return
-				}
-				if len(body) > 0 {
-					_ = r.Body.Close()
-					r.Body = io.NopCloser(bytes.NewBuffer(body))
 				}
 			}
 
@@ -170,7 +168,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 
 			buf := bufPool.Get().(*bytes.Buffer)
 			buf.Reset()
-			defer bufPool.Put(buf)
+			defer putCaptureBuffer(buf)
 
 			rww := &responseWriterWrapper{
 				ResponseWriter: w,
@@ -219,6 +217,37 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 	}
 }
 
+func captureRequestBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxCapturedBodyBytes))
+	if len(body) > 0 {
+		r.Body = readCloser{
+			Reader: io.MultiReader(bytes.NewReader(body), r.Body),
+			Closer: r.Body,
+		}
+	}
+	return body, err
+}
+
+func putCaptureBuffer(buf *bytes.Buffer) {
+	if shouldPoolCaptureBuffer(buf) {
+		buf.Reset()
+		bufPool.Put(buf)
+	}
+}
+
+func shouldPoolCaptureBuffer(buf *bytes.Buffer) bool {
+	return buf.Cap() <= maxCapturedBodyBytes
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
 func cloneHeaderWithout(header http.Header, names ...string) http.Header {
 	clone := header.Clone()
 	for _, name := range names {
@@ -265,7 +294,14 @@ func (rww *responseWriterWrapper) Write(buf []byte) (int, error) {
 	if rww.captureBody {
 		mediaType, _, _ := mime.ParseMediaType(rww.Header().Get("Content-Type"))
 		if mediaType != "application/octet-stream" {
-			rww.body.Write(buf)
+			remaining := maxCapturedBodyBytes - rww.body.Len()
+			if remaining > 0 {
+				captured := buf
+				if len(captured) > remaining {
+					captured = captured[:remaining]
+				}
+				rww.body.Write(captured)
+			}
 		}
 	}
 	return rww.ResponseWriter.Write(buf)

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -159,6 +159,51 @@ func TestMiddleware_AuthorizationHeaderStripped(t *testing.T) {
 	assert.Empty(t, payload.HTTP.Request.Header.Get("Authorization"))
 }
 
+func TestMiddleware_CookieHeadersStripped(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Response-ID", "response-id")
+			http.SetCookie(w, &http.Cookie{
+				Name:  "session",
+				Value: "response-secret",
+			})
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Cookie", "session=request-secret")
+	req.Header.Set("X-Request-ID", "request-id")
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Contains(t, rr.Header().Get("Set-Cookie"), "response-secret")
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(messages[0].Payload, &event))
+
+	payloadBytes, _ := json.Marshal(event.Payload)
+	var payload audit.Payload
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+
+	assert.Empty(t, payload.HTTP.Request.Header.Get("Cookie"))
+	assert.Equal(t, "request-id", payload.HTTP.Request.Header.Get("X-Request-ID"))
+	assert.Empty(t, payload.HTTP.Response.Headers.Get("Set-Cookie"))
+	assert.Equal(t, "response-id", payload.HTTP.Response.Headers.Get("X-Response-ID"))
+	assert.NotContains(t, string(messages[0].Payload), "request-secret")
+	assert.NotContains(t, string(messages[0].Payload), "response-secret")
+}
+
 func TestMiddleware_SensitivePaths(t *testing.T) {
 	t.Parallel()
 
@@ -194,6 +239,56 @@ func TestMiddleware_SensitivePaths(t *testing.T) {
 	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
 
 	assert.Empty(t, payload.HTTP.Response.Body)
+	assert.Empty(t, payload.HTTP.Request.Body)
+	assert.NotContains(t, string(messages[0].Payload), "client_credentials")
+	assert.NotContains(t, string(messages[0].Payload), "access_token")
+}
+
+func TestMiddleware_SensitivePathsMatchPrefixAndPassRequestBodyThrough(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	var receivedBody string
+	handler := Middleware(pub, topic, "test-app", nil,
+		WithEnabled(true),
+		WithSensitivePaths("/api/auth"),
+	)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			receivedBody = string(body)
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"access_token":"response-secret"}`))
+		}),
+	)
+
+	reqBody := `username=alice&password=request-secret`
+	req := httptest.NewRequest("POST", "/api/auth/oauth/token", strings.NewReader(reqBody))
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, reqBody, receivedBody)
+	require.Equal(t, `{"access_token":"response-secret"}`, rr.Body.String())
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(messages[0].Payload, &event))
+
+	payloadBytes, _ := json.Marshal(event.Payload)
+	var payload audit.Payload
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+
+	assert.Empty(t, payload.HTTP.Request.Body)
+	assert.Empty(t, payload.HTTP.Response.Body)
+	assert.NotContains(t, string(messages[0].Payload), "request-secret")
+	assert.NotContains(t, string(messages[0].Payload), "response-secret")
 }
 
 func TestMiddleware_StreamRequestSkipsBodyCapture(t *testing.T) {

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -127,6 +127,85 @@ func TestMiddleware_BasicCapture(t *testing.T) {
 	assert.Equal(t, `{"status":"ok"}`, payload.HTTP.Response.Body)
 }
 
+func TestMiddleware_CapsRequestBodyCaptureAndPassesFullBodyThrough(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	var receivedBody string
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			receivedBody = string(body)
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	capturedPrefix := strings.Repeat("a", maxCapturedBodyBytes)
+	reqBody := capturedPrefix + strings.Repeat("b", 1024)
+	req := httptest.NewRequest("POST", "/api/test", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, reqBody, receivedBody)
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	require.Len(t, payload.HTTP.Request.Body, maxCapturedBodyBytes)
+	assert.Equal(t, capturedPrefix, payload.HTTP.Request.Body)
+	assert.NotContains(t, payload.HTTP.Request.Body, "b")
+}
+
+func TestMiddleware_CapsResponseBodyCaptureAndWritesFullResponse(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	capturedPrefix := strings.Repeat("r", maxCapturedBodyBytes)
+	responseBody := capturedPrefix + strings.Repeat("s", 1024)
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(responseBody[:maxCapturedBodyBytes/2]))
+			_, _ = w.Write([]byte(responseBody[maxCapturedBodyBytes/2:]))
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, responseBody, rr.Body.String())
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	require.Len(t, payload.HTTP.Response.Body, maxCapturedBodyBytes)
+	assert.Equal(t, capturedPrefix, payload.HTTP.Response.Body)
+	assert.NotContains(t, payload.HTTP.Response.Body, "s")
+}
+
+func TestMiddleware_DoesNotPoolOversizedCaptureBuffers(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, shouldPoolCaptureBuffer(bytes.NewBuffer(make([]byte, 0, maxCapturedBodyBytes))))
+	assert.False(t, shouldPoolCaptureBuffer(bytes.NewBuffer(make([]byte, 0, maxCapturedBodyBytes+1))))
+}
+
 func TestMiddleware_AuthorizationHeaderStripped(t *testing.T) {
 	t.Parallel()
 
@@ -238,8 +317,8 @@ func TestMiddleware_SensitivePaths(t *testing.T) {
 	var payload audit.Payload
 	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
 
-	assert.Empty(t, payload.HTTP.Response.Body)
 	assert.Empty(t, payload.HTTP.Request.Body)
+	assert.Empty(t, payload.HTTP.Response.Body)
 	assert.NotContains(t, string(messages[0].Payload), "client_credentials")
 	assert.NotContains(t, string(messages[0].Payload), "access_token")
 }
@@ -285,6 +364,7 @@ func TestMiddleware_SensitivePathsMatchPrefixAndPassRequestBodyThrough(t *testin
 	var payload audit.Payload
 	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
 
+	assert.Equal(t, "/api/auth/oauth/token", payload.HTTP.Request.Path)
 	assert.Empty(t, payload.HTTP.Request.Body)
 	assert.Empty(t, payload.HTTP.Response.Body)
 	assert.NotContains(t, string(messages[0].Payload), "request-secret")
@@ -1064,6 +1144,20 @@ func TestAsyncPublisher_CloseRespectsContextTimeout(t *testing.T) {
 
 	pub.release()
 	require.NoError(t, asyncPublisher.Close(context.Background()))
+}
+
+func auditPayloadFromMessage(t *testing.T, msg *message.Message) audit.Payload {
+	t.Helper()
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(msg.Payload, &event))
+
+	payloadBytes, err := json.Marshal(event.Payload)
+	require.NoError(t, err)
+
+	var payload audit.Payload
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+	return payload
 }
 
 func serveAuditRequest(t *testing.T, handler http.Handler) {

--- a/pkg/authn/jwt/auth.go
+++ b/pkg/authn/jwt/auth.go
@@ -129,5 +129,9 @@ func ClaimsFromRequest(r *http.Request, keySets map[string]oidc.KeySet) (*oidc.A
 		return claims, err
 	}
 
+	if err := oidc.CheckNotBefore(claims, 0); err != nil {
+		return claims, err
+	}
+
 	return claims, nil
 }

--- a/pkg/authn/jwt/auth_test.go
+++ b/pkg/authn/jwt/auth_test.go
@@ -61,6 +61,10 @@ func createAccessToken(t *testing.T, privateKey *rsa.PrivateKey, issuer string, 
 	// Set scopes
 	accessTokenClaims.Scopes = scopes
 
+	return signAccessTokenClaims(t, privateKey, accessTokenClaims)
+}
+
+func signAccessTokenClaims(t *testing.T, privateKey *rsa.PrivateKey, accessTokenClaims *oidc.AccessTokenClaims) string {
 	// Create JWT using go-jose
 	signer, err := jose.NewSigner(
 		jose.SigningKey{
@@ -314,6 +318,52 @@ func TestJWTAuth_Authenticate(t *testing.T) {
 
 				authenticated, err := tt.auth.Authenticate(nil, req)
 				require.Error(t, err)
+				assert.False(t, authenticated)
+			})
+		}
+	})
+
+	t.Run("failure with token before not-before time", func(t *testing.T) {
+		t.Parallel()
+		keySet, privateKey, issuer := setupTestKeySet(t)
+		tests := []struct {
+			name string
+			auth Authenticator
+		}{
+			{
+				name: "JWTAuth",
+				auth: NewJWTAuth(map[string]oidc.KeySet{issuer: keySet}, "test-service", false, nil),
+			},
+			{
+				name: "JWTAuth with additional checks",
+				auth: NewJWTAuth(map[string]oidc.KeySet{issuer: keySet}, "test-service", false, autoPassingAdditionalChecks),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				now := stdtime.Now().UTC()
+				expirationTime := libtime.New(now.Add(2 * stdtime.Hour))
+
+				accessTokenClaims := oidc.NewAccessTokenClaims(
+					issuer,
+					"test-user",
+					[]string{"test-client"},
+					expirationTime,
+					"test-jti",
+					"test-client",
+				)
+				accessTokenClaims.NotBefore = oidc.FromTime(libtime.New(now.Add(1 * stdtime.Hour)))
+
+				token := signAccessTokenClaims(t, privateKey, accessTokenClaims)
+
+				req := httptest.NewRequest("GET", "/test", nil)
+				req.Header.Set("Authorization", "Bearer "+token)
+				req = req.WithContext(logging.TestingContext())
+
+				authenticated, err := tt.auth.Authenticate(nil, req)
+				require.Error(t, err)
+				assert.ErrorIs(t, err, oidc.ErrNotBefore)
 				assert.False(t, authenticated)
 			})
 		}

--- a/pkg/authn/jwt/module_test.go
+++ b/pkg/authn/jwt/module_test.go
@@ -30,10 +30,11 @@ func setupTestOIDCServer(t *testing.T) (*httptest.Server, string, chan bool) {
 	// Discovery endpoint
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		discoveryCalled <- true
+		issuer := "http://" + r.Host
 
 		config := oidc.DiscoveryConfiguration{
-			Issuer:  r.URL.Scheme + "://" + r.Host,
-			JwksURI: r.URL.Scheme + "://" + r.Host + "/.well-known/jwks.json",
+			Issuer:  issuer,
+			JwksURI: issuer + "/.well-known/jwks.json",
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/authn/licence/jwt.go
+++ b/pkg/authn/licence/jwt.go
@@ -93,6 +93,10 @@ func ValidateToken(jwtToken string, expectedIssuer string, opts ...ValidateToken
 }
 
 func (l *Licence) validate() error {
+	if l.validateToken != nil {
+		return l.validateToken()
+	}
+
 	return ValidateToken(
 		l.jwtToken,
 		l.expectedIssuer,

--- a/pkg/authn/licence/licence.go
+++ b/pkg/authn/licence/licence.go
@@ -1,6 +1,7 @@
 package licence
 
 import (
+	"sync"
 	"time"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -12,6 +13,9 @@ type Licence struct {
 	jwtToken            string
 	licenceValidateTick time.Duration
 	appStoped           chan struct{}
+	stopOnce            sync.Once
+	wg                  sync.WaitGroup
+	validateToken       func() error
 
 	// Will be checked in claims (aud claim)
 	serviceName string
@@ -42,6 +46,7 @@ func NewLicence(
 
 func (l *Licence) run(licenceError chan error) {
 	ticker := time.NewTicker(l.licenceValidateTick)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -72,11 +77,20 @@ func (l *Licence) Start(licenceError chan error) error {
 	}
 	l.logger.Info("Licence check passed")
 
-	go l.run(licenceError)
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		l.run(licenceError)
+	}()
 
 	return nil
 }
 
 func (l *Licence) Stop() {
-	close(l.appStoped)
+	l.stopOnce.Do(func() {
+		if l.appStoped != nil {
+			close(l.appStoped)
+		}
+	})
+	l.wg.Wait()
 }

--- a/pkg/authn/licence/licence_test.go
+++ b/pkg/authn/licence/licence_test.go
@@ -6,9 +6,11 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -205,6 +207,94 @@ func TestLicence_Start(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		require.Equal(t, "Licence check stopped, app stopped", logger.getMessage())
 	})
+}
+
+func TestLicence_StopIsIdempotent(t *testing.T) {
+	privateKey, pubPEM := generateTestRSAKeyPair(t)
+	setEmbeddedKey(t, pubPEM)
+
+	logger := &mockLogger{}
+	claims := jwt.MapClaims{
+		"sub": "test-cluster",
+		"aud": "test-service",
+		"iss": "test-issuer",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	tokenString := createTokenWithRSAKey(t, claims, privateKey)
+
+	licence := NewLicence(
+		logger,
+		tokenString,
+		time.Minute,
+		"test-service",
+		"test-cluster",
+		"test-issuer",
+	)
+
+	licenceError := make(chan error, 1)
+	require.NoError(t, licence.Start(licenceError))
+	require.NotPanics(t, func() {
+		licence.Stop()
+		licence.Stop()
+	})
+}
+
+func TestLicence_StopWaitsForInFlightValidationBeforeChannelClose(t *testing.T) {
+	logger := &mockLogger{}
+	licence := NewLicence(
+		logger,
+		"unused-token",
+		10*time.Millisecond,
+		"test-service",
+		"test-cluster",
+		"test-issuer",
+	)
+
+	validateStarted := make(chan struct{})
+	releaseValidate := make(chan struct{})
+	var validateCalls atomic.Int32
+	licence.validateToken = func() error {
+		if validateCalls.Add(1) == 1 {
+			return nil
+		}
+
+		close(validateStarted)
+		<-releaseValidate
+		return errors.New("licence validation failed")
+	}
+
+	licenceError := make(chan error, 1)
+	require.NoError(t, licence.Start(licenceError))
+
+	select {
+	case <-validateStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for licence validation to start")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		licence.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned before in-flight validation completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseValidate)
+
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Stop to return")
+	}
+
+	close(licenceError)
+	err := <-licenceError
+	require.EqualError(t, err, "licence validation failed")
 }
 
 func TestValidateToken(t *testing.T) {

--- a/pkg/authn/oidc/client/discover.go
+++ b/pkg/authn/oidc/client/discover.go
@@ -3,12 +3,17 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
 	httphelper "github.com/formancehq/go-libs/v5/pkg/authn/oidc/http"
 )
+
+type issuerGetter interface {
+	GetIssuer() string
+}
 
 // Discover calls the discovery endpoint of the provided issuer and returns its configuration
 // It accepts an optional argument "wellknownUrl" which can be used to override the discovery endpoint url
@@ -27,6 +32,21 @@ func Discover[V any](ctx context.Context, issuer string, httpClient *http.Client
 	if err != nil {
 		return nil, errors.Join(oidc.ErrDiscoveryFailed, err)
 	}
+	if err := validateDiscoveredIssuer(issuer, discoveryConfig); err != nil {
+		return nil, errors.Join(oidc.ErrDiscoveryFailed, err)
+	}
 
 	return discoveryConfig, nil
+}
+
+func validateDiscoveredIssuer[V any](issuer string, discoveryConfig *V) error {
+	issuerConfig, ok := any(discoveryConfig).(issuerGetter)
+	if !ok {
+		return nil
+	}
+	discoveredIssuer := issuerConfig.GetIssuer()
+	if discoveredIssuer != issuer {
+		return fmt.Errorf("%w: Expected: %s, got: %s", oidc.ErrIssuerInvalid, issuer, discoveredIssuer)
+	}
+	return nil
 }

--- a/pkg/authn/oidc/client/discover_test.go
+++ b/pkg/authn/oidc/client/discover_test.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
+)
+
+func TestDiscoverValidatesIssuer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns discovery configuration when issuer matches", func(t *testing.T) {
+		t.Parallel()
+
+		issuer := "https://issuer.example.com"
+		server := httptest.NewServer(discoveryHandler(t, issuer))
+		t.Cleanup(server.Close)
+
+		discoveryConfig, err := Discover[oidc.DiscoveryConfiguration](
+			context.Background(),
+			issuer,
+			server.Client(),
+			server.URL,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, issuer, discoveryConfig.Issuer)
+	})
+
+	t.Run("rejects discovery configuration when issuer differs", func(t *testing.T) {
+		t.Parallel()
+
+		issuer := "https://issuer.example.com"
+		discoveredIssuer := "https://other-issuer.example.com"
+		server := httptest.NewServer(discoveryHandler(t, discoveredIssuer))
+		t.Cleanup(server.Close)
+
+		discoveryConfig, err := Discover[oidc.DiscoveryConfiguration](
+			context.Background(),
+			issuer,
+			server.Client(),
+			server.URL,
+		)
+
+		require.Nil(t, discoveryConfig)
+		require.ErrorIs(t, err, oidc.ErrDiscoveryFailed)
+		require.ErrorIs(t, err, oidc.ErrIssuerInvalid)
+		require.ErrorContains(t, err, "Expected: "+issuer+", got: "+discoveredIssuer)
+	})
+}
+
+func discoveryHandler(t *testing.T, issuer string) http.Handler {
+	t.Helper()
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(oidc.DiscoveryConfiguration{
+			Issuer:  issuer,
+			JwksURI: issuer + "/.well-known/jwks.json",
+		})
+		require.NoError(t, err)
+	})
+}

--- a/pkg/authn/oidc/discovery.go
+++ b/pkg/authn/oidc/discovery.go
@@ -162,6 +162,13 @@ type DiscoveryConfiguration struct {
 	BackChannelLogoutSessionSupported bool `json:"backchannel_logout_session_supported,omitempty"`
 }
 
+func (d *DiscoveryConfiguration) GetIssuer() string {
+	if d == nil {
+		return ""
+	}
+	return d.Issuer
+}
+
 type AuthMethod string
 
 const (

--- a/pkg/authn/oidc/token.go
+++ b/pkg/authn/oidc/token.go
@@ -68,6 +68,10 @@ func (c *TokenClaims) GetIssuedAt() time.Time {
 	return c.IssuedAt.AsTime()
 }
 
+func (c *TokenClaims) GetNotBefore() time.Time {
+	return c.NotBefore.AsTime()
+}
+
 func (c *TokenClaims) GetNonce() string {
 	return c.Nonce
 }

--- a/pkg/authn/oidc/verifier.go
+++ b/pkg/authn/oidc/verifier.go
@@ -27,6 +27,10 @@ type Claims interface {
 	GetAuthorizedParty() string
 }
 
+type NotBeforeClaims interface {
+	GetNotBefore() time.Time
+}
+
 type IDClaims interface {
 	Claims
 	GetAccessTokenHash() string
@@ -46,6 +50,7 @@ var (
 	ErrSignatureInvalidPayload = errors.New("signature does not match Payload")
 	ErrSignatureInvalid        = errors.New("invalid signature")
 	ErrExpired                 = errors.New("token has expired")
+	ErrNotBefore               = errors.New("token is not valid yet")
 	ErrIatMissing              = errors.New("issuedAt of token is missing")
 	ErrIatInFuture             = errors.New("issuedAt of token is in the future")
 	ErrIatToOld                = errors.New("issuedAt of token is to old")
@@ -191,6 +196,18 @@ func CheckExpiration(claims Claims, offset time.Duration) error {
 	expiration := claims.GetExpiration()
 	if !time.Now().Add(offset).Before(expiration) {
 		return ErrExpired
+	}
+	return nil
+}
+
+func CheckNotBefore(claims NotBeforeClaims, offset time.Duration) error {
+	notBefore := claims.GetNotBefore()
+	if notBefore.IsZero() {
+		return nil
+	}
+	nowWithOffset := time.Now().Add(offset).Round(time.Second)
+	if nowWithOffset.Before(notBefore) {
+		return fmt.Errorf("%w: (nbf: %v, now with offset: %v)", ErrNotBefore, notBefore, nowWithOffset)
 	}
 	return nil
 }

--- a/pkg/messaging/publish/circuit/circuit_breaker.go
+++ b/pkg/messaging/publish/circuit/circuit_breaker.go
@@ -37,13 +37,23 @@ type CircuitBreaker struct {
 	stateMu sync.RWMutex
 	state   State
 
+	stopOnce sync.Once
+	doneOnce sync.Once
+
+	publisherCloseOnce sync.Once
+	publisherCloseErr  error
+
+	loopMu      sync.Mutex
+	loopCancel  context.CancelFunc
+	loopStarted bool
+
 	// openInterval is the time interval for the "open" state, before switching
 	// to the "half-open" state.
 	openInterval      time.Duration
 	openIntervalTimer *time.Timer
 
 	sendChan    chan *internalMessage
-	stopChannel chan chan struct{}
+	stopChannel chan struct{}
 	stopped     chan struct{}
 }
 
@@ -61,7 +71,7 @@ func NewCircuitBreaker(
 	openIntervalDuration time.Duration,
 ) *CircuitBreaker {
 	return &CircuitBreaker{
-		stopChannel: make(chan chan struct{}),
+		stopChannel: make(chan struct{}),
 		stopped:     make(chan struct{}),
 		logger:      logger,
 		publisher:   publisher,
@@ -109,10 +119,31 @@ func (cb *CircuitBreaker) CloseState() {
 }
 
 func (cb *CircuitBreaker) Loop(ctx context.Context) {
-	defer close(cb.stopped)
+	ctx, cancel := context.WithCancel(ctx)
+	if !cb.startLoop(cancel) {
+		cancel()
+		return
+	}
+	defer func() {
+		cb.clearLoopCancel()
+		cancel()
+		cb.markStopped()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-cb.stopChannel:
+		return
+	default:
+	}
+
 	// Start in the half open state to fetch the messages from the database
 	cb.HalfOpenState()
 	if err := cb.catchUpDatabase(ctx); err != nil {
+		if ctx.Err() != nil {
+			return
+		}
 		cb.OpenState()
 		// Don't switch to closed state if there was an error
 	} else {
@@ -122,9 +153,10 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 	for {
 		select {
-		case ch := <-cb.stopChannel:
-			close(ch)
-			// context cancelled
+		case <-ctx.Done():
+			return
+
+		case <-cb.stopChannel:
 			return
 
 		case <-cb.openIntervalTimer.C:
@@ -133,6 +165,9 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 			cb.HalfOpenState()
 
 			if err := cb.catchUpDatabase(ctx); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
 				cb.OpenState()
 				continue
 			}
@@ -146,7 +181,7 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 				return
 			}
 
-			switch cb.state {
+			switch cb.GetState() {
 			case StateClose:
 				// We are in the closed state, send the message to the publisher
 
@@ -162,8 +197,9 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 					if err != nil {
 						select {
 						case msg.errChan <- err:
-						case ch := <-cb.stopChannel:
-							close(ch)
+						case <-ctx.Done():
+							return
+						case <-cb.stopChannel:
 							return
 						}
 						continue
@@ -177,8 +213,9 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 				if err != nil {
 					select {
 					case msg.errChan <- err:
-					case ch := <-cb.stopChannel:
-						close(ch)
+					case <-ctx.Done():
+						return
+					case <-cb.stopChannel:
 						return
 					}
 					continue
@@ -187,8 +224,9 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 			select {
 			case msg.errChan <- nil:
-			case ch := <-cb.stopChannel:
-				close(ch)
+			case <-ctx.Done():
+				return
+			case <-cb.stopChannel:
 				return
 			}
 		}
@@ -197,6 +235,10 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		// fetch the oldest messages from the database
 		messages, err := cb.store.List(ctx)
 		if err != nil {
@@ -211,6 +253,10 @@ func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 		messagesToDelete := make([]uint64, 0)
 		var publishError error
 		for _, msg := range messages {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
 			// We need to publish the messages one by one in order to know
 			// which one failed.
 
@@ -229,6 +275,10 @@ func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 			messagesToDelete = append(messagesToDelete, msg.ID)
 		}
 
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		err = cb.store.Delete(ctx, messagesToDelete)
 		if err != nil {
 			// error deleting messages, let's switch back to the open state
@@ -244,6 +294,12 @@ func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 
 func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) error {
 	for _, msg := range messages {
+		select {
+		case <-cb.stopChannel:
+			return errors.New("circuit breaker closed")
+		default:
+		}
+
 		errChan := make(chan error, 1)
 
 		internalMessage := &internalMessage{
@@ -254,6 +310,8 @@ func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) er
 
 		select {
 		case cb.sendChan <- internalMessage:
+		case <-cb.stopChannel:
+			return errors.New("circuit breaker closed")
 		case <-cb.stopped:
 			return errors.New("circuit breaker closed")
 		}
@@ -263,6 +321,8 @@ func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) er
 			if err != nil {
 				return err
 			}
+		case <-cb.stopChannel:
+			return errors.New("circuit breaker closed")
 		case <-cb.stopped:
 			return errors.New("circuit breaker closed")
 		}
@@ -272,11 +332,63 @@ func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) er
 }
 
 func (cb *CircuitBreaker) Close() error {
-	ch := make(chan struct{})
-	cb.stopChannel <- ch
-	<-ch
+	cb.stopOnce.Do(func() {
+		close(cb.stopChannel)
+		cb.cancelLoop()
+	})
 
-	return cb.publisher.Close()
+	if cb.hasLoopStarted() {
+		<-cb.stopped
+	} else {
+		cb.markStopped()
+	}
+
+	cb.publisherCloseOnce.Do(func() {
+		cb.publisherCloseErr = cb.publisher.Close()
+	})
+
+	return cb.publisherCloseErr
+}
+
+func (cb *CircuitBreaker) startLoop(cancel context.CancelFunc) bool {
+	cb.loopMu.Lock()
+	defer cb.loopMu.Unlock()
+
+	if cb.loopStarted {
+		return false
+	}
+
+	cb.loopStarted = true
+	cb.loopCancel = cancel
+	return true
+}
+
+func (cb *CircuitBreaker) clearLoopCancel() {
+	cb.loopMu.Lock()
+	cb.loopCancel = nil
+	cb.loopMu.Unlock()
+}
+
+func (cb *CircuitBreaker) cancelLoop() {
+	cb.loopMu.Lock()
+	cancel := cb.loopCancel
+	cb.loopMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (cb *CircuitBreaker) hasLoopStarted() bool {
+	cb.loopMu.Lock()
+	defer cb.loopMu.Unlock()
+	return cb.loopStarted
+}
+
+func (cb *CircuitBreaker) markStopped() {
+	cb.doneOnce.Do(func() {
+		close(cb.stopped)
+	})
 }
 
 const (
@@ -297,7 +409,7 @@ func newMessage(ctx context.Context, data []byte, metadata map[string]string) (*
 		if err != nil {
 			return nil, err
 		}
-		otel.GetTextMapPropagator().Inject(ctx, carrier)
+		ctx = otel.GetTextMapPropagator().Extract(ctx, carrier)
 	}
 
 	msg.SetContext(ctx)

--- a/pkg/messaging/publish/circuit/circuit_breaker_test.go
+++ b/pkg/messaging/publish/circuit/circuit_breaker_test.go
@@ -11,7 +11,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish/circuit/storage"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
@@ -429,4 +433,140 @@ func TestCircuitBreaker(t *testing.T) {
 			assert.Equal(c, StateOpen, circuitBreaker.GetState())
 		}, 2*time.Second, 100*time.Millisecond)
 	})
+}
+
+func TestCircuitBreakerCloseWithoutLoopIsIdempotent(t *testing.T) {
+	messages := make(chan *testMessages, 10)
+	publisher := newMockPublisher(messages)
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		publisher,
+		newMockStore(),
+		5*time.Second,
+	)
+
+	requireCloseWithin(t, circuitBreaker)
+	requireCloseWithin(t, circuitBreaker)
+	require.Equal(t, 1, publisher.CloseCount())
+}
+
+func TestCircuitBreakerCloseCancelsCatchUp(t *testing.T) {
+	store := &blockingListStore{
+		listStarted: make(chan struct{}, 1),
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(make(chan *testMessages, 10)),
+		store,
+		5*time.Second,
+	)
+
+	go circuitBreaker.Loop(context.Background())
+
+	select {
+	case <-store.listStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected catchup to start")
+	}
+
+	requireCloseWithin(t, circuitBreaker)
+}
+
+func TestCircuitBreakerLoopStopsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(make(chan *testMessages, 10)),
+		newMockStore(),
+		5*time.Second,
+	)
+
+	go circuitBreaker.Loop(ctx)
+	require.Eventually(t, circuitBreaker.hasLoopStarted, time.Second, 10*time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-circuitBreaker.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("expected loop to stop after context cancellation")
+	}
+
+	require.NoError(t, circuitBreaker.Close())
+}
+
+func TestCircuitBreakerCatchUpExtractsStoredTraceContext(t *testing.T) {
+	originalPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTextMapPropagator(originalPropagator)
+	})
+
+	messages := make(chan *testMessages, 10)
+	store := newMockStore()
+	require.NoError(t, store.Insert(context.Background(), "test", []byte("test"), map[string]string{
+		otelContextKey: `{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`,
+	}))
+
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(messages),
+		store,
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+	defer func() {
+		require.NoError(t, circuitBreaker.Close())
+	}()
+
+	var received *testMessages
+	select {
+	case received = <-messages:
+	case <-time.After(time.Second):
+		t.Fatal("expected replayed message")
+	}
+
+	spanContext := trace.SpanContextFromContext(received.msg.Context())
+	require.True(t, spanContext.IsValid())
+	require.True(t, spanContext.IsRemote())
+	require.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", spanContext.TraceID().String())
+	require.Equal(t, "00f067aa0ba902b7", spanContext.SpanID().String())
+}
+
+func requireCloseWithin(t *testing.T, circuitBreaker *CircuitBreaker) {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected circuit breaker close to return")
+	}
+}
+
+type blockingListStore struct {
+	listStarted chan struct{}
+}
+
+func (s *blockingListStore) Insert(ctx context.Context, topic string, data []byte, metadata map[string]string) error {
+	return nil
+}
+
+func (s *blockingListStore) List(ctx context.Context) ([]*storage.CircuitBreakerModel, error) {
+	select {
+	case s.listStarted <- struct{}{}:
+	default:
+	}
+
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *blockingListStore) Delete(ctx context.Context, ids []uint64) error {
+	return nil
 }

--- a/pkg/messaging/publish/circuit/utils_test.go
+++ b/pkg/messaging/publish/circuit/utils_test.go
@@ -22,6 +22,7 @@ type testMessages struct {
 type mockPublisher struct {
 	mu       sync.RWMutex
 	err      error
+	closed   int
 	messages chan *testMessages
 }
 
@@ -64,7 +65,14 @@ func (p *mockPublisher) Publish(topic string, messages ...*message.Message) erro
 func (p *mockPublisher) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.closed++
 	return nil
+}
+
+func (p *mockPublisher) CloseCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.closed
 }
 
 type MockStore struct {

--- a/pkg/messaging/queue/listener.go
+++ b/pkg/messaging/queue/listener.go
@@ -32,6 +32,7 @@ type listener struct {
 	wg         *sync.WaitGroup
 	mux        *sync.Mutex
 	hasStarted bool
+	doneClosed bool
 
 	logger logging.Logger
 
@@ -80,13 +81,19 @@ func NewListener(
 // Start polling for messages
 func (l *listener) Listen(ctx context.Context, ch <-chan *message.Message) {
 	l.mux.Lock()
+	if l.hasStarted || l.doneClosed {
+		l.mux.Unlock()
+		return
+	}
 	l.hasStarted = true
 	l.logger.WithField("listenerName", l.name).WithField("workerCount", l.workerCount).Debugf("queue listener starting listen...")
+	for i := 0; i < l.workerCount; i++ {
+		l.wg.Add(1)
+	}
 	l.mux.Unlock()
 
 	// fan out and process messages concurrently
 	for i := 0; i < l.workerCount; i++ {
-		l.wg.Add(1)
 		go func() {
 			l.startWorker(ctx, ch)
 		}()
@@ -95,7 +102,9 @@ func (l *listener) Listen(ctx context.Context, ch <-chan *message.Message) {
 	go func() {
 		l.wg.Wait()
 		l.logger.WithField("listenerName", l.name).Infof("queue listener closed")
-		close(l.done)
+		l.mux.Lock()
+		l.closeDoneLocked()
+		l.mux.Unlock()
 	}()
 	return
 }
@@ -106,9 +115,17 @@ func (l *listener) Done() <-chan struct{} {
 	defer l.mux.Unlock()
 	if !l.hasStarted {
 		// listen was never called
-		close(l.done)
+		l.closeDoneLocked()
 	}
 	return l.done
+}
+
+func (l *listener) closeDoneLocked() {
+	if l.doneClosed {
+		return
+	}
+	l.doneClosed = true
+	close(l.done)
 }
 
 func (l *listener) startWorker(ctx context.Context, messages <-chan *message.Message) {

--- a/pkg/messaging/queue/listener.go
+++ b/pkg/messaging/queue/listener.go
@@ -58,7 +58,7 @@ func NewListener(
 		}
 		fn(&opts)
 	}
-	if opts.WorkerCount < 0 {
+	if opts.WorkerCount <= 0 {
 		return nil, fmt.Errorf("workerCount must be bigger than 0")
 	}
 	if callbackFn == nil {

--- a/pkg/messaging/queue/listener_test.go
+++ b/pkg/messaging/queue/listener_test.go
@@ -35,6 +35,14 @@ func TestNewListenerNegativeWorkerCount(t *testing.T) {
 	assert.Nil(t, listener)
 }
 
+func TestNewListenerZeroWorkerCount(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error { return nil }, queue.WithWorkerCount(0))
+	require.NotNil(t, err)
+	assert.ErrorContains(t, err, "workerCount")
+	assert.Nil(t, listener)
+}
+
 func TestNewListenerInvalidCallback(t *testing.T) {
 	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
 	listener, err := queue.NewListener(logger, nil)

--- a/pkg/messaging/queue/listener_test.go
+++ b/pkg/messaging/queue/listener_test.go
@@ -51,6 +51,81 @@ func TestNewListenerInvalidCallback(t *testing.T) {
 	assert.Nil(t, listener)
 }
 
+func TestListenerDoneIsIdempotentBeforeListen(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	done := listener.Done()
+	requireClosed(t, done)
+	assert.Equal(t, done, listener.Done())
+	requireClosed(t, done)
+}
+
+func TestListenerDoneBeforeListenMakesLaterListenNoop(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	called := make(chan struct{}, 1)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		called <- struct{}{}
+		return nil
+	})
+	require.NoError(t, err)
+
+	done := listener.Done()
+	requireClosed(t, done)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *message.Message, 1)
+	ch <- message.NewMessage("test-uuid", []byte("test-payload"))
+	listener.Listen(ctx, ch)
+
+	select {
+	case <-called:
+		t.Fatal("callback was called after listener was already done")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestListenerListenIsIdempotent(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	processed := make(chan string, 2)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		processed <- string(msg)
+		return nil
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstCh := make(chan *message.Message, 1)
+	secondCh := make(chan *message.Message, 1)
+	listener.Listen(ctx, firstCh)
+	listener.Listen(ctx, secondCh)
+
+	secondCh <- message.NewMessage("second-uuid", []byte("second"))
+	select {
+	case got := <-processed:
+		t.Fatalf("second Listen call processed message %q", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	firstCh <- message.NewMessage("first-uuid", []byte("first"))
+	select {
+	case got := <-processed:
+		assert.Equal(t, "first", got)
+	case <-time.After(time.Second):
+		t.Fatal("first Listen call did not process message")
+	}
+
+	cancel()
+	requireClosed(t, listener.Done())
+}
+
 func TestHandleMessageInjectsLoggerAndPropagatesTraceContext(t *testing.T) {
 	// Register W3C TraceContext propagator so Extract parses traceparent from metadata
 	otel.SetTextMapPropagator(propagation.TraceContext{})
@@ -126,4 +201,14 @@ func TestCallbackDeadlineForcesCancels(t *testing.T) {
 
 	cancel()
 	<-listener.Done()
+}
+
+func requireClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("channel was not closed")
+	}
 }

--- a/pkg/service/health/controller.go
+++ b/pkg/service/health/controller.go
@@ -3,7 +3,6 @@ package health
 import (
 	"encoding/json"
 	"net/http"
-	"sync"
 )
 
 type HealthController struct {
@@ -11,34 +10,30 @@ type HealthController struct {
 }
 
 type result struct {
+	Index int
 	Check NamedCheck
 	Err   error
 }
 
 func (ctrl *HealthController) Check(w http.ResponseWriter, r *http.Request) {
-	sg := sync.WaitGroup{}
-	sg.Add(len(ctrl.Checks))
-
+	ctx := r.Context()
 	results := make(chan result, len(ctrl.Checks))
-	for _, ch := range ctrl.Checks {
-		go func(ch NamedCheck) {
-			defer sg.Done()
-			select {
-			case <-r.Context().Done():
-				return
-			case results <- result{
+	for index, ch := range ctrl.Checks {
+		go func(index int, ch NamedCheck) {
+			results <- result{
+				Index: index,
 				Check: ch,
-				Err:   ch.Do(r.Context()),
-			}:
+				Err:   ch.Do(ctx),
 			}
-		}(ch)
+		}(index, ch)
 	}
-	sg.Wait()
-	close(results)
 
 	response := map[string]string{}
+	completed := make([]bool, len(ctrl.Checks))
 	hasError := false
-	for r := range results {
+
+	recordResult := func(r result) {
+		completed[r.Index] = true
 		if r.Err != nil {
 			hasError = true
 			response[r.Check.Name()] = r.Err.Error()
@@ -47,6 +42,36 @@ func (ctrl *HealthController) Check(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	completedCount := 0
+	for completedCount < len(ctrl.Checks) {
+		select {
+		case r := <-results:
+			recordResult(r)
+			completedCount++
+		case <-ctx.Done():
+			for completedCount < len(ctrl.Checks) {
+				select {
+				case r := <-results:
+					recordResult(r)
+					completedCount++
+				default:
+					hasError = true
+					for index, ch := range ctrl.Checks {
+						if !completed[index] {
+							response[ch.Name()] = ctx.Err().Error()
+						}
+					}
+					writeResponse(w, response, hasError)
+					return
+				}
+			}
+		}
+	}
+
+	writeResponse(w, response, hasError)
+}
+
+func writeResponse(w http.ResponseWriter, response map[string]string, hasError bool) {
 	if hasError {
 		w.WriteHeader(http.StatusInternalServerError)
 	} else {

--- a/pkg/service/health/controller_test.go
+++ b/pkg/service/health/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
@@ -86,4 +87,53 @@ func TestHealthController(t *testing.T) {
 		app := fx.New(options...)
 		require.NoError(t, app.Err())
 	}
+}
+
+func TestHealthControllerReturnsWhenContextCanceledDuringHungCheck(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	ctrl := health.NewHealthController(
+		health.NewNamedCheck("hung", health.CheckFn(func(ctx context.Context) error {
+			close(started)
+			<-release
+			return nil
+		})),
+	)
+	t.Cleanup(func() {
+		close(release)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/_health", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		ctrl.Check(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("health check did not start")
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("health controller did not return after request context cancellation")
+	}
+
+	require.Equal(t, http.StatusInternalServerError, rec.Result().StatusCode)
+
+	ret := make(map[string]string)
+	require.NoError(t, json.NewDecoder(rec.Result().Body).Decode(&ret))
+	require.Equal(t, map[string]string{
+		"hung": context.Canceled.Error(),
+	}, ret)
 }

--- a/pkg/storage/bun/connect/connect_test.go
+++ b/pkg/storage/bun/connect/connect_test.go
@@ -1,11 +1,16 @@
 package connect
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
 func TestObfuscateDSN(t *testing.T) {
@@ -84,5 +89,26 @@ func TestBuildPGXConnectorDefaultsToReadWriteTargetSessionAttrs(t *testing.T) {
 	want := reflect.ValueOf(pgconn.ValidateConnectTargetSessionAttrsReadWrite).Pointer()
 	if got != want {
 		t.Fatalf("unexpected ValidateConnect func pointer: got %x, want %x", got, want)
+	}
+}
+
+func TestIAMConnectorReturnsBuildAuthTokenError(t *testing.T) {
+	expectedErr := errors.New("retrieve aws credentials")
+	connector := &iamConnector{
+		dsn: "postgres://db-user@localhost:5432/mydb?sslmode=disable",
+		driver: &iamDriver{
+			awsConfig: aws.Config{
+				Region: "us-east-1",
+				Credentials: aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+					return aws.Credentials{}, expectedErr
+				}),
+			},
+		},
+		logger: logging.Testing(),
+	}
+
+	_, err := connector.Connect(context.Background())
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected BuildAuthToken error %q, got %v", expectedErr, err)
 	}
 }

--- a/pkg/storage/bun/connect/iam.go
+++ b/pkg/storage/bun/connect/iam.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
@@ -49,7 +50,7 @@ type iamConnector struct {
 }
 
 func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
-	url, err := dburl.Parse(i.dsn)
+	databaseURL, err := dburl.Parse(i.dsn)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing dsn: %s", i.dsn)
 	}
@@ -60,9 +61,9 @@ func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
 
 		ret, err := auth.BuildAuthToken(
 			ctx,
-			url.Host,
+			databaseURL.Host,
 			i.driver.awsConfig.Region,
-			url.User.Username(),
+			databaseURL.User.Username(),
 			i.driver.awsConfig.Credentials,
 		)
 		if err != nil {
@@ -75,21 +76,9 @@ func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
 		return nil, errors.Wrap(err, "building aws auth token")
 	}
 
-	dsn := fmt.Sprintf(
-		"host=%s port=%s user=%s password=%s dbname=%s",
-		url.Hostname(),
-		url.Port(),
-		url.User.Username(),
-		authenticationToken,
-		url.Path[1:],
-	)
-	for key, strings := range url.Query() {
-		for _, value := range strings {
-			dsn = fmt.Sprintf("%s %s=%s", dsn, key, value)
-		}
-	}
+	dsn := buildIAMAuthDSN(&databaseURL.URL, authenticationToken)
 
-	i.logger.Debugf("IAM: Connect using dsn '%s'", dsn)
+	i.logger.Debugf("IAM: Connect using dsn '%s'", obfuscateDSN(dsn))
 
 	config, err := pgx.ParseConfig(dsn)
 	if err != nil {
@@ -107,3 +96,9 @@ func (i iamConnector) Driver() driver.Driver {
 }
 
 var _ driver.Connector = &iamConnector{}
+
+func buildIAMAuthDSN(databaseURL *url.URL, authenticationToken string) string {
+	dsnURL := *databaseURL
+	dsnURL.User = url.UserPassword(databaseURL.User.Username(), authenticationToken)
+	return dsnURL.String()
+}

--- a/pkg/storage/bun/connect/iam.go
+++ b/pkg/storage/bun/connect/iam.go
@@ -69,7 +69,7 @@ func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
 			otlp.RecordError(ctx, err)
 		}
 
-		return ret, nil
+		return ret, err
 	}()
 	if err != nil {
 		return nil, errors.Wrap(err, "building aws auth token")

--- a/pkg/storage/bun/connect/iam_test.go
+++ b/pkg/storage/bun/connect/iam_test.go
@@ -1,0 +1,62 @@
+package connect
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/xo/dburl"
+)
+
+func TestBuildIAMAuthDSNEscapesAuthTokenAndQueryValues(t *testing.T) {
+	databaseURL, err := dburl.Parse("postgres://iam%20user:old%20password@db.example.com:5432/service%20db?sslmode=require&application_name=worker%20one%2Bblue%26green%3Dtrue&search_path=tenant%3Done%2Cpublic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := "db.example.com:5432/?Action=connect&DBUser=iam user&X-Amz-Credential=AKIA/20260614/eu-west-1/rds-db/aws4_request&X-Amz-Signature=a+b=c=="
+
+	dsn := buildIAMAuthDSN(&databaseURL.URL, token)
+	if strings.Contains(dsn, token) {
+		t.Fatalf("expected auth token to be URL-escaped, got raw token in %q", dsn)
+	}
+
+	config, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("failed to parse generated IAM DSN: %v", err)
+	}
+
+	if config.User != "iam user" {
+		t.Fatalf("unexpected user: got %q", config.User)
+	}
+	if config.Password != token {
+		t.Fatalf("unexpected password token: got %q, want %q", config.Password, token)
+	}
+	if config.Database != "service db" {
+		t.Fatalf("unexpected database: got %q", config.Database)
+	}
+	if got := config.RuntimeParams["application_name"]; got != "worker one+blue&green=true" {
+		t.Fatalf("unexpected application_name: got %q", got)
+	}
+	if got := config.RuntimeParams["search_path"]; got != "tenant=one,public" {
+		t.Fatalf("unexpected search_path: got %q", got)
+	}
+}
+
+func TestBuildIAMAuthDSNObfuscatesAuthToken(t *testing.T) {
+	databaseURL, err := dburl.Parse("postgres://iam-user@db.example.com:5432/app?sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := "db.example.com:5432/?Action=connect&DBUser=iam-user&X-Amz-Credential=AKIA/20260614/eu-west-1/rds-db/aws4_request&X-Amz-Signature=a+b=c=="
+
+	loggedDSN := obfuscateDSN(buildIAMAuthDSN(&databaseURL.URL, token))
+	if loggedDSN != "postgres://iam-user:%2A%2A%2A%2A@db.example.com:5432/app?sslmode=disable" {
+		t.Fatalf("unexpected obfuscated DSN: got %q", loggedDSN)
+	}
+
+	for _, sensitive := range []string{token, "X-Amz-Credential", "X-Amz-Signature", "AKIA"} {
+		if strings.Contains(loggedDSN, sensitive) {
+			t.Fatalf("obfuscated DSN leaked %q in %q", sensitive, loggedDSN)
+		}
+	}
+}

--- a/pkg/transport/api/utils.go
+++ b/pkg/transport/api/utils.go
@@ -21,6 +21,8 @@ const (
 	ErrorInternal       = "INTERNAL"
 	ErrorCodeForbidden  = "FORBIDDEN"
 	ErrorCodeValidation = "VALIDATION"
+
+	internalServerErrorMessage = "internal server error"
 )
 
 func writeJSON(w http.ResponseWriter, statusCode int, v any) {
@@ -66,7 +68,10 @@ func BadRequestWithDetails(w http.ResponseWriter, code string, err error, detail
 
 func InternalServerError(w http.ResponseWriter, r *http.Request, err error) {
 	logging.FromContext(r.Context()).Error(err)
-	WriteErrorResponse(w, http.StatusInternalServerError, ErrorInternal, err)
+	writeJSON(w, http.StatusInternalServerError, ErrorResponse{
+		ErrorCode:    ErrorInternal,
+		ErrorMessage: internalServerErrorMessage,
+	})
 }
 
 func Accepted(w http.ResponseWriter, v any) {

--- a/pkg/transport/api/utils_test.go
+++ b/pkg/transport/api/utils_test.go
@@ -208,7 +208,7 @@ func TestInternalServerError(t *testing.T) {
 
 	// Create a response recorder
 	rr := httptest.NewRecorder()
-	testErr := errors.New("internal server error")
+	testErr := errors.New(`pq: duplicate key value violates unique constraint "accounts_pkey" at /srv/app/internal/storage/accounts.go:42`)
 
 	// Call the function
 	api.InternalServerError(rr, req, testErr)
@@ -220,15 +220,19 @@ func TestInternalServerError(t *testing.T) {
 	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 
 	// Check the response body
+	rawBody := rr.Body.String()
 	var response api.ErrorResponse
-	decodeErr := json.NewDecoder(rr.Body).Decode(&response)
+	decodeErr := json.NewDecoder(bytes.NewBufferString(rawBody)).Decode(&response)
 	require.NoError(t, decodeErr)
 	require.Equal(t, api.ErrorInternal, response.ErrorCode)
-	require.Equal(t, testErr.Error(), response.ErrorMessage)
+	require.Equal(t, "internal server error", response.ErrorMessage)
+	require.NotContains(t, rawBody, "accounts_pkey")
+	require.NotContains(t, rawBody, "/srv/app/internal/storage/accounts.go")
 
 	// Verify that the error was logged
 	logOutput := buf.String()
-	require.Contains(t, logOutput, testErr.Error())
+	require.Contains(t, logOutput, "accounts_pkey")
+	require.Contains(t, logOutput, "/srv/app/internal/storage/accounts.go")
 }
 
 func TestAccepted(t *testing.T) {


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1186` from EN-1136.

This PR contains the scoped change: Honor health check context cancellation.

Stack base: `feat/en-1185-circuit-lifecycle`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
