### PR TITLE
fix(fx): scope auth and HTTP publisher *http.Client to their module (v3.6 backport)

### DIFF
--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -3,10 +3,8 @@ description: Setup Env for Linux x64
 runs:
   using: composite
   steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: namespacelabs/nscloud-setup-buildx-action@v0
     - name: Install Nix
       uses: cachix/install-nix-action@v31
     ## Disabling cache for now, as it's slowing down the build. Downloading nix

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,9 @@ concurrency:
 
 jobs:
   Ci:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: 'namespacelabs/nscloud-checkout-action@v9'
         with:
           fetch-depth: 0
       - name: Setup Env

--- a/auth/module.go
+++ b/auth/module.go
@@ -51,7 +51,7 @@ func Module(cfg ModuleConfig) fx.Option {
 
 	if cfg.Enabled {
 		options = append(options,
-			fx.Supply(http.DefaultClient),
+			fx.Supply(http.DefaultClient, fx.Private),
 			fx.Provide(func(httpClient *http.Client) (Authenticator, error) {
 				retryableHttpClient := retryablehttp.NewClient()
 				retryableHttpClient.RetryMax = cfg.ReadKeySetMaxRetries

--- a/auth/module_http_publisher_test.go
+++ b/auth/module_http_publisher_test.go
@@ -1,0 +1,78 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"github.com/formancehq/go-libs/v3/auth"
+	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v3/oidc"
+	"github.com/formancehq/go-libs/v3/publish"
+)
+
+// Regression test for TS-456 (ledger):
+// auth.Module (with cfg.Enabled=true) and publish's HTTP publisher both supply
+// an unnamed *http.Client at the parent fx scope. uber/fx rejects the duplicate
+// provider, so a ledger started with --auth-enabled and --publisher-http-enabled
+// fails to boot.
+func TestAuthAndHTTPPublisherCoexist(t *testing.T) {
+	t.Parallel()
+
+	oidcServer := newFakeOIDCServerForTest(t)
+
+	cmd := &cobra.Command{}
+	publish.AddFlags("test", cmd.Flags())
+	require.NoError(t, cmd.Flags().Set(publish.PublisherHttpEnabledFlag, "true"))
+	require.NoError(t, cmd.Flags().Set(publish.PublisherTopicMappingFlag, "*:"+oidcServer.URL))
+
+	var authenticator auth.Authenticator
+
+	app := fxtest.New(t,
+		fx.NopLogger,
+		fx.Provide(func() context.Context { return context.Background() }),
+		fx.Provide(func() logging.Logger { return logging.Testing() }),
+		auth.Module(auth.ModuleConfig{
+			Enabled: true,
+			Issuers: []string{oidcServer.URL},
+			Service: "test-service",
+		}),
+		publish.FXModuleFromFlags(cmd, false),
+		fx.Populate(&authenticator),
+	)
+	require.NoError(t, app.Err())
+	app.RequireStart()
+	t.Cleanup(func() { app.RequireStop() })
+
+	require.NotNil(t, authenticator)
+}
+
+func newFakeOIDCServerForTest(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		_ = json.NewEncoder(w).Encode(oidc.DiscoveryConfiguration{
+			Issuer:  scheme + "://" + r.Host,
+			JwksURI: scheme + "://" + r.Host + "/.well-known/jwks.json",
+		})
+	})
+	mux.HandleFunc("/.well-known/jwks.json", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/publish/http.go
+++ b/publish/http.go
@@ -32,11 +32,11 @@ func defaultHTTPMarshalMessageFunc() wHttp.MarshalMessageFunc {
 }
 
 func httpModule() fx.Option {
-	return fx.Options(
+	return fx.Module("publish-http",
 		fx.Provide(newHTTPPublisher),
 		fx.Provide(newHTTPPublisherConfig),
 		fx.Provide(defaultHTTPMarshalMessageFunc),
-		fx.Supply(http.DefaultClient),
+		fx.Supply(http.DefaultClient, fx.Private),
 		fx.Provide(func(p *wHttp.Publisher) message.Publisher {
 			return p
 		}),


### PR DESCRIPTION
## Summary

Backport of #651 to `release/v3.6`.

- `auth.Module` (when `cfg.Enabled=true`) and `publish.httpModule` both registered an unnamed `*http.Client` provider at the parent fx scope. When both were used in the same app, uber/fx rejected the duplicate provider and the app failed to start with `cannot provide *http.Client from [0]: already provided by "reflect".makeFuncStub`.
- Mark both `*http.Client` providers as `fx.Private` so each module keeps its own client. Wrapped `publish.httpModule` in `fx.Module("publish-http", …)` so `fx.Private` has a scope to attach to.
- Added a regression test in `auth/module_http_publisher_test.go` that builds an fx app combining both modules and asserts there is no provider conflict.

## Context

Reported on [TS-456](https://formance-team.atlassian.net/browse/TS-456). Affects ledger `v2.3.x` (which depends on `go-libs/v3`) and `v2.4.x` (depends on `v5`, fixed in #651).

This backport unblocks the ledger v2.3 hotfix. Once merged, please tag `v3.6.3` so ledger `release/v2.3` can pin to a released version (currently the hotfix uses a `replace` directive against this branch).

## Test plan

- [x] New `TestAuthAndHTTPPublisherCoexist` fails on `release/v3.6` head with the exact error from the ticket and passes with this fix.
- [x] `go test ./auth/... ./publish/...` green.
- [ ] Bump go-libs in ledger `release/v2.3` to `v3.6.3` once tagged.

[TS-456]: https://formance-team.atlassian.net/browse/TS-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ