### PR TITLE
feat(httpserver): skip configurable paths in request logs and traces

### DIFF
--- a/pkg/transport/httpserver/middlewares.go
+++ b/pkg/transport/httpserver/middlewares.go
@@ -21,11 +21,20 @@ func (lrw *loggingResponseWriter) WriteHeader(statusCode int) {
 	lrw.ResponseWriter.WriteHeader(statusCode)
 }
 
-func LoggerMiddleware(l logging.Logger) func(h http.Handler) http.Handler {
+func LoggerMiddleware(l logging.Logger, opts ...Option) func(h http.Handler) http.Handler {
+	cfg := newMiddlewareConfig(opts...)
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			start := time.Now()
 			r = r.WithContext(logging.ContextWithLogger(r.Context(), l))
+
+			// Skip request logging for ignored paths (e.g. health probes), but
+			// keep the logger available to downstream handlers via the context.
+			if cfg.isIgnored(r.URL.Path) {
+				h.ServeHTTP(w, r)
+				return
+			}
+
+			start := time.Now()
 			logger := logging.FromContext(r.Context())
 
 			rec := NewLoggingResponseWriter(w)

--- a/pkg/transport/httpserver/options.go
+++ b/pkg/transport/httpserver/options.go
@@ -1,0 +1,62 @@
+package httpserver
+
+// defaultIgnoredPaths lists the request paths that the logging and tracing
+// middlewares skip by default. These are infrastructure probe endpoints that
+// would otherwise emit one log line and one span on every scrape, drowning out
+// real traffic.
+//
+// Extend the set with AppendIgnoredPaths, or replace it entirely with
+// WithIgnoredPaths.
+var defaultIgnoredPaths = []string{"/_healthcheck", "/_info"}
+
+// Option configures the logging and tracing middlewares (LoggerMiddleware and
+// OTLPMiddleware). Options are applied in the order they are given.
+type Option func(*middlewareConfig)
+
+type middlewareConfig struct {
+	ignoredPaths map[string]struct{}
+}
+
+func newMiddlewareConfig(opts ...Option) *middlewareConfig {
+	cfg := &middlewareConfig{ignoredPaths: pathSet(defaultIgnoredPaths)}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
+func pathSet(paths []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		set[p] = struct{}{}
+	}
+	return set
+}
+
+func (c *middlewareConfig) isIgnored(path string) bool {
+	_, ok := c.ignoredPaths[path]
+	return ok
+}
+
+// AppendIgnoredPaths adds paths to the set the middlewares skip, on top of the
+// defaults ("/_healthcheck", "/_info"). This is the option to reach for in
+// almost all cases.
+func AppendIgnoredPaths(paths ...string) Option {
+	return func(c *middlewareConfig) {
+		for _, p := range paths {
+			c.ignoredPaths[p] = struct{}{}
+		}
+	}
+}
+
+// WithIgnoredPaths replaces the entire ignore set, discarding the defaults —
+// including "/_healthcheck" and "/_info". Pass them explicitly if you still
+// want them skipped. Calling WithIgnoredPaths() with no arguments makes the
+// middlewares log and trace every request.
+//
+// Most callers want AppendIgnoredPaths instead.
+func WithIgnoredPaths(paths ...string) Option {
+	return func(c *middlewareConfig) {
+		c.ignoredPaths = pathSet(paths)
+	}
+}

--- a/pkg/transport/httpserver/options_test.go
+++ b/pkg/transport/httpserver/options_test.go
@@ -1,0 +1,94 @@
+package httpserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+// ignoredPathCase drives both the logging and tracing middleware tests: given a
+// set of options and a request path, the request should either be observed
+// (logged / traced) or skipped.
+type ignoredPathCase struct {
+	name     string
+	opts     []Option
+	path     string
+	observed bool
+}
+
+func ignoredPathCases() []ignoredPathCase {
+	return []ignoredPathCase{
+		{"default skips /_healthcheck", nil, "/_healthcheck", false},
+		{"default skips /_info", nil, "/_info", false},
+		{"default observes other paths", nil, "/organizations", true},
+		{"append adds a path", []Option{AppendIgnoredPaths("/ready")}, "/ready", false},
+		{"append keeps the defaults", []Option{AppendIgnoredPaths("/ready")}, "/_healthcheck", false},
+		{"with replaces the defaults", []Option{WithIgnoredPaths("/ready")}, "/_healthcheck", true},
+		{"with skips the listed path", []Option{WithIgnoredPaths("/ready")}, "/ready", false},
+		{"empty with observes everything", []Option{WithIgnoredPaths()}, "/_healthcheck", true},
+	}
+}
+
+func TestLoggerMiddlewareIgnoredPaths(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range ignoredPathCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			buf := &safeBuffer{}
+			logger := logging.NewDefaultLogger(buf, false, false, false)
+
+			handler := LoggerMiddleware(logger, tc.opts...)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			if tc.observed {
+				require.Contains(t, buf.String(), "Request")
+				require.Contains(t, buf.String(), tc.path)
+			} else {
+				require.NotContains(t, buf.String(), "Request")
+			}
+		})
+	}
+}
+
+func TestOTLPMiddlewareIgnoredPaths(t *testing.T) {
+	// Not parallel: the test swaps the global tracer provider.
+	for _, tc := range ignoredPathCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+			previous := otel.GetTracerProvider()
+			otel.SetTracerProvider(tp)
+			t.Cleanup(func() { otel.SetTracerProvider(previous) })
+
+			handler := OTLPMiddleware("test-server", false, tc.opts...)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			require.NoError(t, tp.ForceFlush(context.Background()))
+
+			if tc.observed {
+				require.Len(t, recorder.Ended(), 1)
+			} else {
+				require.Empty(t, recorder.Ended())
+			}
+		})
+	}
+}

--- a/pkg/transport/httpserver/otlp_middleware.go
+++ b/pkg/transport/httpserver/otlp_middleware.go
@@ -54,10 +54,23 @@ func isJSONContent(contentType string) bool {
 	return strings.Contains(strings.ToLower(contentType), "application/json")
 }
 
-func OTLPMiddleware(serverName string, debug bool) func(h http.Handler) http.Handler {
-	m := otelchi.Middleware(serverName)
+func OTLPMiddleware(serverName string, debug bool, opts ...Option) func(h http.Handler) http.Handler {
+	cfg := newMiddlewareConfig(opts...)
+	// Hand the ignore set to otelchi as a filter so no span is started for
+	// ignored paths (e.g. health probes). A filter returning false excludes the
+	// request from tracing.
+	m := otelchi.Middleware(serverName, otelchi.WithFilter(func(r *http.Request) bool {
+		return !cfg.isIgnored(r.URL.Path)
+	}))
 	return func(h http.Handler) http.Handler {
 		return m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// otelchi created no span for ignored paths; skip attribute
+			// collection and body capture entirely.
+			if cfg.isIgnored(r.URL.Path) {
+				h.ServeHTTP(w, r)
+				return
+			}
+
 			span := trace.SpanFromContext(r.Context())
 
 			// Always log basic request metadata


### PR DESCRIPTION
## What

Adds configurable path exclusion to the HTTP `LoggerMiddleware` and `OTLPMiddleware` so infrastructure probe endpoints stop generating noise in logs and traces.

Two functional options:

- `AppendIgnoredPaths(...string)` — adds to the defaults (the common case).
- `WithIgnoredPaths(...string)` — replaces the default set entirely; `WithIgnoredPaths()` with no args logs/traces everything.

**Behavioral default change:** both middlewares now skip `/_healthcheck` and `/_info` out of the box. Signatures are variadic, so existing callers compile unchanged and pick up the quiet defaults for free.

Tracing exclusion is delegated to `otelchi.WithFilter`, so **no span is even started** for ignored paths (not just dropped after the fact).

## Why

`LoggerMiddleware` logs one `Request` line per call and `OTLPMiddleware` opens one span per call — including every k8s/LB health probe, which drowns out real traffic. There was no way to opt out short of forking the middleware per service.

## Usage

After bumping go-libs, no code change is required — `/_healthcheck` and `/_info` go quiet automatically. To silence additional endpoints:

```go
// Most common: add to the defaults. Pass the SAME options to both
// middlewares, or logs and spans diverge.
ignored := []httpserver.Option{httpserver.AppendIgnoredPaths("/_ready")}
r.Use(httpserver.OTLPMiddleware("my-service", debug, ignored...))
r.Use(httpserver.LoggerMiddleware(logger, ignored...))
// Skips: /_healthcheck, /_info, /_ready
```

```go
// Replace the defaults (drops /_healthcheck + /_info unless re-listed):
httpserver.LoggerMiddleware(logger, httpserver.WithIgnoredPaths("/_ready"))

// Log/trace absolutely everything, including health probes:
httpserver.LoggerMiddleware(logger, httpserver.WithIgnoredPaths())
```

## Notes

- Exclusion is **exact-path match** (not prefix/wildcard).
- No server-side HTTP metrics middleware exists in go-libs, so metrics are unaffected. The `Option` type is general enough for a future metrics middleware to share the same ignore set.

## Tests

Table-driven tests for **both** middlewares covering default / append / replace / empty-replace, asserting log output (buffer) and span count (`tracetest.SpanRecorder`).
