### PR TITLE
fix(types): synchronize linked list access (EN-1193)

### DIFF
--- a/pkg/types/collections/linked_list.go
+++ b/pkg/types/collections/linked_list.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"reflect"
 	"sync"
 )
 
@@ -19,6 +20,13 @@ func (n *LinkedListNode[T]) Value() T {
 }
 
 func (n *LinkedListNode[T]) Remove() {
+	n.list.mu.Lock()
+	defer n.list.mu.Unlock()
+
+	n.remove()
+}
+
+func (n *LinkedListNode[T]) remove() {
 	if n.previousNode != nil {
 		n.previousNode.nextNode = n.nextNode
 	}
@@ -67,7 +75,7 @@ func (r *LinkedList[T]) RemoveFirst(cmp func(T) bool) *LinkedListNode[T] {
 	node := r.firstNode
 	for node != nil {
 		if cmp(node.object) {
-			node.Remove()
+			node.remove()
 			return node
 		}
 		node = node.nextNode
@@ -78,11 +86,14 @@ func (r *LinkedList[T]) RemoveFirst(cmp func(T) bool) *LinkedListNode[T] {
 
 func (r *LinkedList[T]) RemoveValue(t T) *LinkedListNode[T] {
 	return r.RemoveFirst(func(t2 T) bool {
-		return (any)(t) == (any)(t2)
+		return comparableEqual(t, t2)
 	})
 }
 
 func (r *LinkedList[T]) TakeFirst() T {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	var t T
 	if r.firstNode == nil {
 		return t
@@ -90,6 +101,7 @@ func (r *LinkedList[T]) TakeFirst() T {
 	ret := r.firstNode.object
 	if r.firstNode.nextNode == nil {
 		r.firstNode = nil
+		r.lastNode = nil
 	} else {
 		r.firstNode = r.firstNode.nextNode
 		r.firstNode.previousNode = nil
@@ -124,6 +136,9 @@ func (r *LinkedList[T]) ForEach(f func(t T)) {
 }
 
 func (r *LinkedList[T]) Slice() []T {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	ret := make([]T, 0)
 	node := r.firstNode
 	for node != nil {
@@ -134,9 +149,34 @@ func (r *LinkedList[T]) Slice() []T {
 }
 
 func (r *LinkedList[T]) FirstNode() *LinkedListNode[T] {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	return r.firstNode
 }
 
 func NewLinkedList[T any]() *LinkedList[T] {
 	return &LinkedList[T]{}
+}
+
+func comparableEqual[T any](a, b T) (equal bool) {
+	aAny := any(a)
+	bAny := any(b)
+
+	aType := reflect.TypeOf(aAny)
+	bType := reflect.TypeOf(bAny)
+	if aType == nil || bType == nil {
+		return aType == bType
+	}
+	if aType != bType || !aType.Comparable() {
+		return false
+	}
+
+	defer func() {
+		if recover() != nil {
+			equal = false
+		}
+	}()
+
+	return aAny == bAny
 }

--- a/pkg/types/collections/linked_list_internal_test.go
+++ b/pkg/types/collections/linked_list_internal_test.go
@@ -1,0 +1,17 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinkedListTakeFirstClearsLastNodeWhenListBecomesEmpty(t *testing.T) {
+	t.Parallel()
+	list := NewLinkedList[int]()
+	list.Append(1)
+
+	require.Equal(t, 1, list.TakeFirst())
+	require.Nil(t, list.firstNode)
+	require.Nil(t, list.lastNode)
+}

--- a/pkg/types/collections/linked_list_test.go
+++ b/pkg/types/collections/linked_list_test.go
@@ -118,6 +118,43 @@ func TestLinkedList(t *testing.T) {
 		require.Equal(t, 4, list.Length())
 	})
 
+	t.Run("RemoveValueNonComparable", func(t *testing.T) {
+		t.Parallel()
+		list := collectionutils.NewLinkedList[[]int]()
+		list.Append([]int{1}, []int{2})
+
+		require.NotPanics(t, func() {
+			node := list.RemoveValue([]int{1})
+			require.Nil(t, node)
+		})
+		require.Equal(t, [][]int{{1}, {2}}, list.Slice())
+
+		interfaceList := collectionutils.NewLinkedList[any]()
+		interfaceList.Append([]int{1}, "match")
+
+		require.NotPanics(t, func() {
+			node := interfaceList.RemoveValue([]int{1})
+			require.Nil(t, node)
+		})
+
+		node := interfaceList.RemoveValue("match")
+		require.NotNil(t, node)
+		require.Equal(t, "match", node.Value())
+		require.Equal(t, []any{[]int{1}}, interfaceList.Slice())
+
+		type interfaceField struct {
+			value any
+		}
+		structList := collectionutils.NewLinkedList[interfaceField]()
+		structList.Append(interfaceField{value: []int{1}})
+
+		require.NotPanics(t, func() {
+			node := structList.RemoveValue(interfaceField{value: []int{1}})
+			require.Nil(t, node)
+		})
+		require.Equal(t, []interfaceField{{value: []int{1}}}, structList.Slice())
+	})
+
 	t.Run("TakeFirst", func(t *testing.T) {
 		t.Parallel()
 		list := collectionutils.NewLinkedList[int]()
@@ -303,5 +340,36 @@ func TestLinkedList(t *testing.T) {
 		// Sum should be 10 * sum of numbers from 0 to 99
 		expectedSum := 10 * (99 * 100 / 2)
 		require.Equal(t, expectedSum, sum)
+	})
+
+	t.Run("ConcurrentTakeFirstSliceAndFirstNode", func(t *testing.T) {
+		t.Parallel()
+		list := collectionutils.NewLinkedList[int]()
+		list.Append(1, 2, 3, 4, 5)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func(base int) {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					list.Append(base*1000 + j)
+					_ = list.TakeFirst()
+				}
+			}(i)
+		}
+
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					_ = list.Slice()
+					_ = list.FirstNode()
+				}
+			}()
+		}
+
+		wg.Wait()
 	})
 }


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1193` from EN-1136.

This PR contains the scoped change: Synchronize linked list access.

Stack base: `feat/en-1192-hot-path-panics`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
