### PR TITLE
fix: roll up approved backlog fixes (EN-1172-EN-1184)

### DIFF
--- a/pkg/audit/httpaudit/middleware.go
+++ b/pkg/audit/httpaudit/middleware.go
@@ -34,7 +34,7 @@ type httpOptions struct {
 // serialized audit message well within broker payload limits (e.g. NATS max_payload).
 const DefaultMaxCapturedBodyBytes = 64 * 1024
 
-// WithSensitivePaths sets paths for which the response body should not be captured.
+// WithSensitivePaths sets path prefixes for which request and response bodies should not be captured.
 func WithSensitivePaths(paths ...string) HTTPOption {
 	return func(o *httpOptions) {
 		for _, p := range paths {
@@ -173,7 +173,9 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				err                  error
 			)
 
-			if !isStreamRequest(r) {
+			sensitivePath := ho.isSensitivePath(r.URL.Path)
+
+			if !isStreamRequest(r) && !sensitivePath {
 				body, requestBodyTruncated, err = captureRequestBody(r, ho.maxBodyBytes)
 				if err != nil && !errors.Is(err, io.EOF) {
 					http.Error(w, "failed to read request body", http.StatusInternalServerError)
@@ -181,9 +183,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				}
 			}
 
-			requestHeaders := r.Header.Clone()
-			requestHeaders.Del("Authorization")
-			requestHeaders.Del(audit.HandledHeader)
+			requestHeaders := cloneHeaderWithout(r.Header, "Authorization", "Cookie", audit.HandledHeader)
 
 			r.Header.Set(audit.HandledHeader, handledHeaderValue)
 
@@ -196,16 +196,18 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				body:           buf,
 				statusCode:     http.StatusOK,
 				maxBodyBytes:   ho.maxBodyBytes,
+				captureBody:    !sensitivePath,
 			}
 
 			next.ServeHTTP(rww, r)
 
-			responseBody := rww.body.String()
-			responseBodyTruncated := rww.bodyTruncated
-			if _, sensitive := ho.sensitivePaths[r.URL.Path]; sensitive {
-				responseBody = ""
-				responseBodyTruncated = false
+			responseBody := ""
+			responseBodyTruncated := false
+			if !sensitivePath {
+				responseBody = rww.body.String()
+				responseBodyTruncated = rww.bodyTruncated
 			}
+			responseHeaders := cloneHeaderWithout(rww.Header(), "Set-Cookie")
 
 			actor := audit.ExtractClaims(r, auditOpts)
 
@@ -224,7 +226,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 					},
 					Response: audit.HTTPResponse{
 						StatusCode:    rww.statusCode,
-						Headers:       rww.Header(),
+						Headers:       responseHeaders,
 						Body:          responseBody,
 						BodyTruncated: responseBodyTruncated,
 					},
@@ -234,6 +236,36 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 			eventPublisher.Publish(r.Context(), payload)
 		})
 	}
+}
+
+func cloneHeaderWithout(header http.Header, names ...string) http.Header {
+	clone := header.Clone()
+	for _, name := range names {
+		clone.Del(name)
+	}
+	return clone
+}
+
+func (o *httpOptions) isSensitivePath(requestPath string) bool {
+	for sensitivePath := range o.sensitivePaths {
+		if pathMatchesPrefix(requestPath, sensitivePath) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathMatchesPrefix(requestPath string, sensitivePath string) bool {
+	if sensitivePath == "" {
+		return false
+	}
+
+	sensitivePath = strings.TrimRight(sensitivePath, "/")
+	if sensitivePath == "" {
+		return strings.HasPrefix(requestPath, "/")
+	}
+
+	return requestPath == sensitivePath || strings.HasPrefix(requestPath, sensitivePath+"/")
 }
 
 func isStreamRequest(r *http.Request) bool {
@@ -289,13 +321,14 @@ type responseWriterWrapper struct {
 	body          *bytes.Buffer
 	statusCode    int
 	maxBodyBytes  int
+	captureBody   bool
 	bodyTruncated bool
 }
 
 func (rww *responseWriterWrapper) Write(buf []byte) (int, error) {
 	mediaType, _, _ := mime.ParseMediaType(rww.Header().Get("Content-Type"))
-	if mediaType != "application/octet-stream" {
-		rww.captureBody(buf)
+	if rww.captureBody && mediaType != "application/octet-stream" {
+		rww.captureBodyBytes(buf)
 	}
 	return rww.ResponseWriter.Write(buf)
 }
@@ -303,7 +336,7 @@ func (rww *responseWriterWrapper) Write(buf []byte) (int, error) {
 // captureBody appends bytes to the audited copy up to maxBodyBytes, flagging
 // truncation once the cap is reached. The full buffer is still written to the
 // client by the caller.
-func (rww *responseWriterWrapper) captureBody(buf []byte) {
+func (rww *responseWriterWrapper) captureBodyBytes(buf []byte) {
 	remaining := rww.maxBodyBytes - rww.body.Len()
 	if remaining <= 0 {
 		if len(buf) > 0 {

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -289,6 +289,45 @@ func TestMiddleware_AuthorizationHeaderStripped(t *testing.T) {
 	assert.Empty(t, payload.HTTP.Request.Header.Get("Authorization"))
 }
 
+func TestMiddleware_CookieHeadersStripped(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Response-ID", "response-id")
+			http.SetCookie(w, &http.Cookie{
+				Name:  "session",
+				Value: "response-secret",
+			})
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Cookie", "session=request-secret")
+	req.Header.Set("X-Request-ID", "request-id")
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Contains(t, rr.Header().Get("Set-Cookie"), "response-secret")
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	assert.Empty(t, payload.HTTP.Request.Header.Get("Cookie"))
+	assert.Equal(t, "request-id", payload.HTTP.Request.Header.Get("X-Request-ID"))
+	assert.Empty(t, payload.HTTP.Response.Headers.Get("Set-Cookie"))
+	assert.Equal(t, "response-id", payload.HTTP.Response.Headers.Get("X-Response-ID"))
+	assert.NotContains(t, string(messages[0].Payload), "request-secret")
+	assert.NotContains(t, string(messages[0].Payload), "response-secret")
+}
+
 func TestMiddleware_SensitivePaths(t *testing.T) {
 	t.Parallel()
 
@@ -324,6 +363,52 @@ func TestMiddleware_SensitivePaths(t *testing.T) {
 	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
 
 	assert.Empty(t, payload.HTTP.Response.Body)
+	assert.Empty(t, payload.HTTP.Request.Body)
+	assert.NotContains(t, string(messages[0].Payload), "client_credentials")
+	assert.NotContains(t, string(messages[0].Payload), "access_token")
+}
+
+func TestMiddleware_SensitivePathsMatchPrefixAndPassRequestBodyThrough(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	var receivedBody string
+	handler := Middleware(pub, topic, "test-app", nil,
+		WithEnabled(true),
+		WithSensitivePaths("/api/auth"),
+	)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			receivedBody = string(body)
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"access_token":"response-secret"}`))
+		}),
+	)
+
+	reqBody := `username=alice&password=request-secret`
+	req := httptest.NewRequest("POST", "/api/auth/oauth/token", strings.NewReader(reqBody))
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, reqBody, receivedBody)
+	require.Equal(t, `{"access_token":"response-secret"}`, rr.Body.String())
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	assert.Empty(t, payload.HTTP.Request.Body)
+	assert.Empty(t, payload.HTTP.Response.Body)
+	assert.False(t, payload.HTTP.Request.BodyTruncated)
+	assert.False(t, payload.HTTP.Response.BodyTruncated)
+	assert.NotContains(t, string(messages[0].Payload), "request-secret")
+	assert.NotContains(t, string(messages[0].Payload), "response-secret")
 }
 
 func TestMiddleware_StreamRequestSkipsBodyCapture(t *testing.T) {

--- a/pkg/authn/licence/jwt.go
+++ b/pkg/authn/licence/jwt.go
@@ -93,6 +93,10 @@ func ValidateToken(jwtToken string, expectedIssuer string, opts ...ValidateToken
 }
 
 func (l *Licence) validate() error {
+	if l.validateToken != nil {
+		return l.validateToken()
+	}
+
 	return ValidateToken(
 		l.jwtToken,
 		l.expectedIssuer,

--- a/pkg/authn/licence/licence.go
+++ b/pkg/authn/licence/licence.go
@@ -59,7 +59,14 @@ func (l *Licence) run(licenceError chan error) {
 			l.logger.Info("Licence check started")
 			if err := l.validate(); err != nil {
 				l.logger.Error("Licence check failed", err)
-				licenceError <- err
+				select {
+				case licenceError <- err:
+				default:
+					select {
+					case licenceError <- err:
+					case <-l.appStoped:
+					}
+				}
 				return
 			}
 			l.logger.Info("Licence check passed")

--- a/pkg/authn/licence/licence.go
+++ b/pkg/authn/licence/licence.go
@@ -1,6 +1,7 @@
 package licence
 
 import (
+	"sync"
 	"time"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -12,6 +13,9 @@ type Licence struct {
 	jwtToken            string
 	licenceValidateTick time.Duration
 	appStoped           chan struct{}
+	stopOnce            sync.Once
+	wg                  sync.WaitGroup
+	validateToken       func() error
 
 	// Will be checked in claims (aud claim)
 	serviceName string
@@ -42,6 +46,7 @@ func NewLicence(
 
 func (l *Licence) run(licenceError chan error) {
 	ticker := time.NewTicker(l.licenceValidateTick)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -72,11 +77,20 @@ func (l *Licence) Start(licenceError chan error) error {
 	}
 	l.logger.Info("Licence check passed")
 
-	go l.run(licenceError)
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		l.run(licenceError)
+	}()
 
 	return nil
 }
 
 func (l *Licence) Stop() {
-	close(l.appStoped)
+	l.stopOnce.Do(func() {
+		if l.appStoped != nil {
+			close(l.appStoped)
+		}
+	})
+	l.wg.Wait()
 }

--- a/pkg/authn/licence/licence_test.go
+++ b/pkg/authn/licence/licence_test.go
@@ -297,6 +297,56 @@ func TestLicence_StopWaitsForInFlightValidationBeforeChannelClose(t *testing.T) 
 	require.EqualError(t, err, "licence validation failed")
 }
 
+func TestLicence_StopDoesNotWaitForUnreadValidationError(t *testing.T) {
+	logger := &mockLogger{}
+	licence := NewLicence(
+		logger,
+		"unused-token",
+		10*time.Millisecond,
+		"test-service",
+		"test-cluster",
+		"test-issuer",
+	)
+
+	validationFailed := make(chan struct{})
+	var validateCalls atomic.Int32
+	licence.validateToken = func() error {
+		if validateCalls.Add(1) == 1 {
+			return nil
+		}
+
+		close(validationFailed)
+		return errors.New("licence validation failed")
+	}
+
+	licenceError := make(chan error)
+	require.NoError(t, licence.Start(licenceError))
+
+	select {
+	case <-validationFailed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for licence validation to fail")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		licence.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Stop to return")
+	}
+
+	select {
+	case err := <-licenceError:
+		t.Fatalf("unexpected licence error send after stop: %v", err)
+	default:
+	}
+}
+
 func TestValidateToken(t *testing.T) {
 	privateKey, pubPEM := generateTestRSAKeyPair(t)
 	setEmbeddedKey(t, pubPEM)

--- a/pkg/authn/licence/licence_test.go
+++ b/pkg/authn/licence/licence_test.go
@@ -6,9 +6,11 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -205,6 +207,94 @@ func TestLicence_Start(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		require.Equal(t, "Licence check stopped, app stopped", logger.getMessage())
 	})
+}
+
+func TestLicence_StopIsIdempotent(t *testing.T) {
+	privateKey, pubPEM := generateTestRSAKeyPair(t)
+	setEmbeddedKey(t, pubPEM)
+
+	logger := &mockLogger{}
+	claims := jwt.MapClaims{
+		"sub": "test-cluster",
+		"aud": "test-service",
+		"iss": "test-issuer",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	tokenString := createTokenWithRSAKey(t, claims, privateKey)
+
+	licence := NewLicence(
+		logger,
+		tokenString,
+		time.Minute,
+		"test-service",
+		"test-cluster",
+		"test-issuer",
+	)
+
+	licenceError := make(chan error, 1)
+	require.NoError(t, licence.Start(licenceError))
+	require.NotPanics(t, func() {
+		licence.Stop()
+		licence.Stop()
+	})
+}
+
+func TestLicence_StopWaitsForInFlightValidationBeforeChannelClose(t *testing.T) {
+	logger := &mockLogger{}
+	licence := NewLicence(
+		logger,
+		"unused-token",
+		10*time.Millisecond,
+		"test-service",
+		"test-cluster",
+		"test-issuer",
+	)
+
+	validateStarted := make(chan struct{})
+	releaseValidate := make(chan struct{})
+	var validateCalls atomic.Int32
+	licence.validateToken = func() error {
+		if validateCalls.Add(1) == 1 {
+			return nil
+		}
+
+		close(validateStarted)
+		<-releaseValidate
+		return errors.New("licence validation failed")
+	}
+
+	licenceError := make(chan error, 1)
+	require.NoError(t, licence.Start(licenceError))
+
+	select {
+	case <-validateStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for licence validation to start")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		licence.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned before in-flight validation completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseValidate)
+
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Stop to return")
+	}
+
+	close(licenceError)
+	err := <-licenceError
+	require.EqualError(t, err, "licence validation failed")
 }
 
 func TestValidateToken(t *testing.T) {

--- a/pkg/messaging/queue/listener.go
+++ b/pkg/messaging/queue/listener.go
@@ -32,6 +32,7 @@ type listener struct {
 	wg         *sync.WaitGroup
 	mux        *sync.Mutex
 	hasStarted bool
+	doneClosed bool
 
 	logger logging.Logger
 
@@ -58,7 +59,7 @@ func NewListener(
 		}
 		fn(&opts)
 	}
-	if opts.WorkerCount < 0 {
+	if opts.WorkerCount <= 0 {
 		return nil, fmt.Errorf("workerCount must be bigger than 0")
 	}
 	if callbackFn == nil {
@@ -80,12 +81,17 @@ func NewListener(
 // Start polling for messages
 func (l *listener) Listen(ctx context.Context, ch <-chan *message.Message) {
 	l.mux.Lock()
+	if l.hasStarted || l.doneClosed {
+		l.mux.Unlock()
+		return
+	}
 	l.hasStarted = true
-	l.logger.WithField("listenerName", l.name).WithField("workerCount", l.workerCount).Debugf("queue listener starting listen...")
+	workerCount := l.workerCount
+	l.logger.WithField("listenerName", l.name).WithField("workerCount", workerCount).Debugf("queue listener starting listen...")
 	l.mux.Unlock()
 
 	// fan out and process messages concurrently
-	for i := 0; i < l.workerCount; i++ {
+	for i := 0; i < workerCount; i++ {
 		l.wg.Add(1)
 		go func() {
 			l.startWorker(ctx, ch)
@@ -95,7 +101,9 @@ func (l *listener) Listen(ctx context.Context, ch <-chan *message.Message) {
 	go func() {
 		l.wg.Wait()
 		l.logger.WithField("listenerName", l.name).Infof("queue listener closed")
-		close(l.done)
+		l.mux.Lock()
+		l.closeDoneLocked()
+		l.mux.Unlock()
 	}()
 	return
 }
@@ -106,9 +114,17 @@ func (l *listener) Done() <-chan struct{} {
 	defer l.mux.Unlock()
 	if !l.hasStarted {
 		// listen was never called
-		close(l.done)
+		l.closeDoneLocked()
 	}
 	return l.done
+}
+
+func (l *listener) closeDoneLocked() {
+	if l.doneClosed {
+		return
+	}
+	l.doneClosed = true
+	close(l.done)
 }
 
 func (l *listener) startWorker(ctx context.Context, messages <-chan *message.Message) {

--- a/pkg/messaging/queue/listener_test.go
+++ b/pkg/messaging/queue/listener_test.go
@@ -35,12 +35,95 @@ func TestNewListenerNegativeWorkerCount(t *testing.T) {
 	assert.Nil(t, listener)
 }
 
+func TestNewListenerZeroWorkerCount(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error { return nil }, queue.WithWorkerCount(0))
+	require.NotNil(t, err)
+	assert.ErrorContains(t, err, "workerCount")
+	assert.Nil(t, listener)
+}
+
 func TestNewListenerInvalidCallback(t *testing.T) {
 	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
 	listener, err := queue.NewListener(logger, nil)
 	require.NotNil(t, err)
 	assert.ErrorContains(t, err, "callback")
 	assert.Nil(t, listener)
+}
+
+func TestListenerDoneIsIdempotentBeforeListen(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	done := listener.Done()
+	requireClosed(t, done)
+	assert.Equal(t, done, listener.Done())
+	requireClosed(t, done)
+}
+
+func TestListenerDoneBeforeListenMakesLaterListenNoop(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	called := make(chan struct{}, 1)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		called <- struct{}{}
+		return nil
+	})
+	require.NoError(t, err)
+
+	done := listener.Done()
+	requireClosed(t, done)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *message.Message, 1)
+	ch <- message.NewMessage("test-uuid", []byte("test-payload"))
+	listener.Listen(ctx, ch)
+
+	select {
+	case <-called:
+		t.Fatal("callback was called after listener was already done")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestListenerListenIsIdempotent(t *testing.T) {
+	logger := logging.NewDefaultLogger(os.Stderr, true, true, false)
+	processed := make(chan string, 2)
+	listener, err := queue.NewListener(logger, func(ctx context.Context, meta map[string]string, msg []byte) error {
+		processed <- string(msg)
+		return nil
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstCh := make(chan *message.Message, 1)
+	secondCh := make(chan *message.Message, 1)
+	listener.Listen(ctx, firstCh)
+	listener.Listen(ctx, secondCh)
+
+	secondCh <- message.NewMessage("second-uuid", []byte("second"))
+	select {
+	case got := <-processed:
+		t.Fatalf("second Listen call processed message %q", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	firstCh <- message.NewMessage("first-uuid", []byte("first"))
+	select {
+	case got := <-processed:
+		assert.Equal(t, "first", got)
+	case <-time.After(time.Second):
+		t.Fatal("first Listen call did not process message")
+	}
+
+	cancel()
+	requireClosed(t, listener.Done())
 }
 
 func TestHandleMessageInjectsLoggerAndPropagatesTraceContext(t *testing.T) {
@@ -118,4 +201,14 @@ func TestCallbackDeadlineForcesCancels(t *testing.T) {
 
 	cancel()
 	<-listener.Done()
+}
+
+func requireClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("channel was not closed")
+	}
 }

--- a/pkg/storage/bun/connect/connect_test.go
+++ b/pkg/storage/bun/connect/connect_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -110,5 +111,29 @@ func TestIAMConnectorReturnsBuildAuthTokenError(t *testing.T) {
 	_, err := connector.Connect(context.Background())
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected BuildAuthToken error %q, got %v", expectedErr, err)
+	}
+}
+
+func TestIAMConnectorParseErrorDoesNotLeakDSN(t *testing.T) {
+	dsn := "postgres://db-user:super-secret@%gh/mydb?sslmode=disable"
+	connector := &iamConnector{
+		dsn: dsn,
+		driver: &iamDriver{
+			awsConfig: aws.Config{Region: "us-east-1"},
+		},
+		logger: logging.Testing(),
+	}
+
+	_, err := connector.Connect(context.Background())
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if got := err.Error(); got != "parsing dsn" {
+		t.Fatalf("unexpected parse error: got %q", got)
+	}
+	for _, leaked := range []string{dsn, "super-secret"} {
+		if strings.Contains(err.Error(), leaked) {
+			t.Fatalf("parse error leaked %q in %q", leaked, err.Error())
+		}
 	}
 }

--- a/pkg/storage/bun/connect/connect_test.go
+++ b/pkg/storage/bun/connect/connect_test.go
@@ -1,11 +1,16 @@
 package connect
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
 func TestObfuscateDSN(t *testing.T) {
@@ -84,5 +89,26 @@ func TestBuildPGXConnectorDefaultsToReadWriteTargetSessionAttrs(t *testing.T) {
 	want := reflect.ValueOf(pgconn.ValidateConnectTargetSessionAttrsReadWrite).Pointer()
 	if got != want {
 		t.Fatalf("unexpected ValidateConnect func pointer: got %x, want %x", got, want)
+	}
+}
+
+func TestIAMConnectorReturnsBuildAuthTokenError(t *testing.T) {
+	expectedErr := errors.New("retrieve aws credentials")
+	connector := &iamConnector{
+		dsn: "postgres://db-user@localhost:5432/mydb?sslmode=disable",
+		driver: &iamDriver{
+			awsConfig: aws.Config{
+				Region: "us-east-1",
+				Credentials: aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+					return aws.Credentials{}, expectedErr
+				}),
+			},
+		},
+		logger: logging.Testing(),
+	}
+
+	_, err := connector.Connect(context.Background())
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected BuildAuthToken error %q, got %v", expectedErr, err)
 	}
 }

--- a/pkg/storage/bun/connect/iam.go
+++ b/pkg/storage/bun/connect/iam.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
@@ -49,7 +50,7 @@ type iamConnector struct {
 }
 
 func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
-	url, err := dburl.Parse(i.dsn)
+	databaseURL, err := dburl.Parse(i.dsn)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing dsn: %s", i.dsn)
 	}
@@ -60,36 +61,24 @@ func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
 
 		ret, err := auth.BuildAuthToken(
 			ctx,
-			url.Host,
+			databaseURL.Host,
 			i.driver.awsConfig.Region,
-			url.User.Username(),
+			databaseURL.User.Username(),
 			i.driver.awsConfig.Credentials,
 		)
 		if err != nil {
 			otlp.RecordError(ctx, err)
 		}
 
-		return ret, nil
+		return ret, err
 	}()
 	if err != nil {
 		return nil, errors.Wrap(err, "building aws auth token")
 	}
 
-	dsn := fmt.Sprintf(
-		"host=%s port=%s user=%s password=%s dbname=%s",
-		url.Hostname(),
-		url.Port(),
-		url.User.Username(),
-		authenticationToken,
-		url.Path[1:],
-	)
-	for key, strings := range url.Query() {
-		for _, value := range strings {
-			dsn = fmt.Sprintf("%s %s=%s", dsn, key, value)
-		}
-	}
+	dsn := buildIAMAuthDSN(&databaseURL.URL, authenticationToken)
 
-	i.logger.Debugf("IAM: Connect using dsn '%s'", dsn)
+	i.logger.Debugf("IAM: Connect using dsn '%s'", obfuscateDSN(dsn))
 
 	config, err := pgx.ParseConfig(dsn)
 	if err != nil {
@@ -107,3 +96,9 @@ func (i iamConnector) Driver() driver.Driver {
 }
 
 var _ driver.Connector = &iamConnector{}
+
+func buildIAMAuthDSN(databaseURL *url.URL, authenticationToken string) string {
+	dsnURL := *databaseURL
+	dsnURL.User = url.UserPassword(databaseURL.User.Username(), authenticationToken)
+	return dsnURL.String()
+}

--- a/pkg/storage/bun/connect/iam.go
+++ b/pkg/storage/bun/connect/iam.go
@@ -52,7 +52,7 @@ type iamConnector struct {
 func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	databaseURL, err := dburl.Parse(i.dsn)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing dsn: %s", i.dsn)
+		return nil, errors.New("parsing dsn")
 	}
 
 	authenticationToken, err := func() (string, error) {

--- a/pkg/storage/bun/connect/iam_test.go
+++ b/pkg/storage/bun/connect/iam_test.go
@@ -1,0 +1,62 @@
+package connect
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/xo/dburl"
+)
+
+func TestBuildIAMAuthDSNEscapesAuthTokenAndQueryValues(t *testing.T) {
+	databaseURL, err := dburl.Parse("postgres://iam%20user:old%20password@db.example.com:5432/service%20db?sslmode=require&application_name=worker%20one%2Bblue%26green%3Dtrue&search_path=tenant%3Done%2Cpublic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := "db.example.com:5432/?Action=connect&DBUser=iam user&X-Amz-Credential=AKIA/20260614/eu-west-1/rds-db/aws4_request&X-Amz-Signature=a+b=c=="
+
+	dsn := buildIAMAuthDSN(&databaseURL.URL, token)
+	if strings.Contains(dsn, token) {
+		t.Fatalf("expected auth token to be URL-escaped, got raw token in %q", dsn)
+	}
+
+	config, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("failed to parse generated IAM DSN: %v", err)
+	}
+
+	if config.User != "iam user" {
+		t.Fatalf("unexpected user: got %q", config.User)
+	}
+	if config.Password != token {
+		t.Fatalf("unexpected password token: got %q, want %q", config.Password, token)
+	}
+	if config.Database != "service db" {
+		t.Fatalf("unexpected database: got %q", config.Database)
+	}
+	if got := config.RuntimeParams["application_name"]; got != "worker one+blue&green=true" {
+		t.Fatalf("unexpected application_name: got %q", got)
+	}
+	if got := config.RuntimeParams["search_path"]; got != "tenant=one,public" {
+		t.Fatalf("unexpected search_path: got %q", got)
+	}
+}
+
+func TestBuildIAMAuthDSNObfuscatesAuthToken(t *testing.T) {
+	databaseURL, err := dburl.Parse("postgres://iam-user@db.example.com:5432/app?sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := "db.example.com:5432/?Action=connect&DBUser=iam-user&X-Amz-Credential=AKIA/20260614/eu-west-1/rds-db/aws4_request&X-Amz-Signature=a+b=c=="
+
+	loggedDSN := obfuscateDSN(buildIAMAuthDSN(&databaseURL.URL, token))
+	if loggedDSN != "postgres://iam-user:%2A%2A%2A%2A@db.example.com:5432/app?sslmode=disable" {
+		t.Fatalf("unexpected obfuscated DSN: got %q", loggedDSN)
+	}
+
+	for _, sensitive := range []string{token, "X-Amz-Credential", "X-Amz-Signature", "AKIA"} {
+		if strings.Contains(loggedDSN, sensitive) {
+			t.Fatalf("obfuscated DSN leaked %q in %q", sensitive, loggedDSN)
+		}
+	}
+}

--- a/pkg/transport/api/utils.go
+++ b/pkg/transport/api/utils.go
@@ -21,6 +21,8 @@ const (
 	ErrorInternal       = "INTERNAL"
 	ErrorCodeForbidden  = "FORBIDDEN"
 	ErrorCodeValidation = "VALIDATION"
+
+	internalServerErrorMessage = "internal server error"
 )
 
 func writeJSON(w http.ResponseWriter, statusCode int, v any) {
@@ -34,9 +36,13 @@ func writeJSON(w http.ResponseWriter, statusCode int, v any) {
 }
 
 func WriteErrorResponse(w http.ResponseWriter, statusCode int, errorCode string, err error) {
+	writeErrorResponse(w, statusCode, errorCode, err.Error())
+}
+
+func writeErrorResponse(w http.ResponseWriter, statusCode int, errorCode string, errorMessage string) {
 	writeJSON(w, statusCode, ErrorResponse{
 		ErrorCode:    errorCode,
-		ErrorMessage: err.Error(),
+		ErrorMessage: errorMessage,
 	})
 }
 
@@ -66,7 +72,7 @@ func BadRequestWithDetails(w http.ResponseWriter, code string, err error, detail
 
 func InternalServerError(w http.ResponseWriter, r *http.Request, err error) {
 	logging.FromContext(r.Context()).Error(err)
-	WriteErrorResponse(w, http.StatusInternalServerError, ErrorInternal, err)
+	writeErrorResponse(w, http.StatusInternalServerError, ErrorInternal, internalServerErrorMessage)
 }
 
 func Accepted(w http.ResponseWriter, v any) {

--- a/pkg/transport/api/utils_test.go
+++ b/pkg/transport/api/utils_test.go
@@ -208,7 +208,7 @@ func TestInternalServerError(t *testing.T) {
 
 	// Create a response recorder
 	rr := httptest.NewRecorder()
-	testErr := errors.New("internal server error")
+	testErr := errors.New(`pq: duplicate key value violates unique constraint "accounts_pkey" at /srv/app/internal/storage/accounts.go:42`)
 
 	// Call the function
 	api.InternalServerError(rr, req, testErr)
@@ -220,15 +220,19 @@ func TestInternalServerError(t *testing.T) {
 	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 
 	// Check the response body
+	rawBody := rr.Body.String()
 	var response api.ErrorResponse
-	decodeErr := json.NewDecoder(rr.Body).Decode(&response)
+	decodeErr := json.NewDecoder(bytes.NewBufferString(rawBody)).Decode(&response)
 	require.NoError(t, decodeErr)
 	require.Equal(t, api.ErrorInternal, response.ErrorCode)
-	require.Equal(t, testErr.Error(), response.ErrorMessage)
+	require.Equal(t, "internal server error", response.ErrorMessage)
+	require.NotContains(t, rawBody, "accounts_pkey")
+	require.NotContains(t, rawBody, "/srv/app/internal/storage/accounts.go")
 
 	// Verify that the error was logged
 	logOutput := buf.String()
-	require.Contains(t, logOutput, testErr.Error())
+	require.Contains(t, logOutput, "accounts_pkey")
+	require.Contains(t, logOutput, "/srv/app/internal/storage/accounts.go")
 }
 
 func TestAccepted(t *testing.T) {


### PR DESCRIPTION
Rollup for the first simplified block, replacing the intermediate PRs #626 through #633.

Included here:
- EN-1172 audit credential/body redaction, rebased on top of the already-merged audit body cap from #647
- EN-1177 IAM auth token error propagation
- EN-1179 IAM DSN safety and log redaction
- EN-1181 generic internal error responses, including the review fix from #630
- EN-1182 licence shutdown safety
- EN-1183 zero queue worker rejection
- EN-1184 idempotent queue listener close, including the review fix from #633

Note: EN-1174/#627 is intentionally not reapplied here because #647 already merged the body cap behavior on main with the newer configurable cap and truncation flags.

Local verification:
- go test ./pkg/audit/httpaudit ./pkg/storage/bun/connect ./pkg/transport/api ./pkg/authn/licence
- go test -c ./pkg/messaging/queue -o /tmp/go-libs-rollup-en1172-1184/queue.test

`go test ./pkg/messaging/queue` still requires Docker/localstack at TestMain startup; local Docker is not available in this environment.