### PR TITLE
ci: reduce workflow permissions (EN-1195)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,7 @@ on:
     types: [ assigned, opened, synchronize, reopened, labeled ]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

Stacked split PR for `EN-1195` from EN-1136.

This PR contains the scoped change: Reduce CI workflow permissions.

Stack base: `feat/en-1194-temporal-logger`.

## Validation

Validated while rebuilding the stack:
- package-specific `go test` for this ticket
- `go mod tidy` with no diff at stack top
- `git diff --check`
- `go test ./...` at stack top

## Notes

This replaces the oversized draft PR #623 with reviewable stacked PRs. Review this PR against its stack base, not directly against `main`, unless GitHub already shows the selected base above.
