### PR TITLE
fix(httpserver): preserve response writer interfaces (EN-1191)

### DIFF
--- a/pkg/transport/httpserver/middlewares.go
+++ b/pkg/transport/httpserver/middlewares.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/felixge/httpsnoop"
+
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
@@ -14,6 +16,10 @@ type loggingResponseWriter struct {
 
 func NewLoggingResponseWriter(w http.ResponseWriter) *loggingResponseWriter {
 	return &loggingResponseWriter{w, http.StatusOK}
+}
+
+func (lrw *loggingResponseWriter) Unwrap() http.ResponseWriter {
+	return lrw.ResponseWriter
 }
 
 func (lrw *loggingResponseWriter) WriteHeader(statusCode int) {
@@ -28,12 +34,12 @@ func LoggerMiddleware(l logging.Logger) func(h http.Handler) http.Handler {
 			r = r.WithContext(logging.ContextWithLogger(r.Context(), l))
 			logger := logging.FromContext(r.Context())
 
-			rec := NewLoggingResponseWriter(w)
 			// copy
 			method := r.Method
 			path := r.URL.Path
 
-			h.ServeHTTP(rec, r)
+			metrics := httpsnoop.CaptureMetrics(h, w, r)
+			statusCode := metrics.Code
 			latency := time.Since(start)
 
 			logger = logger.WithFields(map[string]interface{}{
@@ -41,9 +47,9 @@ func LoggerMiddleware(l logging.Logger) func(h http.Handler) http.Handler {
 				"path":       path,
 				"latency":    latency,
 				"user_agent": r.UserAgent(),
-				"status":     rec.statusCode,
+				"status":     statusCode,
 			})
-			if rec.statusCode >= 400 {
+			if statusCode >= 400 {
 				logger.Error("Request")
 			} else {
 				logger.Info("Request")

--- a/pkg/transport/httpserver/otlp_middleware_test.go
+++ b/pkg/transport/httpserver/otlp_middleware_test.go
@@ -17,6 +17,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
 func TestOTLPMiddlewareDebugRedactsAndCapsTraceAttributes(t *testing.T) {
@@ -123,6 +125,32 @@ func TestOTLPMiddlewareDoesNotAdvertiseUnsupportedResponseWriterInterfaces(t *te
 			handler.ServeHTTP(newPlainResponseWriter(), httptest.NewRequest(http.MethodGet, "/test", nil))
 		})
 	}
+}
+
+func TestLoggerMiddlewarePreservesResponseWriterInterfaces(t *testing.T) {
+	base := newOptionalResponseWriter()
+	handler := LoggerMiddleware(logging.Testing())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertOptionalResponseWriterInterfaces(t, w)
+	}))
+
+	handler.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	require.Equal(t, 1, base.flushes)
+	require.Equal(t, 1, base.pushes)
+	require.Equal(t, "/events", base.pushTarget)
+	require.Equal(t, 1, base.hijacks)
+	require.Equal(t, testWriteDeadline, base.writeDeadline)
+}
+
+func TestLoggingResponseWriterUnwrapsForResponseController(t *testing.T) {
+	base := newOptionalResponseWriter()
+	controller := http.NewResponseController(NewLoggingResponseWriter(base))
+
+	require.NoError(t, controller.Flush())
+	require.NoError(t, controller.SetWriteDeadline(testWriteDeadline))
+
+	require.Equal(t, 1, base.flushes)
+	require.Equal(t, testWriteDeadline, base.writeDeadline)
 }
 
 func recordedSpanAttributes(t *testing.T, spanRecorder *tracetest.SpanRecorder) map[string]attribute.Value {


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1191` from EN-1136.

This PR contains the scoped change: Preserve response writer interfaces.

Stack base: `feat/en-1180-otlp-debug-redaction`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
