### PR TITLE
fix(fx): scope authn and HTTP publisher *http.Client to their module

### DIFF
--- a/pkg/fx/authnfx/jwt.go
+++ b/pkg/fx/authnfx/jwt.go
@@ -30,7 +30,7 @@ func jwtModuleOptions(nameAnnotation string) []fx.Option {
 	options := make([]fx.Option, 0)
 	if nameAnnotation == "" {
 		options = append(options,
-			fx.Supply(http.DefaultClient),
+			fx.Supply(http.DefaultClient, fx.Private),
 			fx.Provide(jwt.NewKeySets),
 			fx.Provide(jwt.NewAuthenticatorFromConfig),
 		)

--- a/pkg/fx/authnfx/jwt_test.go
+++ b/pkg/fx/authnfx/jwt_test.go
@@ -1,0 +1,29 @@
+package authnfx_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"github.com/formancehq/go-libs/v5/pkg/authn/jwt"
+	"github.com/formancehq/go-libs/v5/pkg/fx/authnfx"
+	"github.com/formancehq/go-libs/v5/pkg/fx/messagingfx"
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+// Regression test for TS-456: JWTModule and messagingfx.HTTPModule both
+// supplied an unnamed *http.Client which fx rejected as a duplicate provider.
+func TestJWTAndHTTPPublisherCoexist(t *testing.T) {
+	t.Parallel()
+
+	app := fxtest.New(t,
+		fx.NopLogger,
+		fx.Supply(fx.Annotate(logging.Testing(), fx.As(new(logging.Logger)))),
+		authnfx.JWTModule(jwt.Config{}),
+		messagingfx.Module(map[string]string{}),
+		messagingfx.HTTPModule(),
+	)
+	require.NoError(t, app.Err())
+}

--- a/pkg/fx/messagingfx/publish.go
+++ b/pkg/fx/messagingfx/publish.go
@@ -217,11 +217,11 @@ func NatsModule(url, group string, autoProvision bool, natsOptions ...nats.Optio
 }
 
 func HTTPModule() fx.Option {
-	return fx.Options(
+	return fx.Module("publish-http",
 		fx.Provide(publish.NewHTTPPublisher),
 		fx.Provide(publish.NewHTTPPublisherConfig),
 		fx.Provide(publish.DefaultHTTPMarshalMessageFunc),
-		fx.Supply(http.DefaultClient),
+		fx.Supply(http.DefaultClient, fx.Private),
 		fx.Provide(func(p *wHttp.Publisher) message.Publisher {
 			return p
 		}),


### PR DESCRIPTION
## Summary

- `authnfx.JWTModule` and `messagingfx.HTTPModule` both registered an unnamed `*http.Client` provider at the parent fx scope. When both modules were used in the same app, uber/fx rejected the duplicate provider and the app failed to start with `cannot provide *http.Client from [0]: already provided by "reflect".makeFuncStub`.
- Mark both `*http.Client` providers as `fx.Private` so each module keeps its own client. Wrapped `HTTPModule` in `fx.Module("publish-http", …)` so `fx.Private` has a scope to attach to.
- Added a regression test in `pkg/fx/authnfx/jwt_test.go` that builds an fx app combining both modules and asserts there is no provider conflict.

## Context

Reported on [TS-456](https://formance-team.atlassian.net/browse/TS-456). Reproduces on ledger `>= v2.3.3` as soon as `PUBLISHER_HTTP_ENABLED=true` because the ledger's `serve` command always loads `authnfx.JWTModuleFromFlags` regardless of whether auth is enabled.

Minimal repro from the ticket (crashes before any DB dial):

```sh
docker run --rm -e DEBUG=true \
    -e POSTGRES_URI='postgresql://x:x@127.0.0.1/x?sslmode=disable' \
    -e PUBLISHER_HTTP_ENABLED=true \
    -e PUBLISHER_TOPIC_MAPPING='*:http://example:8080' \
    ghcr.io/formancehq/ledger:v2.4.10 serve
```

## Test plan

- [x] New `TestJWTAndHTTPPublisherCoexist` fails on `main` with the exact error from the ticket and passes with this fix.
- [x] `go test ./pkg/fx/authnfx/... ./pkg/fx/messagingfx/...` green.
- [ ] Bump `go-libs` in ledger once this is released and confirm the docker repro starts normally.

[TS-456]: https://formance-team.atlassian.net/browse/TS-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ