### PR TITLE
fix(audit): cap captured request/response bodies and flag truncation

### DIFF
--- a/pkg/audit/httpaudit/middleware.go
+++ b/pkg/audit/httpaudit/middleware.go
@@ -26,13 +26,34 @@ type httpOptions struct {
 	sensitivePaths      map[string]struct{}
 	eventPublisher      auditEventPublisher
 	handledHeaderSecret string
+	maxBodyBytes        int
 }
+
+// DefaultMaxCapturedBodyBytes bounds how many bytes of each request and response
+// body are stored in an audit event when WithMaxBodyBytes is not set. It keeps the
+// serialized audit message well within broker payload limits (e.g. NATS max_payload).
+const DefaultMaxCapturedBodyBytes = 64 * 1024
 
 // WithSensitivePaths sets paths for which the response body should not be captured.
 func WithSensitivePaths(paths ...string) HTTPOption {
 	return func(o *httpOptions) {
 		for _, p := range paths {
 			o.sensitivePaths[p] = struct{}{}
+		}
+	}
+}
+
+// WithMaxBodyBytes caps how many bytes of each captured request and response body
+// are stored in the audit event. Bodies larger than the cap are truncated to the
+// cap and flagged via HTTPRequest.BodyTruncated / HTTPResponse.BodyTruncated, which
+// bounds the serialized audit message so it stays within broker payload limits
+// (e.g. NATS max_payload). The full body is always passed through to the client and
+// downstream handlers; only the audited copy is bounded. A value <= 0 keeps the
+// default cap (DefaultMaxCapturedBodyBytes).
+func WithMaxBodyBytes(maxBytes int) HTTPOption {
+	return func(o *httpOptions) {
+		if maxBytes > 0 {
+			o.maxBodyBytes = maxBytes
 		}
 	}
 }
@@ -97,6 +118,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 
 	ho := &httpOptions{
 		sensitivePaths: make(map[string]struct{}),
+		maxBodyBytes:   DefaultMaxCapturedBodyBytes,
 	}
 	for _, opt := range httpOpts {
 		opt(ho)
@@ -146,19 +168,16 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 			}
 
 			var (
-				body []byte
-				err  error
+				body                 []byte
+				requestBodyTruncated bool
+				err                  error
 			)
 
 			if !isStreamRequest(r) {
-				body, err = io.ReadAll(r.Body)
+				body, requestBodyTruncated, err = captureRequestBody(r, ho.maxBodyBytes)
 				if err != nil && !errors.Is(err, io.EOF) {
 					http.Error(w, "failed to read request body", http.StatusInternalServerError)
 					return
-				}
-				if len(body) > 0 {
-					_ = r.Body.Close()
-					r.Body = io.NopCloser(bytes.NewBuffer(body))
 				}
 			}
 
@@ -170,19 +189,22 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 
 			buf := bufPool.Get().(*bytes.Buffer)
 			buf.Reset()
-			defer bufPool.Put(buf)
+			defer putCaptureBuffer(buf)
 
 			rww := &responseWriterWrapper{
 				ResponseWriter: w,
 				body:           buf,
 				statusCode:     http.StatusOK,
+				maxBodyBytes:   ho.maxBodyBytes,
 			}
 
 			next.ServeHTTP(rww, r)
 
 			responseBody := rww.body.String()
+			responseBodyTruncated := rww.bodyTruncated
 			if _, sensitive := ho.sensitivePaths[r.URL.Path]; sensitive {
 				responseBody = ""
+				responseBodyTruncated = false
 			}
 
 			actor := audit.ExtractClaims(r, auditOpts)
@@ -193,21 +215,18 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				Actor:   actor,
 				HTTP: audit.HTTP{
 					Request: audit.HTTPRequest{
-						Method: r.Method,
-						Path:   r.URL.Path,
-						Host:   r.Host,
-						Header: requestHeaders,
-						Body: func() string {
-							if len(body) > 0 {
-								return string(body)
-							}
-							return ""
-						}(),
+						Method:        r.Method,
+						Path:          r.URL.Path,
+						Host:          r.Host,
+						Header:        requestHeaders,
+						Body:          string(body),
+						BodyTruncated: requestBodyTruncated,
 					},
 					Response: audit.HTTPResponse{
-						StatusCode: rww.statusCode,
-						Headers:    rww.Header(),
-						Body:       responseBody,
+						StatusCode:    rww.statusCode,
+						Headers:       rww.Header(),
+						Body:          responseBody,
+						BodyTruncated: responseBodyTruncated,
 					},
 				},
 			}
@@ -222,18 +241,82 @@ func isStreamRequest(r *http.Request) bool {
 	return strings.HasPrefix(ct, "application/vnd.formance") && strings.HasSuffix(ct, "-stream")
 }
 
+// captureRequestBody reads up to maxBytes of the request body for audit capture
+// while leaving the full body readable by downstream handlers. truncated reports
+// whether the captured copy was cut to the cap.
+func captureRequestBody(r *http.Request, maxBytes int) (captured []byte, truncated bool, err error) {
+	if r.Body == nil {
+		return nil, false, nil
+	}
+
+	// Read one byte past the cap to detect whether the body exceeds it.
+	raw, err := io.ReadAll(io.LimitReader(r.Body, int64(maxBytes)+1))
+	if len(raw) > 0 {
+		r.Body = readCloser{
+			Reader: io.MultiReader(bytes.NewReader(raw), r.Body),
+			Closer: r.Body,
+		}
+	}
+
+	captured = raw
+	if len(raw) > maxBytes {
+		truncated = true
+		captured = raw[:maxBytes]
+	}
+	return captured, truncated, err
+}
+
+func putCaptureBuffer(buf *bytes.Buffer) {
+	if shouldPoolCaptureBuffer(buf) {
+		buf.Reset()
+		bufPool.Put(buf)
+	}
+}
+
+// shouldPoolCaptureBuffer keeps oversized buffers (from large WithMaxBodyBytes
+// caps) out of the shared pool so they are not pinned in memory.
+func shouldPoolCaptureBuffer(buf *bytes.Buffer) bool {
+	return buf.Cap() <= DefaultMaxCapturedBodyBytes
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
 type responseWriterWrapper struct {
 	http.ResponseWriter
-	body       *bytes.Buffer
-	statusCode int
+	body          *bytes.Buffer
+	statusCode    int
+	maxBodyBytes  int
+	bodyTruncated bool
 }
 
 func (rww *responseWriterWrapper) Write(buf []byte) (int, error) {
 	mediaType, _, _ := mime.ParseMediaType(rww.Header().Get("Content-Type"))
 	if mediaType != "application/octet-stream" {
-		rww.body.Write(buf)
+		rww.captureBody(buf)
 	}
 	return rww.ResponseWriter.Write(buf)
+}
+
+// captureBody appends bytes to the audited copy up to maxBodyBytes, flagging
+// truncation once the cap is reached. The full buffer is still written to the
+// client by the caller.
+func (rww *responseWriterWrapper) captureBody(buf []byte) {
+	remaining := rww.maxBodyBytes - rww.body.Len()
+	if remaining <= 0 {
+		if len(buf) > 0 {
+			rww.bodyTruncated = true
+		}
+		return
+	}
+	if len(buf) > remaining {
+		rww.body.Write(buf[:remaining])
+		rww.bodyTruncated = true
+		return
+	}
+	rww.body.Write(buf)
 }
 
 func (rww *responseWriterWrapper) WriteHeader(statusCode int) {

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -125,6 +125,136 @@ func TestMiddleware_BasicCapture(t *testing.T) {
 	assert.Equal(t, `{"key":"value"}`, payload.HTTP.Request.Body)
 	assert.Equal(t, http.StatusOK, payload.HTTP.Response.StatusCode)
 	assert.Equal(t, `{"status":"ok"}`, payload.HTTP.Response.Body)
+	assert.False(t, payload.HTTP.Request.BodyTruncated)
+	assert.False(t, payload.HTTP.Response.BodyTruncated)
+}
+
+func TestMiddleware_CapsRequestBodyAndFlagsTruncation(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	var received string
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			received = string(b)
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	prefix := strings.Repeat("a", DefaultMaxCapturedBodyBytes)
+	reqBody := prefix + strings.Repeat("b", 1024)
+	req := httptest.NewRequest("POST", "/api/test", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	// The handler still sees the full request body.
+	assert.Equal(t, reqBody, received)
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	assert.Len(t, payload.HTTP.Request.Body, DefaultMaxCapturedBodyBytes)
+	assert.Equal(t, prefix, payload.HTTP.Request.Body)
+	assert.True(t, payload.HTTP.Request.BodyTruncated)
+}
+
+func TestMiddleware_CapsResponseBodyAndFlagsTruncation(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	prefix := strings.Repeat("r", DefaultMaxCapturedBodyBytes)
+	responseBody := prefix + strings.Repeat("s", 1024)
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			// Write across the cap boundary in two chunks.
+			_, _ = w.Write([]byte(responseBody[:DefaultMaxCapturedBodyBytes/2]))
+			_, _ = w.Write([]byte(responseBody[DefaultMaxCapturedBodyBytes/2:]))
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	// The client still receives the full response body.
+	assert.Equal(t, responseBody, rr.Body.String())
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	assert.Len(t, payload.HTTP.Response.Body, DefaultMaxCapturedBodyBytes)
+	assert.Equal(t, prefix, payload.HTTP.Response.Body)
+	assert.True(t, payload.HTTP.Response.BodyTruncated)
+}
+
+func TestMiddleware_WithMaxBodyBytesOverridesDefault(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	const limit = 16
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true), WithMaxBodyBytes(limit))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(strings.Repeat("z", 100)))
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, strings.Repeat("z", 100), rr.Body.String())
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	assert.Len(t, payload.HTTP.Response.Body, limit)
+	assert.True(t, payload.HTTP.Response.BodyTruncated)
+}
+
+func TestMiddleware_DoesNotPoolOversizedCaptureBuffers(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, shouldPoolCaptureBuffer(bytes.NewBuffer(make([]byte, 0, DefaultMaxCapturedBodyBytes))))
+	assert.False(t, shouldPoolCaptureBuffer(bytes.NewBuffer(make([]byte, 0, DefaultMaxCapturedBodyBytes+1))))
+}
+
+func auditPayloadFromMessage(t *testing.T, msg *message.Message) audit.Payload {
+	t.Helper()
+
+	var event publish.EventMessage
+	require.NoError(t, json.Unmarshal(msg.Payload, &event))
+
+	payloadBytes, err := json.Marshal(event.Payload)
+	require.NoError(t, err)
+
+	var payload audit.Payload
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+	return payload
 }
 
 func TestMiddleware_AuthorizationHeaderStripped(t *testing.T) {

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -44,15 +44,17 @@ type HTTP struct {
 }
 
 type HTTPRequest struct {
-	Method string      `json:"method"`
-	Path   string      `json:"path"`
-	Host   string      `json:"host"`
-	Header http.Header `json:"header"`
-	Body   string      `json:"body,omitempty"`
+	Method        string      `json:"method"`
+	Path          string      `json:"path"`
+	Host          string      `json:"host"`
+	Header        http.Header `json:"header"`
+	Body          string      `json:"body,omitempty"`
+	BodyTruncated bool        `json:"body_truncated,omitempty"`
 }
 
 type HTTPResponse struct {
-	StatusCode int         `json:"status_code"`
-	Headers    http.Header `json:"headers"`
-	Body       string      `json:"body,omitempty"`
+	StatusCode    int         `json:"status_code"`
+	Headers       http.Header `json:"headers"`
+	Body          string      `json:"body,omitempty"`
+	BodyTruncated bool        `json:"body_truncated,omitempty"`
 }


### PR DESCRIPTION
Adapted from https://github.com/formancehq/go-libs/pull/627 but with a configurable since it depends on the transport, and a flag to mark truncated bodies

The HTTP audit middleware captured the full request and response bodies with no size limit. For large responses (e.g. GET /{ledger}/transactions), the serialized audit event exceeded the NATS max_payload, so the async publisher dropped the event with "nats: maximum payload exceeded" and the request's server span was marked as errored even though the API returned 200.

Bound each captured body to a configurable cap (WithMaxBodyBytes, default 64KiB) and flag truncation via HTTPRequest/HTTPResponse.BodyTruncated. The full body is still passed through to the client and downstream handlers; only the audited copy is bounded, keeping the audit message within broker payload limits.