### PR TITLE
fix(temporal): synchronize worker shutdown (EN-1188)

### DIFF
--- a/pkg/fx/workflowfx/temporal.go
+++ b/pkg/fx/workflowfx/temporal.go
@@ -2,6 +2,7 @@ package workflowfx
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel/metric"
@@ -66,25 +67,34 @@ func TemporalWorkerModule(ctx context.Context, taskQueue string, options worker.
 			}, fx.ParamTags(``, ``, `group:"workflows"`, `group:"activities"`)),
 		),
 		fx.Invoke(func(lc fx.Lifecycle, w worker.Worker) {
-			willStop := false
-			lc.Append(fx.Hook{
-				OnStart: func(ctx context.Context) error {
-					go func() {
-						err := w.Run(worker.InterruptCh())
-						if err != nil {
-							if !willStop {
-								panic(err)
-							}
-						}
-					}()
-					return nil
-				},
-				OnStop: func(ctx context.Context) error {
-					willStop = true
-					w.Stop()
-					return nil
-				},
-			})
+			registerTemporalWorkerLifecycle(lc, w)
 		}),
 	)
+}
+
+type temporalWorkerRunner interface {
+	Run(interruptCh <-chan interface{}) error
+	Stop()
+}
+
+func registerTemporalWorkerLifecycle(lc fx.Lifecycle, w temporalWorkerRunner) {
+	var willStop atomic.Bool
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			go func() {
+				err := w.Run(worker.InterruptCh())
+				if err != nil {
+					if !willStop.Load() {
+						panic(err)
+					}
+				}
+			}()
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			willStop.Store(true)
+			w.Stop()
+			return nil
+		},
+	})
 }

--- a/pkg/fx/workflowfx/temporal_test.go
+++ b/pkg/fx/workflowfx/temporal_test.go
@@ -1,0 +1,68 @@
+package workflowfx
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/fx"
+)
+
+func TestRegisterTemporalWorkerLifecycleIsRaceSafeWhenRunReturnsDuringStop(t *testing.T) {
+	lc := &lifecycleRecorder{}
+	w := &shutdownErrorWorker{
+		runErr:      errors.New("worker stopped"),
+		runReturned: make(chan struct{}),
+	}
+
+	registerTemporalWorkerLifecycle(lc, w)
+
+	if len(lc.hooks) != 1 {
+		t.Fatalf("expected 1 lifecycle hook, got %d", len(lc.hooks))
+	}
+
+	hook := lc.hooks[0]
+	if hook.OnStart == nil {
+		t.Fatal("expected OnStart hook")
+	}
+	if hook.OnStop == nil {
+		t.Fatal("expected OnStop hook")
+	}
+
+	if err := hook.OnStart(context.Background()); err != nil {
+		t.Fatalf("OnStart returned error: %v", err)
+	}
+	if err := hook.OnStop(context.Background()); err != nil {
+		t.Fatalf("OnStop returned error: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+}
+
+type lifecycleRecorder struct {
+	hooks []fx.Hook
+}
+
+func (lc *lifecycleRecorder) Append(hook fx.Hook) {
+	lc.hooks = append(lc.hooks, hook)
+}
+
+type shutdownErrorWorker struct {
+	runErr      error
+	runReturned chan struct{}
+}
+
+func (w *shutdownErrorWorker) Run(<-chan interface{}) error {
+	time.Sleep(10 * time.Millisecond)
+	close(w.runReturned)
+	return w.runErr
+}
+
+func (w *shutdownErrorWorker) Stop() {
+	select {
+	case <-w.runReturned:
+	case <-time.After(time.Second):
+		panic("worker Run did not return")
+	}
+}


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1188` from EN-1136.

This PR contains the scoped change: Synchronize Temporal worker shutdown.

Stack base: `feat/en-1187-grpc-stop-timeout`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
