### PR TITLE
fix(grpc): bound graceful stop by context (EN-1187)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	golang.org/x/oauth2 v0.35.0
 	golang.org/x/text v0.37.0
 	google.golang.org/grpc v1.80.0
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -226,6 +227,5 @@ require (
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/transport/grpcserver/serverport.go
+++ b/pkg/transport/grpcserver/serverport.go
@@ -39,9 +39,20 @@ func startServer(ctx context.Context, s *serverport.Server, serverOptions []grpc
 	}()
 
 	return func(ctx context.Context) error {
-		grpcServer.GracefulStop()
+		stopped := make(chan struct{})
+		go func() {
+			grpcServer.GracefulStop()
+			close(stopped)
+		}()
 
-		return nil
+		select {
+		case <-stopped:
+			return nil
+		case <-ctx.Done():
+			grpcServer.Stop()
+			<-stopped
+			return ctx.Err()
+		}
 	}, nil
 }
 

--- a/pkg/transport/grpcserver/serverport_test.go
+++ b/pkg/transport/grpcserver/serverport_test.go
@@ -1,0 +1,106 @@
+package grpcserver
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/transport/serverport"
+)
+
+func TestStartServerStopContextForcesGracefulStop(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := serverport.NewServer(serverPortDiscr, serverport.WithListener(listener))
+	streamStarted := make(chan struct{})
+	var closeStarted sync.Once
+
+	stop, err := startServer(
+		logging.TestingContext(),
+		server,
+		nil,
+		[]func(*grpc.Server){
+			func(grpcServer *grpc.Server) {
+				grpcServer.RegisterService(&grpc.ServiceDesc{
+					ServiceName: "test.Blocking",
+					HandlerType: (*any)(nil),
+					Streams: []grpc.StreamDesc{
+						{
+							StreamName: "Watch",
+							Handler: func(_ any, stream grpc.ServerStream) error {
+								closeStarted.Do(func() {
+									close(streamStarted)
+								})
+								<-stream.Context().Done()
+								return stream.Context().Err()
+							},
+							ServerStreams: true,
+							ClientStreams: true,
+						},
+					},
+				}, &struct{}{})
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	connCtx, cancelConn := context.WithTimeout(context.Background(), time.Second)
+	defer cancelConn()
+	conn, err := grpc.DialContext(
+		connCtx,
+		listener.Addr().String(),
+		grpc.WithBlock(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	defer cancelStream()
+
+	stream, err := conn.NewStream(
+		streamCtx,
+		&grpc.StreamDesc{
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+		"/test.Blocking/Watch",
+	)
+	require.NoError(t, err)
+	require.NoError(t, stream.SendMsg(&emptypb.Empty{}))
+
+	select {
+	case <-streamStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stream handler did not start")
+	}
+
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelStop()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- stop(stopCtx)
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		cancelStream()
+		t.Fatal("stop did not return after context deadline")
+	}
+}


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1187` from EN-1136.

This PR contains the scoped change: Bound gRPC graceful stop by context.

Stack base: `feat/en-1186-health-context`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
