### PR TITLE
fix(httpserver): redact and cap OTLP debug capture (EN-1180)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.14
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.24
 	github.com/aws/smithy-go v1.24.2
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/getkin/kin-openapi v0.134.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-jose/go-jose/v4 v4.1.4
@@ -127,7 +128,6 @@ require (
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-chi/render v1.0.3 // indirect
 	github.com/go-faster/city v1.0.1 // indirect

--- a/pkg/service/flags.go
+++ b/pkg/service/flags.go
@@ -21,6 +21,10 @@ func BindEnvToFlagSet(set *pflag.FlagSet) {
 	set.VisitAll(func(flag *pflag.Flag) {
 		envVar := strings.ToUpper(flag.Name)
 		envVar = strings.Replace(envVar, "-", "_", -1)
+		// DEBUG is commonly set by tooling and shells; keep debug mode explicit.
+		if flag.Name == DebugFlag && envVar == "DEBUG" {
+			return
+		}
 		value := os.Getenv(envVar)
 		if value == "" {
 			return
@@ -33,9 +37,8 @@ func BindEnvToFlagSet(set *pflag.FlagSet) {
 			}
 		}
 
-		err := set.Set(flag.Name, value)
-		if err != nil {
-			panic(err)
+		if err := set.Set(flag.Name, value); err != nil {
+			return
 		}
 	})
 }

--- a/pkg/service/flags_test.go
+++ b/pkg/service/flags_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFlags(t *testing.T) {
@@ -42,4 +44,45 @@ func TestFlags(t *testing.T) {
 	}
 
 	fmt.Println(command.Flags().GetString("root1"))
+}
+
+func TestBindEnvToFlagSetDoesNotEnableDebugFromBareDebugEnv(t *testing.T) {
+	t.Setenv("DEBUG", "1")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool(DebugFlag, false, "")
+
+	BindEnvToFlagSet(flags)
+
+	debug, err := flags.GetBool(DebugFlag)
+	require.NoError(t, err)
+	require.False(t, debug)
+}
+
+func TestBindEnvToFlagSetStillBindsNonDebugEnv(t *testing.T) {
+	t.Setenv("ROOT1", "changed")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("root1", "default", "")
+
+	BindEnvToFlagSet(flags)
+
+	root1, err := flags.GetString("root1")
+	require.NoError(t, err)
+	require.Equal(t, "changed", root1)
+}
+
+func TestBindEnvToFlagSetIgnoresInvalidEnvValue(t *testing.T) {
+	t.Setenv("ENABLED", "not-a-bool")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool("enabled", false, "")
+
+	require.NotPanics(t, func() {
+		BindEnvToFlagSet(flags)
+	})
+
+	enabled, err := flags.GetBool("enabled")
+	require.NoError(t, err)
+	require.False(t, enabled)
 }

--- a/pkg/transport/httpserver/otlp_middleware.go
+++ b/pkg/transport/httpserver/otlp_middleware.go
@@ -5,53 +5,196 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
+	"github.com/felixge/httpsnoop"
 	"github.com/riandyrn/otelchi"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	debugBodyAttributeLimit   = 64 * 1024
+	debugHeaderAttributeLimit = 8 * 1024
+	debugRedactedValue        = "[REDACTED]"
+)
+
 type responseWriter struct {
-	http.ResponseWriter
-	data        []byte
-	statusCode  int
-	captureBody bool
+	data          []byte
+	statusCode    int
+	captureBody   bool
+	bodyLimit     int
+	bodyTruncated bool
+	wroteHeader   bool
 }
 
-func (w *responseWriter) WriteHeader(code int) {
+func (w *responseWriter) wrap(writer http.ResponseWriter) http.ResponseWriter {
+	return httpsnoop.Wrap(writer, httpsnoop.Hooks{
+		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(code int) {
+				if w.writeHeader(code) {
+					next(code)
+				}
+			}
+		},
+		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(data []byte) (int, error) {
+				w.write()
+
+				n, err := next(data)
+				if w.captureBody && n > 0 {
+					w.capture(data[:n])
+				}
+				return n, err
+			}
+		},
+		Flush: func(next httpsnoop.FlushFunc) httpsnoop.FlushFunc {
+			return func() {
+				w.write()
+				next()
+			}
+		},
+		ReadFrom: func(next httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+			return func(src io.Reader) (int64, error) {
+				w.write()
+				if w.captureBody {
+					src = &captureReader{
+						reader:  src,
+						capture: w.capture,
+					}
+				}
+				return next(src)
+			}
+		},
+	})
+}
+
+func (w *responseWriter) writeHeader(code int) bool {
+	if code >= 100 && code <= 199 {
+		return true
+	}
+	if w.wroteHeader {
+		return false
+	}
+
+	w.wroteHeader = true
 	w.statusCode = code
-	if !w.captureBody {
-		w.ResponseWriter.WriteHeader(code)
+	return true
+}
+
+func (w *responseWriter) write() {
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		w.statusCode = http.StatusOK
 	}
 }
 
-func (w *responseWriter) Write(data []byte) (int, error) {
-	if !w.captureBody {
-		return w.ResponseWriter.Write(data)
+func (w *responseWriter) capture(data []byte) {
+	if len(data) == 0 {
+		return
 	}
+
+	remaining := w.bodyLimit - len(w.data)
+	if remaining <= 0 {
+		w.bodyTruncated = true
+		return
+	}
+
+	if len(data) > remaining {
+		w.data = append(w.data, data[:remaining]...)
+		w.bodyTruncated = true
+		return
+	}
+
 	w.data = append(w.data, data...)
-	return len(data), nil
 }
 
-func (w *responseWriter) finalize() {
-	if !w.captureBody {
-		return
+type captureReader struct {
+	reader  io.Reader
+	capture func([]byte)
+}
+
+func (r *captureReader) Read(data []byte) (int, error) {
+	n, err := r.reader.Read(data)
+	if n > 0 {
+		r.capture(data[:n])
 	}
-	if w.statusCode != 0 {
-		w.ResponseWriter.WriteHeader(w.statusCode)
-	}
-	if len(w.data) == 0 {
-		return
-	}
-	_, err := w.ResponseWriter.Write(w.data)
-	if err != nil {
-		panic(err)
-	}
+	return n, err
 }
 
 func isJSONContent(contentType string) bool {
 	return strings.Contains(strings.ToLower(contentType), "application/json")
+}
+
+func formatDebugHeaders(headers http.Header, limit int) (string, bool) {
+	names := make([]string, 0, len(headers))
+	for name := range headers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var builder strings.Builder
+	for _, name := range names {
+		value := strings.Join(headers[name], ", ")
+		if isSensitiveHeader(name) {
+			value = debugRedactedValue
+		}
+
+		part := fmt.Sprintf("%s: %s", name, value)
+		if builder.Len() > 0 {
+			part = "\n" + part
+		}
+		if appendLimitedString(&builder, part, limit) {
+			return builder.String(), true
+		}
+	}
+
+	return builder.String(), false
+}
+
+func isSensitiveHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "authorization", "cookie", "proxy-authorization", "set-cookie":
+		return true
+	default:
+		return false
+	}
+}
+
+func appendLimitedString(builder *strings.Builder, value string, limit int) bool {
+	remaining := limit - builder.Len()
+	if remaining <= 0 {
+		return len(value) > 0
+	}
+	if len(value) > remaining {
+		builder.WriteString(value[:remaining])
+		return true
+	}
+	builder.WriteString(value)
+	return false
+}
+
+type bodyReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func captureDebugBody(body io.ReadCloser, limit int) ([]byte, bool, io.ReadCloser, error) {
+	data, err := io.ReadAll(io.LimitReader(body, int64(limit)+1))
+	replacement := &bodyReadCloser{
+		Reader: io.MultiReader(bytes.NewReader(data), body),
+		Closer: body,
+	}
+	if err != nil {
+		return nil, false, replacement, err
+	}
+
+	if len(data) > limit {
+		return data[:limit], true, replacement, nil
+	}
+
+	return data, false, replacement, nil
 }
 
 func OTLPMiddleware(serverName string, debug bool) func(h http.Handler) http.Handler {
@@ -72,30 +215,43 @@ func OTLPMiddleware(serverName string, debug bool) func(h http.Handler) http.Han
 
 			if debug {
 				// Debug: request headers
-				headerParts := make([]string, 0, len(r.Header))
-				for name, values := range r.Header {
-					headerParts = append(headerParts, fmt.Sprintf("%s: %s", name, strings.Join(values, ", ")))
+				headers, truncated := formatDebugHeaders(r.Header, debugHeaderAttributeLimit)
+				span.SetAttributes(attribute.String("http.request.headers", headers))
+				if truncated {
+					span.SetAttributes(attribute.Bool("http.request.headers.truncated", true))
 				}
-				span.SetAttributes(attribute.String("http.request.headers", strings.Join(headerParts, "\n")))
 
 				// Debug: request body (JSON only)
 				if captureBody && r.Body != nil {
-					body, err := io.ReadAll(r.Body)
+					body, truncated, replacement, err := captureDebugBody(r.Body, debugBodyAttributeLimit)
+					r.Body = replacement
 					if err == nil {
 						span.SetAttributes(attribute.String("http.request.body", string(body)))
-						r.Body = io.NopCloser(bytes.NewReader(body))
+						if truncated {
+							span.SetAttributes(attribute.Bool("http.request.body.truncated", true))
+						}
 					}
 				}
 			}
 
-			rw := &responseWriter{
-				ResponseWriter: w,
-				data:           make([]byte, 0, 1024),
-				captureBody:    captureBody,
+			if !debug {
+				metrics := httpsnoop.Metrics{Code: http.StatusOK}
+				defer func() {
+					span.SetAttributes(attribute.Int("http.response.status_code", metrics.Code))
+				}()
+				metrics.CaptureMetrics(w, func(w http.ResponseWriter) {
+					h.ServeHTTP(w, r)
+				})
+				return
 			}
-			defer func() {
-				rw.finalize()
 
+			rw := &responseWriter{
+				data:        make([]byte, 0, 1024),
+				captureBody: captureBody,
+				bodyLimit:   debugBodyAttributeLimit,
+			}
+			ww := rw.wrap(w)
+			defer func() {
 				// Always log status code
 				statusCode := rw.statusCode
 				if statusCode == 0 {
@@ -105,20 +261,23 @@ func OTLPMiddleware(serverName string, debug bool) func(h http.Handler) http.Han
 
 				if debug {
 					// Debug: response headers
-					respHeaderParts := make([]string, 0, len(rw.Header()))
-					for name, values := range rw.Header() {
-						respHeaderParts = append(respHeaderParts, fmt.Sprintf("%s: %s", name, strings.Join(values, ", ")))
+					headers, truncated := formatDebugHeaders(ww.Header(), debugHeaderAttributeLimit)
+					span.SetAttributes(attribute.String("http.response.headers", headers))
+					if truncated {
+						span.SetAttributes(attribute.Bool("http.response.headers.truncated", true))
 					}
-					span.SetAttributes(attribute.String("http.response.headers", strings.Join(respHeaderParts, "\n")))
 
 					// Debug: response body (only if we captured it, i.e. JSON content)
 					if captureBody && len(rw.data) > 0 {
 						span.SetAttributes(attribute.String("http.response.body", string(rw.data)))
+						if rw.bodyTruncated {
+							span.SetAttributes(attribute.Bool("http.response.body.truncated", true))
+						}
 					}
 				}
 			}()
 
-			h.ServeHTTP(rw, r)
+			h.ServeHTTP(ww, r)
 		}))
 	}
 }

--- a/pkg/transport/httpserver/otlp_middleware_test.go
+++ b/pkg/transport/httpserver/otlp_middleware_test.go
@@ -1,0 +1,264 @@
+package httpserver
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestOTLPMiddlewareDebugRedactsAndCapsTraceAttributes(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	previousTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(tracerProvider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousTracerProvider)
+		require.NoError(t, tracerProvider.Shutdown(context.Background()))
+	})
+
+	requestBody := `{"body":"` + strings.Repeat("a", debugBodyAttributeLimit+128) + `"}`
+	responseBody := `{"body":"` + strings.Repeat("b", debugBodyAttributeLimit+128) + `"}`
+
+	handler := OTLPMiddleware("test-server", true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, requestBody, string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Set-Cookie", "session=secret")
+		w.Header().Set("X-Large-Response", strings.Repeat("r", debugHeaderAttributeLimit))
+		w.WriteHeader(http.StatusAccepted)
+		_, err = w.Write([]byte(responseBody))
+		require.NoError(t, err)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test?debug=true", strings.NewReader(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Cookie", "session=secret")
+	req.Header.Set("X-Debug", "visible")
+	req.Header.Set("X-Large", strings.Repeat("h", debugHeaderAttributeLimit))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	require.Equal(t, responseBody, rec.Body.String())
+
+	attrs := recordedSpanAttributes(t, spanRecorder)
+
+	requestHeaders := attrs["http.request.headers"].AsString()
+	require.LessOrEqual(t, len(requestHeaders), debugHeaderAttributeLimit)
+	require.Contains(t, requestHeaders, "Authorization: "+debugRedactedValue)
+	require.Contains(t, requestHeaders, "Cookie: "+debugRedactedValue)
+	require.Contains(t, requestHeaders, "X-Debug: visible")
+	require.NotContains(t, requestHeaders, "Bearer secret")
+	require.NotContains(t, requestHeaders, "session=secret")
+	require.True(t, attrs["http.request.headers.truncated"].AsBool())
+
+	responseHeaders := attrs["http.response.headers"].AsString()
+	require.LessOrEqual(t, len(responseHeaders), debugHeaderAttributeLimit)
+	require.Contains(t, responseHeaders, "Set-Cookie: "+debugRedactedValue)
+	require.NotContains(t, responseHeaders, "session=secret")
+	require.True(t, attrs["http.response.headers.truncated"].AsBool())
+
+	require.Equal(t, requestBody[:debugBodyAttributeLimit], attrs["http.request.body"].AsString())
+	require.True(t, attrs["http.request.body.truncated"].AsBool())
+	require.Equal(t, responseBody[:debugBodyAttributeLimit], attrs["http.response.body"].AsString())
+	require.True(t, attrs["http.response.body.truncated"].AsBool())
+}
+
+func TestOTLPMiddlewareDebugDoesNotPanicOnResponseWriteError(t *testing.T) {
+	handler := OTLPMiddleware("test-server", true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"ok":true}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	require.NotPanics(t, func() {
+		handler.ServeHTTP(&failingResponseWriter{header: make(http.Header)}, req)
+	})
+}
+
+func TestOTLPMiddlewarePreservesResponseWriterInterfaces(t *testing.T) {
+	for _, debug := range []bool{false, true} {
+		t.Run(debugName(debug), func(t *testing.T) {
+			base := newOptionalResponseWriter()
+			handler := OTLPMiddleware("test-server", debug)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertOptionalResponseWriterInterfaces(t, w)
+			}))
+
+			handler.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+			require.Equal(t, 1, base.flushes)
+			require.Equal(t, 1, base.pushes)
+			require.Equal(t, "/events", base.pushTarget)
+			require.Equal(t, 1, base.hijacks)
+			require.Equal(t, testWriteDeadline, base.writeDeadline)
+		})
+	}
+}
+
+func TestOTLPMiddlewareDoesNotAdvertiseUnsupportedResponseWriterInterfaces(t *testing.T) {
+	for _, debug := range []bool{false, true} {
+		t.Run(debugName(debug), func(t *testing.T) {
+			handler := OTLPMiddleware("test-server", debug)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertNoOptionalResponseWriterInterfaces(t, w)
+			}))
+
+			handler.ServeHTTP(newPlainResponseWriter(), httptest.NewRequest(http.MethodGet, "/test", nil))
+		})
+	}
+}
+
+func recordedSpanAttributes(t *testing.T, spanRecorder *tracetest.SpanRecorder) map[string]attribute.Value {
+	t.Helper()
+
+	for _, span := range spanRecorder.Ended() {
+		attrs := make(map[string]attribute.Value, len(span.Attributes()))
+		for _, attr := range span.Attributes() {
+			attrs[string(attr.Key)] = attr.Value
+		}
+		if _, ok := attrs["http.request.headers"]; ok {
+			return attrs
+		}
+	}
+
+	t.Fatalf("recorded span with OTLP debug attributes not found")
+	return nil
+}
+
+func debugName(debug bool) string {
+	if debug {
+		return "debug=true"
+	}
+	return "debug=false"
+}
+
+func assertOptionalResponseWriterInterfaces(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+
+	flusher, ok := w.(http.Flusher)
+	require.True(t, ok)
+	flusher.Flush()
+
+	pusher, ok := w.(http.Pusher)
+	require.True(t, ok)
+	require.NoError(t, pusher.Push("/events", nil))
+
+	require.NoError(t, http.NewResponseController(w).SetWriteDeadline(testWriteDeadline))
+
+	hijacker, ok := w.(http.Hijacker)
+	require.True(t, ok)
+	_, _, err := hijacker.Hijack()
+	require.ErrorIs(t, err, errTestHijack)
+}
+
+func assertNoOptionalResponseWriterInterfaces(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+
+	_, ok := w.(http.Flusher)
+	require.False(t, ok)
+	_, ok = w.(http.Hijacker)
+	require.False(t, ok)
+	_, ok = w.(http.Pusher)
+	require.False(t, ok)
+}
+
+var (
+	errTestHijack     = errors.New("test hijack")
+	testWriteDeadline = time.Unix(123, 0)
+)
+
+type optionalResponseWriter struct {
+	header        http.Header
+	flushes       int
+	hijacks       int
+	pushes        int
+	pushTarget    string
+	writeDeadline time.Time
+}
+
+func newOptionalResponseWriter() *optionalResponseWriter {
+	return &optionalResponseWriter{
+		header: make(http.Header),
+	}
+}
+
+func (w *optionalResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *optionalResponseWriter) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (w *optionalResponseWriter) WriteHeader(int) {}
+
+func (w *optionalResponseWriter) Flush() {
+	w.flushes++
+}
+
+func (w *optionalResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	w.hijacks++
+	return nil, nil, errTestHijack
+}
+
+func (w *optionalResponseWriter) Push(target string, _ *http.PushOptions) error {
+	w.pushes++
+	w.pushTarget = target
+	return nil
+}
+
+func (w *optionalResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	w.writeDeadline = deadline
+	return nil
+}
+
+type plainResponseWriter struct {
+	header http.Header
+}
+
+func newPlainResponseWriter() *plainResponseWriter {
+	return &plainResponseWriter{
+		header: make(http.Header),
+	}
+}
+
+func (w *plainResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *plainResponseWriter) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (w *plainResponseWriter) WriteHeader(int) {}
+
+type failingResponseWriter struct {
+	header http.Header
+}
+
+func (w *failingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingResponseWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func (w *failingResponseWriter) WriteHeader(int) {}


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1180` from EN-1136.

This PR contains the scoped change: Redact and cap OTLP debug capture.

Stack base: `feat/en-1190-runtime-metrics-options`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
