### PR TITLE
fix: avoid hot-path panics (EN-1192)

### DIFF
--- a/pkg/audit/httpaudit/async_publisher.go
+++ b/pkg/audit/httpaudit/async_publisher.go
@@ -149,7 +149,16 @@ func NewAsyncPublisher(publisher message.Publisher, topicName string, appName st
 func (p *AsyncPublisher) Publish(ctx context.Context, payload audit.Payload) {
 	detachedCtx := context.WithoutCancel(ctx)
 	detachedCtx = logging.ContextWithLogger(detachedCtx, logging.FromContext(ctx))
-	msg := audit.NewEventMessage(detachedCtx, p.appName, payload)
+	msg, err := audit.NewEventMessageWithError(detachedCtx, p.appName, payload)
+	if err != nil {
+		p.publishErrors.Add(1)
+		logger := logging.FromContext(ctx)
+		logger.WithField("audit_payload_id", payload.ID).Errorf("failed to build audit message asynchronously: %v", err)
+		if p.cfg.onError != nil {
+			p.cfg.onError(detachedCtx, payload, err)
+		}
+		return
+	}
 
 	p.mu.RLock()
 	if p.closed {

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/formancehq/go-libs/v5/pkg/audit"
+	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
 	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
@@ -1022,6 +1023,46 @@ func TestMiddleware_AsyncPublishingLogsAndCountsPublishErrors(t *testing.T) {
 	assert.Equal(t, uint64(1), stats.PublishErrors)
 	assert.Contains(t, logBuffer.String(), "failed to publish audit message asynchronously")
 	assert.Contains(t, logBuffer.String(), "publisher failed")
+}
+
+func TestAsyncPublisher_ReportsMessageBuildErrors(t *testing.T) {
+	var logBuffer bytes.Buffer
+	logger := logging.NewDefaultLogger(&logBuffer, true, false, false)
+	pub := &errorPublisher{}
+	topic := "audit-events"
+	errorCallback := make(chan error, 1)
+	asyncPublisher := NewAsyncPublisher(pub, topic, "test-app",
+		WithAsyncPublishingQueueCapacity(1),
+		WithAsyncPublishingWorkerCount(1),
+		WithAsyncPublishingErrorCallback(func(_ context.Context, _ audit.Payload, err error) {
+			errorCallback <- err
+		}),
+	)
+
+	payload := audit.Payload{
+		ID: "payload-id",
+		Actor: audit.Actor{
+			Claims: &oidc.AccessTokenClaims{
+				Claims: map[string]any{
+					"unsupported": func() {},
+				},
+			},
+		},
+	}
+	asyncPublisher.Publish(logging.ContextWithLogger(context.Background(), logger), payload)
+	require.NoError(t, asyncPublisher.Close(context.Background()))
+
+	stats := asyncPublisher.Stats()
+	assert.Equal(t, uint64(0), stats.Enqueued)
+	assert.Equal(t, uint64(0), stats.Published)
+	assert.Equal(t, uint64(0), stats.Dropped)
+	assert.Equal(t, uint64(1), stats.PublishErrors)
+	assert.Equal(t, uint64(0), pub.calls.Load())
+	require.Len(t, errorCallback, 1)
+	err := <-errorCallback
+	require.ErrorContains(t, err, "marshal event message")
+	assert.Contains(t, logBuffer.String(), "failed to build audit message asynchronously")
+	assert.Contains(t, logBuffer.String(), "marshal event message")
 }
 
 func TestMiddleware_PublishLatencyRegression(t *testing.T) {

--- a/pkg/audit/publish.go
+++ b/pkg/audit/publish.go
@@ -19,23 +19,33 @@ import (
 
 // NewEventMessage builds the Watermill message used for audit events.
 func NewEventMessage(ctx context.Context, appName string, payload Payload) *message.Message {
-	return publish.NewMessage(
-		ctx,
-		publish.EventMessage{
-			Date:    time.Now().UTC(),
-			App:     appName,
-			Version: EventVersion,
-			Type:    EventTypeAudit,
-			Payload: payload,
-		},
-	)
+	return publish.NewMessage(ctx, newEventMessage(appName, payload))
+}
+
+// NewEventMessageWithError builds the Watermill message used for audit events.
+func NewEventMessageWithError(ctx context.Context, appName string, payload Payload) (*message.Message, error) {
+	return publish.NewMessageWithError(ctx, newEventMessage(appName, payload))
+}
+
+func newEventMessage(appName string, payload Payload) publish.EventMessage {
+	return publish.EventMessage{
+		Date:    time.Now().UTC(),
+		App:     appName,
+		Version: EventVersion,
+		Type:    EventTypeAudit,
+		Payload: payload,
+	}
 }
 
 // PublishEventWithError publishes an audit event to the configured publisher.
 func PublishEventWithError(ctx context.Context, publisher message.Publisher, topicName string, appName string, payload Payload) error {
+	msg, err := NewEventMessageWithError(ctx, appName, payload)
+	if err != nil {
+		return err
+	}
 	return publisher.Publish(
 		topicName,
-		NewEventMessage(ctx, appName, payload),
+		msg,
 	)
 }
 

--- a/pkg/audit/publish.go
+++ b/pkg/audit/publish.go
@@ -18,6 +18,9 @@ import (
 )
 
 // NewEventMessage builds the Watermill message used for audit events.
+//
+// Deprecated: use NewEventMessageWithError in code paths that can return
+// marshal errors.
 func NewEventMessage(ctx context.Context, appName string, payload Payload) *message.Message {
 	return publish.NewMessage(ctx, newEventMessage(appName, payload))
 }

--- a/pkg/audit/publish_test.go
+++ b/pkg/audit/publish_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
 	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
 )
 
@@ -34,6 +35,26 @@ func TestNewEventMessage(t *testing.T) {
 	assert.Equal(t, payload.ID, decodedPayload.ID)
 }
 
+func TestNewEventMessageWithError(t *testing.T) {
+	t.Parallel()
+
+	payload := Payload{ID: "payload-id"}
+
+	msg, err := NewEventMessageWithError(context.Background(), "test-app", payload)
+
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+}
+
+func TestNewEventMessageWithErrorReturnsMarshalError(t *testing.T) {
+	t.Parallel()
+
+	msg, err := NewEventMessageWithError(context.Background(), "test-app", payloadWithUnsupportedClaims())
+
+	require.Nil(t, msg)
+	require.ErrorContains(t, err, "marshal event message")
+}
+
 func TestPublishEventWithError(t *testing.T) {
 	t.Parallel()
 
@@ -55,6 +76,30 @@ func TestPublishEventWithErrorReturnsPublisherError(t *testing.T) {
 	err := PublishEventWithError(context.Background(), pub, "audit-events", "test-app", Payload{})
 
 	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestPublishEventWithErrorReturnsMarshalError(t *testing.T) {
+	t.Parallel()
+
+	pub := &recordingPublisher{}
+
+	err := PublishEventWithError(context.Background(), pub, "audit-events", "test-app", payloadWithUnsupportedClaims())
+
+	require.ErrorContains(t, err, "marshal event message")
+	require.Empty(t, pub.messages)
+}
+
+func payloadWithUnsupportedClaims() Payload {
+	return Payload{
+		ID: "payload-id",
+		Actor: Actor{
+			Claims: &oidc.AccessTokenClaims{
+				Claims: map[string]any{
+					"unsupported": func() {},
+				},
+			},
+		},
+	}
 }
 
 type recordingPublisher struct {

--- a/pkg/fx/messagingfx/publish_test.go
+++ b/pkg/fx/messagingfx/publish_test.go
@@ -107,7 +107,8 @@ func TestModule(t *testing.T) {
 				span.End()
 			})
 			require.True(t, trace.SpanFromContext(ctx).SpanContext().IsValid())
-			msg := publish.NewMessage(ctx, publish.EventMessage{})
+			msg, err := publish.NewMessageWithError(ctx, publish.EventMessage{})
+			require.NoError(t, err)
 			require.NoError(t, publisher.Publish(tc.topic, msg))
 
 			select {

--- a/pkg/messaging/publish/messages.go
+++ b/pkg/messaging/publish/messages.go
@@ -3,6 +3,7 @@ package publish
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -10,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
 const (
@@ -20,11 +23,31 @@ const (
 )
 
 func NewMessage(ctx context.Context, m EventMessage) *message.Message {
-	data, err := json.Marshal(m)
-	if err != nil {
-		panic(err)
+	msg, err := NewMessageWithError(ctx, m)
+	if err == nil {
+		return msg
 	}
 
+	logging.FromContext(ctx).Errorf("failed to marshal event message: %v", err)
+	m.Payload = nil
+	msg, fallbackErr := NewMessageWithError(ctx, m)
+	if fallbackErr == nil {
+		return msg
+	}
+
+	logging.FromContext(ctx).Errorf("failed to marshal fallback event message: %v", fallbackErr)
+	return newMessage(ctx, []byte("{}"))
+}
+
+func NewMessageWithError(ctx context.Context, m EventMessage) (*message.Message, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("marshal event message: %w", err)
+	}
+	return newMessage(ctx, data), nil
+}
+
+func newMessage(ctx context.Context, data []byte) *message.Message {
 	carrier := propagation.MapCarrier{}
 	otel.GetTextMapPropagator().Inject(ctx, carrier)
 	otelContext, _ := json.Marshal(carrier)

--- a/pkg/messaging/publish/messages.go
+++ b/pkg/messaging/publish/messages.go
@@ -22,6 +22,8 @@ const (
 	otelContextKey = "otel-context"
 )
 
+// NewMessage preserves the legacy best-effort behavior. Prefer
+// NewMessageWithError in code paths that can return marshal errors.
 func NewMessage(ctx context.Context, m EventMessage) *message.Message {
 	msg, err := NewMessageWithError(ctx, m)
 	if err == nil {

--- a/pkg/messaging/publish/messages_test.go
+++ b/pkg/messaging/publish/messages_test.go
@@ -1,0 +1,47 @@
+package publish
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestNewMessageWithErrorReturnsMarshalError(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.ContextWithLogger(context.Background(), logging.NopZap())
+	msg, err := NewMessageWithError(ctx, EventMessage{
+		Type:    "test",
+		Payload: func() {},
+	})
+
+	require.Nil(t, msg)
+	require.ErrorContains(t, err, "marshal event message")
+}
+
+func TestNewMessageFallsBackWithoutPanicOnMarshalError(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.ContextWithLogger(context.Background(), logging.NopZap())
+	var msgPayload *EventMessage
+	var err error
+	var msgID string
+
+	require.NotPanics(t, func() {
+		msg := NewMessage(ctx, EventMessage{
+			Type:    "test",
+			Payload: func() {},
+		})
+		require.NotNil(t, msg)
+		msgID = msg.UUID
+		_, msgPayload, err = UnmarshalMessage(msg)
+	})
+
+	require.NotEmpty(t, msgID)
+	require.NoError(t, err)
+	require.Equal(t, "test", msgPayload.Type)
+	require.Nil(t, msgPayload.Payload)
+}

--- a/pkg/observe/http_client.go
+++ b/pkg/observe/http_client.go
@@ -1,8 +1,12 @@
 package observe
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
@@ -15,25 +19,31 @@ type WithBodiesTracingHTTPTransport struct {
 }
 
 func (t WithBodiesTracingHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	rawRequest, err := httputil.DumpRequest(req, true)
-	if err != nil {
-		panic(err)
+	var rawRequest []byte
+	if t.debug {
+		var dumpErr error
+		rawRequest, dumpErr = dumpRequest(req, true)
+		if dumpErr != nil {
+			return nil, fmt.Errorf("dump http request: %w", dumpErr)
+		}
 	}
 
 	rsp, err := t.underlying.RoundTrip(req)
-	if t.debug || err != nil || rsp.StatusCode >= 400 {
+	if t.debug || err != nil {
 		span := trace.SpanFromContext(req.Context())
-		span.SetAttributes(attribute.String("raw-request", string(rawRequest)))
+		if t.debug {
+			span.SetAttributes(attribute.String("raw-request", string(rawRequest)))
+		}
 		if err != nil {
 			span.SetAttributes(attribute.String("http-error", err.Error()))
 		}
-		if rsp != nil {
-			rawResponse, err := httputil.DumpResponse(rsp, true)
+		if t.debug && rsp != nil {
+			rawResponse, err := dumpResponse(rsp, true)
 			if err != nil {
-				panic(err)
+				span.SetAttributes(attribute.String("raw-response-error", err.Error()))
+			} else {
+				span.SetAttributes(attribute.String("raw-response", string(rawResponse)))
 			}
-
-			span.SetAttributes(attribute.String("raw-response", string(rawResponse)))
 		}
 	}
 
@@ -47,4 +57,70 @@ func NewRoundTripper(httpTransport http.RoundTripper, debug bool, options ...ote
 		debug:      debug,
 	}
 	return otelhttp.NewTransport(transport, options...)
+}
+
+func dumpRequest(req *http.Request, includeBody bool) ([]byte, error) {
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	redactSensitiveHeaders(cloned.Header)
+
+	if !includeBody {
+		return httputil.DumpRequestOut(cloned, false)
+	}
+
+	if req.Body == nil || req.Body == http.NoBody {
+		cloned.Body = req.Body
+		return httputil.DumpRequestOut(cloned, true)
+	}
+
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		cloned.Body = body
+		return httputil.DumpRequestOut(cloned, true)
+	}
+
+	data, readErr := io.ReadAll(req.Body)
+	closeErr := req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(data))
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	cloned.Body = io.NopCloser(bytes.NewReader(data))
+	return httputil.DumpRequestOut(cloned, true)
+}
+
+func dumpResponse(rsp *http.Response, includeBody bool) ([]byte, error) {
+	cloned := new(http.Response)
+	*cloned = *rsp
+	cloned.Header = rsp.Header.Clone()
+	redactSensitiveHeaders(cloned.Header)
+
+	data, err := httputil.DumpResponse(cloned, includeBody)
+	rsp.Body = cloned.Body
+	rsp.ContentLength = cloned.ContentLength
+	return data, err
+}
+
+func redactSensitiveHeaders(headers http.Header) {
+	for name := range headers {
+		if isSensitiveHeader(name) {
+			headers.Set(name, "[REDACTED]")
+		}
+	}
+}
+
+func isSensitiveHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "authorization", "cookie", "proxy-authorization", "set-cookie":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/observe/http_client_test.go
+++ b/pkg/observe/http_client_test.go
@@ -1,0 +1,97 @@
+package observe
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBodiesTracingHTTPTransportDoesNotDumpSuccessfulRequestWhenDebugDisabled(t *testing.T) {
+	t.Parallel()
+
+	transport := WithBodiesTracingHTTPTransport{
+		underlying: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       http.NoBody,
+			}, nil
+		}),
+		debug: false,
+	}
+	req, err := http.NewRequest(http.MethodPost, "http://example.com", errorReadCloser{err: errors.New("body should not be read")})
+	require.NoError(t, err)
+
+	var rsp *http.Response
+	require.NotPanics(t, func() {
+		rsp, err = transport.RoundTrip(req)
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+}
+
+func TestBodiesTracingHTTPTransportReturnsRequestDumpError(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	transport := WithBodiesTracingHTTPTransport{
+		underlying: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			called = true
+			return &http.Response{StatusCode: http.StatusOK}, nil
+		}),
+		debug: true,
+	}
+	req, err := http.NewRequest(http.MethodPost, "http://example.com", errorReadCloser{err: errors.New("read failed")})
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err = transport.RoundTrip(req)
+	})
+
+	require.ErrorContains(t, err, "dump http request")
+	require.False(t, called)
+}
+
+func TestBodiesTracingHTTPTransportDoesNotPanicOnResponseDumpError(t *testing.T) {
+	t.Parallel()
+
+	transport := WithBodiesTracingHTTPTransport{
+		underlying: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       errorReadCloser{err: errors.New("read failed")},
+			}, nil
+		}),
+		debug: true,
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	var rsp *http.Response
+	require.NotPanics(t, func() {
+		rsp, err = transport.RoundTrip(req)
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, rsp.StatusCode)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errorReadCloser struct {
+	err error
+}
+
+func (r errorReadCloser) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (r errorReadCloser) Close() error {
+	return nil
+}

--- a/pkg/transport/httpclient/debug.go
+++ b/pkg/transport/httpclient/debug.go
@@ -1,8 +1,12 @@
 package httpclient
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
@@ -12,22 +16,29 @@ type httpTransport struct {
 }
 
 func (h httpTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	data, err := httputil.DumpRequest(request, true)
-	if err != nil {
-		panic(err)
+	logger := logging.FromContext(request.Context())
+	debugEnabled := logger.Enabled(logging.DebugLevel)
+	if debugEnabled {
+		data, err := dumpRequest(request, true)
+		if err != nil {
+			return nil, fmt.Errorf("dump http request: %w", err)
+		}
+		logger.Debug(string(data))
 	}
-	logging.FromContext(request.Context()).Debug(string(data))
 
 	rsp, err := h.underlying.RoundTrip(request)
 	if err != nil {
 		return nil, err
 	}
 
-	data, err = httputil.DumpResponse(rsp, true)
-	if err != nil {
-		panic(err)
+	if debugEnabled {
+		data, err := dumpResponse(rsp, true)
+		if err != nil {
+			logger.Debugf("failed to dump HTTP response: %v", err)
+			return rsp, nil
+		}
+		logger.Debug(string(data))
 	}
-	logging.FromContext(request.Context()).Debug(string(data))
 
 	return rsp, nil
 }
@@ -37,5 +48,71 @@ var _ http.RoundTripper = &httpTransport{}
 func NewDebugHTTPTransport(underlying http.RoundTripper) *httpTransport {
 	return &httpTransport{
 		underlying: underlying,
+	}
+}
+
+func dumpRequest(req *http.Request, includeBody bool) ([]byte, error) {
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	redactSensitiveHeaders(cloned.Header)
+
+	if !includeBody {
+		return httputil.DumpRequestOut(cloned, false)
+	}
+
+	if req.Body == nil || req.Body == http.NoBody {
+		cloned.Body = req.Body
+		return httputil.DumpRequestOut(cloned, true)
+	}
+
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		cloned.Body = body
+		return httputil.DumpRequestOut(cloned, true)
+	}
+
+	data, readErr := io.ReadAll(req.Body)
+	closeErr := req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(data))
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	cloned.Body = io.NopCloser(bytes.NewReader(data))
+	return httputil.DumpRequestOut(cloned, true)
+}
+
+func dumpResponse(rsp *http.Response, includeBody bool) ([]byte, error) {
+	cloned := new(http.Response)
+	*cloned = *rsp
+	cloned.Header = rsp.Header.Clone()
+	redactSensitiveHeaders(cloned.Header)
+
+	data, err := httputil.DumpResponse(cloned, includeBody)
+	rsp.Body = cloned.Body
+	rsp.ContentLength = cloned.ContentLength
+	return data, err
+}
+
+func redactSensitiveHeaders(headers http.Header) {
+	for name := range headers {
+		if isSensitiveHeader(name) {
+			headers.Set(name, "[REDACTED]")
+		}
+	}
+}
+
+func isSensitiveHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "authorization", "cookie", "proxy-authorization", "set-cookie":
+		return true
+	default:
+		return false
 	}
 }

--- a/pkg/transport/httpclient/debug_test.go
+++ b/pkg/transport/httpclient/debug_test.go
@@ -1,0 +1,136 @@
+package httpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestDebugHTTPTransportSkipsDumpWhenDebugDisabled(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", errorReadCloser{err: errors.New("body should not be read")})
+	require.NoError(t, err)
+
+	rsp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.Empty(t, logger.debugMessages)
+}
+
+func TestDebugHTTPTransportRedactsAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{debugEnabled: true}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("response body")),
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", strings.NewReader("request body"))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer secret-token")
+
+	rsp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "response body", string(body))
+
+	logs := strings.Join(logger.debugMessages, "\n")
+	require.Contains(t, logs, "Authorization: [REDACTED]")
+	require.NotContains(t, logs, "Bearer secret-token")
+}
+
+func TestDebugHTTPTransportDoesNotPanicOnResponseDumpError(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{debugEnabled: true}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       errorReadCloser{err: errors.New("read failed")},
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	var rsp *http.Response
+	require.NotPanics(t, func() {
+		rsp, err = transport.RoundTrip(req)
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.Contains(t, strings.Join(logger.debugMessages, "\n"), "failed to dump HTTP response")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errorReadCloser struct {
+	err error
+}
+
+func (r errorReadCloser) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (r errorReadCloser) Close() error {
+	return nil
+}
+
+type recordingLogger struct {
+	debugEnabled  bool
+	debugMessages []string
+}
+
+func (l *recordingLogger) Tracef(string, ...any) {}
+func (l *recordingLogger) Debugf(format string, args ...any) {
+	l.debugMessages = append(l.debugMessages, fmt.Sprintf(format, args...))
+}
+func (l *recordingLogger) Infof(string, ...any)  {}
+func (l *recordingLogger) Errorf(string, ...any) {}
+func (l *recordingLogger) Trace(...any)          {}
+func (l *recordingLogger) Debug(args ...any) {
+	l.debugMessages = append(l.debugMessages, fmt.Sprint(args...))
+}
+func (l *recordingLogger) Info(...any)  {}
+func (l *recordingLogger) Error(...any) {}
+func (l *recordingLogger) WithFields(map[string]any) logging.Logger {
+	return l
+}
+func (l *recordingLogger) WithField(string, any) logging.Logger {
+	return l
+}
+func (l *recordingLogger) WithContext(context.Context) logging.Logger {
+	return l
+}
+func (l *recordingLogger) Writer() io.Writer {
+	return io.Discard
+}
+func (l *recordingLogger) Enabled(level logging.Level) bool {
+	return l.debugEnabled && level == logging.DebugLevel
+}

--- a/pkg/workflow/temporal/client.go
+++ b/pkg/workflow/temporal/client.go
@@ -100,7 +100,7 @@ func CreateSearchAttributes(ctx context.Context, c client.Client, namespace stri
 			Namespace: namespace,
 		})
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("list temporal search attributes: %w", err)
 		}
 
 		done := true

--- a/pkg/workflow/temporal/client_test.go
+++ b/pkg/workflow/temporal/client_test.go
@@ -1,0 +1,87 @@
+package temporal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/operatorservice/v1"
+	temporalmocks "go.temporal.io/sdk/mocks"
+	"google.golang.org/grpc"
+)
+
+func TestCreateSearchAttributesReturnsListSearchAttributesError(t *testing.T) {
+	t.Parallel()
+
+	operator := &fakeOperatorService{
+		listErr: errors.New("temporarily unavailable"),
+	}
+	c := &temporalmocks.Client{}
+	c.On("OperatorService").Return(operator)
+
+	err := CreateSearchAttributes(context.Background(), c, "default", map[string]enums.IndexedValueType{
+		"CustomKeyword": enums.INDEXED_VALUE_TYPE_KEYWORD,
+	})
+
+	require.ErrorContains(t, err, "list temporal search attributes")
+	require.ErrorContains(t, err, "temporarily unavailable")
+}
+
+type fakeOperatorService struct {
+	addErr  error
+	listErr error
+	listRsp *operatorservice.ListSearchAttributesResponse
+}
+
+func (f *fakeOperatorService) AddSearchAttributes(context.Context, *operatorservice.AddSearchAttributesRequest, ...grpc.CallOption) (*operatorservice.AddSearchAttributesResponse, error) {
+	return &operatorservice.AddSearchAttributesResponse{}, f.addErr
+}
+
+func (f *fakeOperatorService) RemoveSearchAttributes(context.Context, *operatorservice.RemoveSearchAttributesRequest, ...grpc.CallOption) (*operatorservice.RemoveSearchAttributesResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) ListSearchAttributes(context.Context, *operatorservice.ListSearchAttributesRequest, ...grpc.CallOption) (*operatorservice.ListSearchAttributesResponse, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listRsp, nil
+}
+
+func (f *fakeOperatorService) DeleteNamespace(context.Context, *operatorservice.DeleteNamespaceRequest, ...grpc.CallOption) (*operatorservice.DeleteNamespaceResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) AddOrUpdateRemoteCluster(context.Context, *operatorservice.AddOrUpdateRemoteClusterRequest, ...grpc.CallOption) (*operatorservice.AddOrUpdateRemoteClusterResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) RemoveRemoteCluster(context.Context, *operatorservice.RemoveRemoteClusterRequest, ...grpc.CallOption) (*operatorservice.RemoveRemoteClusterResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) ListClusters(context.Context, *operatorservice.ListClustersRequest, ...grpc.CallOption) (*operatorservice.ListClustersResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) GetNexusEndpoint(context.Context, *operatorservice.GetNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.GetNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) CreateNexusEndpoint(context.Context, *operatorservice.CreateNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.CreateNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) UpdateNexusEndpoint(context.Context, *operatorservice.UpdateNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.UpdateNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) DeleteNexusEndpoint(context.Context, *operatorservice.DeleteNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.DeleteNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) ListNexusEndpoints(context.Context, *operatorservice.ListNexusEndpointsRequest, ...grpc.CallOption) (*operatorservice.ListNexusEndpointsResponse, error) {
+	return nil, errors.New("not implemented")
+}


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1192` from EN-1136.

This PR contains the scoped change: Avoid hot-path panics.

Stack base: `feat/en-1191-responsewriter-interfaces`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
