### PR TITLE
fix(observe): wire runtime metrics options (EN-1190)

### DIFF
--- a/pkg/fx/observefx/metrics.go
+++ b/pkg/fx/observefx/metrics.go
@@ -62,35 +62,38 @@ func MetricsModule(cfg metrics.ModuleConfig) fx.Option {
 
 			return ret
 		}, fx.ParamTags(metricsProviderOptionKey))),
-		fx.Invoke(func(lc fx.Lifecycle, metricProvider *sdkmetric.MeterProvider, options ...runtime.Option) {
-			otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-				b3.New(), propagation.TraceContext{}))
-			lc.Append(fx.Hook{
-				OnStart: func(ctx context.Context) error {
-					if cfg.RuntimeMetrics {
-						if err := runtime.Start(options...); err != nil {
-							return err
+		fx.Invoke(fx.Annotate(
+			func(lc fx.Lifecycle, metricProvider *sdkmetric.MeterProvider, options ...runtime.Option) {
+				otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+					b3.New(), propagation.TraceContext{}))
+				lc.Append(fx.Hook{
+					OnStart: func(ctx context.Context) error {
+						if cfg.RuntimeMetrics {
+							if err := runtime.Start(options...); err != nil {
+								return err
+							}
+							if err := host.Start(); err != nil {
+								return err
+							}
 						}
-						if err := host.Start(); err != nil {
-							return err
+						return nil
+					},
+					OnStop: func(ctx context.Context) error {
+						logging.FromContext(ctx).Infof("Flush metrics")
+						if err := metricProvider.ForceFlush(ctx); err != nil {
+							logging.FromContext(ctx).Errorf("unable to flush metrics: %s", err)
 						}
-					}
-					return nil
-				},
-				OnStop: func(ctx context.Context) error {
-					logging.FromContext(ctx).Infof("Flush metrics")
-					if err := metricProvider.ForceFlush(ctx); err != nil {
-						logging.FromContext(ctx).Errorf("unable to flush metrics: %s", err)
-					}
-					logging.FromContext(ctx).Infof("Shutting down metrics provider")
-					if err := metricProvider.Shutdown(ctx); err != nil {
-						logging.FromContext(ctx).Errorf("unable to shutdown metrics provider: %s", err)
-					}
-					logging.FromContext(ctx).Infof("Metrics provider stopped")
-					return nil
-				},
-			})
-		}),
+						logging.FromContext(ctx).Infof("Shutting down metrics provider")
+						if err := metricProvider.Shutdown(ctx); err != nil {
+							logging.FromContext(ctx).Errorf("unable to shutdown metrics provider: %s", err)
+						}
+						logging.FromContext(ctx).Infof("Metrics provider stopped")
+						return nil
+					},
+				})
+			},
+			fx.ParamTags(``, ``, metricsRuntimeOptionKey),
+		)),
 		ProvideMetricsProviderOption(sdkmetric.WithResource),
 		ProvideMetricsProviderOption(sdkmetric.WithReader),
 		fx.Provide(

--- a/pkg/fx/observefx/metrics_test.go
+++ b/pkg/fx/observefx/metrics_test.go
@@ -1,0 +1,38 @@
+package observefx_test
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/contrib/instrumentation/runtime"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"github.com/formancehq/go-libs/v5/pkg/fx/observefx"
+	"github.com/formancehq/go-libs/v5/pkg/observe"
+	"github.com/formancehq/go-libs/v5/pkg/observe/metrics"
+)
+
+func TestMetricsModuleProvidesRuntimeOptionsToRuntimeMetricsInvoke(t *testing.T) {
+	var runtimeOptionProvided atomic.Bool
+
+	app := fxtest.New(t,
+		observefx.ResourceModule(observe.Config{
+			ServiceName: "metrics-test",
+		}),
+		observefx.MetricsModule(metrics.ModuleConfig{
+			MinimumReadMemStatsInterval: time.Second,
+		}),
+		observefx.ProvideRuntimeMetricsOption(func() runtime.Option {
+			runtimeOptionProvided.Store(true)
+			return runtime.WithMinimumReadMemStatsInterval(100 * time.Millisecond)
+		}),
+		fx.NopLogger,
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	require.True(t, runtimeOptionProvided.Load())
+}


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1190` from EN-1136.

This PR contains the scoped change: Wire runtime metrics Fx options.

Stack base: `feat/en-1189-migration-listener`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
