### PR TITLE
fix: roll up lifecycle and metrics backlog fixes (EN-1185-EN-1190)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	golang.org/x/oauth2 v0.35.0
 	golang.org/x/text v0.37.0
 	google.golang.org/grpc v1.80.0
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -226,6 +227,5 @@ require (
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/fx/observefx/metrics.go
+++ b/pkg/fx/observefx/metrics.go
@@ -62,35 +62,38 @@ func MetricsModule(cfg metrics.ModuleConfig) fx.Option {
 
 			return ret
 		}, fx.ParamTags(metricsProviderOptionKey))),
-		fx.Invoke(func(lc fx.Lifecycle, metricProvider *sdkmetric.MeterProvider, options ...runtime.Option) {
-			otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-				b3.New(), propagation.TraceContext{}))
-			lc.Append(fx.Hook{
-				OnStart: func(ctx context.Context) error {
-					if cfg.RuntimeMetrics {
-						if err := runtime.Start(options...); err != nil {
-							return err
+		fx.Invoke(fx.Annotate(
+			func(lc fx.Lifecycle, metricProvider *sdkmetric.MeterProvider, options ...runtime.Option) {
+				otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+					b3.New(), propagation.TraceContext{}))
+				lc.Append(fx.Hook{
+					OnStart: func(ctx context.Context) error {
+						if cfg.RuntimeMetrics {
+							if err := runtime.Start(options...); err != nil {
+								return err
+							}
+							if err := host.Start(); err != nil {
+								return err
+							}
 						}
-						if err := host.Start(); err != nil {
-							return err
+						return nil
+					},
+					OnStop: func(ctx context.Context) error {
+						logging.FromContext(ctx).Infof("Flush metrics")
+						if err := metricProvider.ForceFlush(ctx); err != nil {
+							logging.FromContext(ctx).Errorf("unable to flush metrics: %s", err)
 						}
-					}
-					return nil
-				},
-				OnStop: func(ctx context.Context) error {
-					logging.FromContext(ctx).Infof("Flush metrics")
-					if err := metricProvider.ForceFlush(ctx); err != nil {
-						logging.FromContext(ctx).Errorf("unable to flush metrics: %s", err)
-					}
-					logging.FromContext(ctx).Infof("Shutting down metrics provider")
-					if err := metricProvider.Shutdown(ctx); err != nil {
-						logging.FromContext(ctx).Errorf("unable to shutdown metrics provider: %s", err)
-					}
-					logging.FromContext(ctx).Infof("Metrics provider stopped")
-					return nil
-				},
-			})
-		}),
+						logging.FromContext(ctx).Infof("Shutting down metrics provider")
+						if err := metricProvider.Shutdown(ctx); err != nil {
+							logging.FromContext(ctx).Errorf("unable to shutdown metrics provider: %s", err)
+						}
+						logging.FromContext(ctx).Infof("Metrics provider stopped")
+						return nil
+					},
+				})
+			},
+			fx.ParamTags(``, ``, metricsRuntimeOptionKey),
+		)),
 		ProvideMetricsProviderOption(sdkmetric.WithResource),
 		ProvideMetricsProviderOption(sdkmetric.WithReader),
 		fx.Provide(
@@ -99,10 +102,12 @@ func MetricsModule(cfg metrics.ModuleConfig) fx.Option {
 		ProvideOTLPMetricsPeriodicReaderOption(func() sdkmetric.PeriodicReaderOption {
 			return sdkmetric.WithInterval(cfg.PushInterval)
 		}),
-		ProvideRuntimeMetricsOption(func() runtime.Option {
-			return runtime.WithMinimumReadMemStatsInterval(cfg.MinimumReadMemStatsInterval)
-		}),
 	)
+	if cfg.MinimumReadMemStatsInterval > 0 {
+		options = append(options, ProvideRuntimeMetricsOption(func() runtime.Option {
+			return runtime.WithMinimumReadMemStatsInterval(cfg.MinimumReadMemStatsInterval)
+		}))
+	}
 
 	switch cfg.Exporter {
 	case metrics.StdoutExporter:

--- a/pkg/fx/observefx/metrics_test.go
+++ b/pkg/fx/observefx/metrics_test.go
@@ -1,0 +1,60 @@
+package observefx_test
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/contrib/instrumentation/runtime"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
+	"github.com/formancehq/go-libs/v5/pkg/fx/observefx"
+	"github.com/formancehq/go-libs/v5/pkg/observe"
+	"github.com/formancehq/go-libs/v5/pkg/observe/metrics"
+)
+
+func TestMetricsModuleProvidesRuntimeOptionsToRuntimeMetricsInvoke(t *testing.T) {
+	var runtimeOptionProvided atomic.Bool
+
+	app := fxtest.New(t,
+		observefx.ResourceModule(observe.Config{
+			ServiceName: "metrics-test",
+		}),
+		observefx.MetricsModule(metrics.ModuleConfig{
+			MinimumReadMemStatsInterval: time.Second,
+		}),
+		observefx.ProvideRuntimeMetricsOption(func() runtime.Option {
+			runtimeOptionProvided.Store(true)
+			return runtime.WithMinimumReadMemStatsInterval(100 * time.Millisecond)
+		}),
+		fx.NopLogger,
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	require.True(t, runtimeOptionProvided.Load())
+}
+
+func TestMetricsModuleDoesNotProvideZeroRuntimeMetricsInterval(t *testing.T) {
+	var runtimeOptionsCount int
+
+	app := fxtest.New(t,
+		observefx.ResourceModule(observe.Config{
+			ServiceName: "metrics-test",
+		}),
+		observefx.MetricsModule(metrics.ModuleConfig{}),
+		fx.Invoke(fx.Annotate(
+			func(options ...runtime.Option) {
+				runtimeOptionsCount = len(options)
+			},
+			fx.ParamTags(`group:"_metricsRuntimeOption"`),
+		)),
+		fx.NopLogger,
+	)
+	app.RequireStart()
+	defer app.RequireStop()
+
+	require.Zero(t, runtimeOptionsCount)
+}

--- a/pkg/fx/workflowfx/temporal.go
+++ b/pkg/fx/workflowfx/temporal.go
@@ -2,6 +2,7 @@ package workflowfx
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel/metric"
@@ -66,25 +67,34 @@ func TemporalWorkerModule(ctx context.Context, taskQueue string, options worker.
 			}, fx.ParamTags(``, ``, `group:"workflows"`, `group:"activities"`)),
 		),
 		fx.Invoke(func(lc fx.Lifecycle, w worker.Worker) {
-			willStop := false
-			lc.Append(fx.Hook{
-				OnStart: func(ctx context.Context) error {
-					go func() {
-						err := w.Run(worker.InterruptCh())
-						if err != nil {
-							if !willStop {
-								panic(err)
-							}
-						}
-					}()
-					return nil
-				},
-				OnStop: func(ctx context.Context) error {
-					willStop = true
-					w.Stop()
-					return nil
-				},
-			})
+			registerTemporalWorkerLifecycle(lc, w)
 		}),
 	)
+}
+
+type temporalWorkerRunner interface {
+	Run(interruptCh <-chan interface{}) error
+	Stop()
+}
+
+func registerTemporalWorkerLifecycle(lc fx.Lifecycle, w temporalWorkerRunner) {
+	var willStop atomic.Bool
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			go func() {
+				err := w.Run(worker.InterruptCh())
+				if err != nil {
+					if !willStop.Load() {
+						panic(err)
+					}
+				}
+			}()
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			willStop.Store(true)
+			w.Stop()
+			return nil
+		},
+	})
 }

--- a/pkg/fx/workflowfx/temporal_test.go
+++ b/pkg/fx/workflowfx/temporal_test.go
@@ -1,0 +1,68 @@
+package workflowfx
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/fx"
+)
+
+func TestRegisterTemporalWorkerLifecycleIsRaceSafeWhenRunReturnsDuringStop(t *testing.T) {
+	lc := &lifecycleRecorder{}
+	w := &shutdownErrorWorker{
+		runErr:      errors.New("worker stopped"),
+		runReturned: make(chan struct{}),
+	}
+
+	registerTemporalWorkerLifecycle(lc, w)
+
+	if len(lc.hooks) != 1 {
+		t.Fatalf("expected 1 lifecycle hook, got %d", len(lc.hooks))
+	}
+
+	hook := lc.hooks[0]
+	if hook.OnStart == nil {
+		t.Fatal("expected OnStart hook")
+	}
+	if hook.OnStop == nil {
+		t.Fatal("expected OnStop hook")
+	}
+
+	if err := hook.OnStart(context.Background()); err != nil {
+		t.Fatalf("OnStart returned error: %v", err)
+	}
+	if err := hook.OnStop(context.Background()); err != nil {
+		t.Fatalf("OnStop returned error: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+}
+
+type lifecycleRecorder struct {
+	hooks []fx.Hook
+}
+
+func (lc *lifecycleRecorder) Append(hook fx.Hook) {
+	lc.hooks = append(lc.hooks, hook)
+}
+
+type shutdownErrorWorker struct {
+	runErr      error
+	runReturned chan struct{}
+}
+
+func (w *shutdownErrorWorker) Run(<-chan interface{}) error {
+	time.Sleep(10 * time.Millisecond)
+	close(w.runReturned)
+	return w.runErr
+}
+
+func (w *shutdownErrorWorker) Stop() {
+	select {
+	case <-w.runReturned:
+	case <-time.After(time.Second):
+		panic("worker Run did not return")
+	}
+}

--- a/pkg/messaging/publish/circuit/circuit_breaker.go
+++ b/pkg/messaging/publish/circuit/circuit_breaker.go
@@ -37,13 +37,23 @@ type CircuitBreaker struct {
 	stateMu sync.RWMutex
 	state   State
 
+	stopOnce sync.Once
+	doneOnce sync.Once
+
+	publisherCloseOnce sync.Once
+	publisherCloseErr  error
+
+	loopMu      sync.Mutex
+	loopCancel  context.CancelFunc
+	loopStarted bool
+
 	// openInterval is the time interval for the "open" state, before switching
 	// to the "half-open" state.
 	openInterval      time.Duration
 	openIntervalTimer *time.Timer
 
 	sendChan    chan *internalMessage
-	stopChannel chan chan struct{}
+	stopChannel chan struct{}
 	stopped     chan struct{}
 }
 
@@ -61,7 +71,7 @@ func NewCircuitBreaker(
 	openIntervalDuration time.Duration,
 ) *CircuitBreaker {
 	return &CircuitBreaker{
-		stopChannel: make(chan chan struct{}),
+		stopChannel: make(chan struct{}),
 		stopped:     make(chan struct{}),
 		logger:      logger,
 		publisher:   publisher,
@@ -109,10 +119,31 @@ func (cb *CircuitBreaker) CloseState() {
 }
 
 func (cb *CircuitBreaker) Loop(ctx context.Context) {
-	defer close(cb.stopped)
+	loopCtx, cancel := context.WithCancel(ctx)
+	if !cb.startLoop(cancel) {
+		cancel()
+		return
+	}
+	defer func() {
+		cb.clearLoopCancel()
+		cancel()
+		cb.markStopped()
+	}()
+
+	select {
+	case <-loopCtx.Done():
+		return
+	case <-cb.stopChannel:
+		return
+	default:
+	}
+
 	// Start in the half open state to fetch the messages from the database
 	cb.HalfOpenState()
-	if err := cb.catchUpDatabase(ctx); err != nil {
+	if err := cb.catchUpDatabase(loopCtx, ctx); err != nil {
+		if loopCtx.Err() != nil {
+			return
+		}
 		cb.OpenState()
 		// Don't switch to closed state if there was an error
 	} else {
@@ -122,9 +153,10 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 	for {
 		select {
-		case ch := <-cb.stopChannel:
-			close(ch)
-			// context cancelled
+		case <-loopCtx.Done():
+			return
+
+		case <-cb.stopChannel:
 			return
 
 		case <-cb.openIntervalTimer.C:
@@ -132,7 +164,10 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 			cb.HalfOpenState()
 
-			if err := cb.catchUpDatabase(ctx); err != nil {
+			if err := cb.catchUpDatabase(loopCtx, ctx); err != nil {
+				if loopCtx.Err() != nil {
+					return
+				}
 				cb.OpenState()
 				continue
 			}
@@ -146,7 +181,7 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 				return
 			}
 
-			switch cb.state {
+			switch cb.GetState() {
 			case StateClose:
 				// We are in the closed state, send the message to the publisher
 
@@ -160,12 +195,7 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 					// write the message in the database
 					err = cb.store.Insert(ctx, msg.topic, msg.msg.Payload, msg.msg.Metadata)
 					if err != nil {
-						select {
-						case msg.errChan <- err:
-						case ch := <-cb.stopChannel:
-							close(ch)
-							return
-						}
+						msg.errChan <- err
 						continue
 					}
 				}
@@ -175,30 +205,24 @@ func (cb *CircuitBreaker) Loop(ctx context.Context) {
 
 				err := cb.store.Insert(ctx, msg.topic, msg.msg.Payload, msg.msg.Metadata)
 				if err != nil {
-					select {
-					case msg.errChan <- err:
-					case ch := <-cb.stopChannel:
-						close(ch)
-						return
-					}
+					msg.errChan <- err
 					continue
 				}
 			}
 
-			select {
-			case msg.errChan <- nil:
-			case ch := <-cb.stopChannel:
-				close(ch)
-				return
-			}
+			msg.errChan <- nil
 		}
 	}
 }
 
-func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
+func (cb *CircuitBreaker) catchUpDatabase(loopCtx context.Context, storeCtx context.Context) error {
 	for {
+		if err := loopCtx.Err(); err != nil {
+			return err
+		}
+
 		// fetch the oldest messages from the database
-		messages, err := cb.store.List(ctx)
+		messages, err := cb.store.List(loopCtx)
 		if err != nil {
 			// error fetching messages, let's switch back to the open state
 			return err
@@ -210,11 +234,21 @@ func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 
 		messagesToDelete := make([]uint64, 0)
 		var publishError error
+		var stopError error
 		for _, msg := range messages {
+			if err := loopCtx.Err(); err != nil {
+				stopError = err
+				break
+			}
+
+			if err := storeCtx.Err(); err != nil {
+				return err
+			}
+
 			// We need to publish the messages one by one in order to know
 			// which one failed.
 
-			message, err := newMessage(ctx, msg.Data, msg.Metadata)
+			message, err := newMessage(storeCtx, msg.Data, msg.Metadata)
 			if err != nil {
 				publishError = err
 				break
@@ -229,21 +263,32 @@ func (cb *CircuitBreaker) catchUpDatabase(ctx context.Context) error {
 			messagesToDelete = append(messagesToDelete, msg.ID)
 		}
 
-		err = cb.store.Delete(ctx, messagesToDelete)
-		if err != nil {
-			// error deleting messages, let's switch back to the open state
-			return err
+		if len(messagesToDelete) > 0 {
+			err = cb.store.Delete(storeCtx, messagesToDelete)
+			if err != nil {
+				// error deleting messages, let's switch back to the open state
+				return err
+			}
 		}
 
 		if publishError != nil {
 			// we failed to publish all the messages
 			return publishError
 		}
+		if stopError != nil {
+			return stopError
+		}
 	}
 }
 
 func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) error {
 	for _, msg := range messages {
+		select {
+		case <-cb.stopChannel:
+			return errors.New("circuit breaker closed")
+		default:
+		}
+
 		errChan := make(chan error, 1)
 
 		internalMessage := &internalMessage{
@@ -254,29 +299,92 @@ func (cb *CircuitBreaker) Publish(topic string, messages ...*message.Message) er
 
 		select {
 		case cb.sendChan <- internalMessage:
+		case <-cb.stopChannel:
+			return errors.New("circuit breaker closed")
 		case <-cb.stopped:
 			return errors.New("circuit breaker closed")
 		}
 
-		select {
-		case err := <-errChan:
-			if err != nil {
-				return err
-			}
-		case <-cb.stopped:
-			return errors.New("circuit breaker closed")
+		if err := waitAcceptedMessageResult(errChan, cb.stopped); err != nil {
+			return err
 		}
 	}
 
 	return nil
 }
 
-func (cb *CircuitBreaker) Close() error {
-	ch := make(chan struct{})
-	cb.stopChannel <- ch
-	<-ch
+func waitAcceptedMessageResult(errChan <-chan error, stopped <-chan struct{}) error {
+	select {
+	case err := <-errChan:
+		return err
+	case <-stopped:
+		select {
+		case err := <-errChan:
+			return err
+		default:
+			return errors.New("circuit breaker closed")
+		}
+	}
+}
 
-	return cb.publisher.Close()
+func (cb *CircuitBreaker) Close() error {
+	cb.stopOnce.Do(func() {
+		close(cb.stopChannel)
+		cb.cancelLoop()
+	})
+
+	if cb.hasLoopStarted() {
+		<-cb.stopped
+	} else {
+		cb.markStopped()
+	}
+
+	cb.publisherCloseOnce.Do(func() {
+		cb.publisherCloseErr = cb.publisher.Close()
+	})
+
+	return cb.publisherCloseErr
+}
+
+func (cb *CircuitBreaker) startLoop(cancel context.CancelFunc) bool {
+	cb.loopMu.Lock()
+	defer cb.loopMu.Unlock()
+
+	if cb.loopStarted {
+		return false
+	}
+
+	cb.loopStarted = true
+	cb.loopCancel = cancel
+	return true
+}
+
+func (cb *CircuitBreaker) clearLoopCancel() {
+	cb.loopMu.Lock()
+	cb.loopCancel = nil
+	cb.loopMu.Unlock()
+}
+
+func (cb *CircuitBreaker) cancelLoop() {
+	cb.loopMu.Lock()
+	cancel := cb.loopCancel
+	cb.loopMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (cb *CircuitBreaker) hasLoopStarted() bool {
+	cb.loopMu.Lock()
+	defer cb.loopMu.Unlock()
+	return cb.loopStarted
+}
+
+func (cb *CircuitBreaker) markStopped() {
+	cb.doneOnce.Do(func() {
+		close(cb.stopped)
+	})
 }
 
 const (
@@ -297,7 +405,7 @@ func newMessage(ctx context.Context, data []byte, metadata map[string]string) (*
 		if err != nil {
 			return nil, err
 		}
-		otel.GetTextMapPropagator().Inject(ctx, carrier)
+		ctx = otel.GetTextMapPropagator().Extract(ctx, carrier)
 	}
 
 	msg.SetContext(ctx)

--- a/pkg/messaging/publish/circuit/circuit_breaker_test.go
+++ b/pkg/messaging/publish/circuit/circuit_breaker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,7 +12,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish/circuit/storage"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
@@ -429,4 +434,521 @@ func TestCircuitBreaker(t *testing.T) {
 			assert.Equal(c, StateOpen, circuitBreaker.GetState())
 		}, 2*time.Second, 100*time.Millisecond)
 	})
+}
+
+func TestCircuitBreakerCloseWithoutLoopIsIdempotent(t *testing.T) {
+	messages := make(chan *testMessages, 10)
+	publisher := newMockPublisher(messages)
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		publisher,
+		newMockStore(),
+		5*time.Second,
+	)
+
+	requireCloseWithin(t, circuitBreaker)
+	requireCloseWithin(t, circuitBreaker)
+	require.Equal(t, 1, publisher.CloseCount())
+}
+
+func TestCircuitBreakerCloseCancelsCatchUp(t *testing.T) {
+	store := &blockingListStore{
+		listStarted: make(chan struct{}, 1),
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(make(chan *testMessages, 10)),
+		store,
+		5*time.Second,
+	)
+
+	go circuitBreaker.Loop(context.Background())
+
+	select {
+	case <-store.listStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected catchup to start")
+	}
+
+	requireCloseWithin(t, circuitBreaker)
+}
+
+func TestCircuitBreakerCloseDrainsInFlightInsert(t *testing.T) {
+	store := &blockingInsertStore{
+		insertStarted:     make(chan struct{}, 1),
+		releaseInsert:     make(chan struct{}),
+		insertCtxCanceled: make(chan struct{}, 1),
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(make(chan *testMessages, 10)).WithPublishError(errors.New("publish failed")),
+		store,
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+
+	publishDone := make(chan error, 1)
+	go func() {
+		publishDone <- circuitBreaker.Publish("test", message.NewMessage("1", []byte("payload")))
+	}()
+
+	select {
+	case <-store.insertStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected insert to start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before insert completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	select {
+	case <-store.insertCtxCanceled:
+		t.Fatal("insert context was canceled before insert completed")
+	default:
+	}
+
+	close(store.releaseInsert)
+
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected Close to return after insert completed")
+	}
+	select {
+	case <-publishDone:
+	case <-time.After(time.Second):
+		t.Fatal("expected publish to return after close")
+	}
+	require.True(t, store.inserted)
+}
+
+func TestCircuitBreakerPublishWaitsForAcceptedMessageDuringClose(t *testing.T) {
+	publisher := &blockingPublishPublisher{
+		publishStarted: make(chan struct{}, 1),
+		releasePublish: make(chan struct{}),
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		publisher,
+		newMockStore(),
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+
+	publishDone := make(chan error, 1)
+	go func() {
+		publishDone <- circuitBreaker.Publish("test", message.NewMessage("1", []byte("payload")))
+	}()
+
+	select {
+	case <-publisher.publishStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected publish to start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-publishDone:
+		t.Fatalf("Publish returned before accepted message completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(publisher.releasePublish)
+
+	select {
+	case err := <-publishDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected Publish to return after accepted message completed")
+	}
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected Close to return after accepted message completed")
+	}
+}
+
+func TestWaitAcceptedMessageResultPrefersQueuedResultAfterStop(t *testing.T) {
+	errChan := make(chan error, 1)
+	errChan <- nil
+	stopped := make(chan struct{})
+	close(stopped)
+
+	require.NoError(t, waitAcceptedMessageResult(errChan, stopped))
+}
+
+func TestCircuitBreakerCloseDrainsInFlightReplayDelete(t *testing.T) {
+	messages := make(chan *testMessages, 10)
+	store := &blockingDeleteStore{
+		deleteStarted:     make(chan struct{}, 1),
+		releaseDelete:     make(chan struct{}),
+		deleteCtxCanceled: make(chan struct{}, 1),
+		messages: []*storage.CircuitBreakerModel{{
+			ID:    42,
+			Topic: "test",
+			Data:  []byte("payload"),
+		}},
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(messages),
+		store,
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+
+	select {
+	case <-messages:
+	case <-time.After(time.Second):
+		t.Fatal("expected replayed message")
+	}
+	select {
+	case <-store.deleteStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected delete to start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before delete completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	select {
+	case <-store.deleteCtxCanceled:
+		t.Fatal("delete context was canceled before delete completed")
+	default:
+	}
+
+	close(store.releaseDelete)
+
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected Close to return after delete completed")
+	}
+	require.Empty(t, store.messages)
+}
+
+func TestCircuitBreakerCloseStopsReplayAfterDeletingPublishedMessages(t *testing.T) {
+	publisher := &blockingReplayPublisher{
+		firstStarted:  make(chan struct{}, 1),
+		releaseFirst:  make(chan struct{}),
+		secondStarted: make(chan struct{}, 1),
+	}
+	store := &trackingReplayStore{
+		messages: []*storage.CircuitBreakerModel{
+			{ID: 1, Topic: "test", Data: []byte("first")},
+			{ID: 2, Topic: "test", Data: []byte("second")},
+		},
+	}
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		publisher,
+		store,
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+
+	select {
+	case <-publisher.firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected first replay publish to start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before first replay publish completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(publisher.releaseFirst)
+
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected Close to return after deleting published replay")
+	}
+	select {
+	case <-publisher.secondStarted:
+		t.Fatal("second replay message should not be published after close")
+	default:
+	}
+	require.Equal(t, []uint64{1}, store.deletedIDs)
+	require.Len(t, store.messages, 1)
+	require.Equal(t, uint64(2), store.messages[0].ID)
+}
+
+func TestCircuitBreakerLoopStopsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(make(chan *testMessages, 10)),
+		newMockStore(),
+		5*time.Second,
+	)
+
+	go circuitBreaker.Loop(ctx)
+	require.Eventually(t, circuitBreaker.hasLoopStarted, time.Second, 10*time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-circuitBreaker.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("expected loop to stop after context cancellation")
+	}
+
+	require.NoError(t, circuitBreaker.Close())
+}
+
+func TestCircuitBreakerCatchUpExtractsStoredTraceContext(t *testing.T) {
+	originalPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTextMapPropagator(originalPropagator)
+	})
+
+	messages := make(chan *testMessages, 10)
+	store := newMockStore()
+	require.NoError(t, store.Insert(context.Background(), "test", []byte("test"), map[string]string{
+		otelContextKey: `{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`,
+	}))
+
+	circuitBreaker := NewCircuitBreaker(
+		logging.Testing(),
+		newMockPublisher(messages),
+		store,
+		5*time.Second,
+	)
+	go circuitBreaker.Loop(context.Background())
+	defer func() {
+		require.NoError(t, circuitBreaker.Close())
+	}()
+
+	var received *testMessages
+	select {
+	case received = <-messages:
+	case <-time.After(time.Second):
+		t.Fatal("expected replayed message")
+	}
+
+	spanContext := trace.SpanContextFromContext(received.msg.Context())
+	require.True(t, spanContext.IsValid())
+	require.True(t, spanContext.IsRemote())
+	require.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", spanContext.TraceID().String())
+	require.Equal(t, "00f067aa0ba902b7", spanContext.SpanID().String())
+}
+
+func requireCloseWithin(t *testing.T, circuitBreaker *CircuitBreaker) {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- circuitBreaker.Close()
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("expected circuit breaker close to return")
+	}
+}
+
+type blockingListStore struct {
+	listStarted chan struct{}
+}
+
+func (s *blockingListStore) Insert(ctx context.Context, topic string, data []byte, metadata map[string]string) error {
+	return nil
+}
+
+func (s *blockingListStore) List(ctx context.Context) ([]*storage.CircuitBreakerModel, error) {
+	select {
+	case s.listStarted <- struct{}{}:
+	default:
+	}
+
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *blockingListStore) Delete(ctx context.Context, ids []uint64) error {
+	return nil
+}
+
+type blockingInsertStore struct {
+	insertStarted     chan struct{}
+	releaseInsert     chan struct{}
+	insertCtxCanceled chan struct{}
+	inserted          bool
+}
+
+func (s *blockingInsertStore) Insert(ctx context.Context, topic string, data []byte, metadata map[string]string) error {
+	select {
+	case s.insertStarted <- struct{}{}:
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		select {
+		case s.insertCtxCanceled <- struct{}{}:
+		default:
+		}
+		return ctx.Err()
+	case <-s.releaseInsert:
+		s.inserted = true
+		return nil
+	}
+}
+
+func (s *blockingInsertStore) List(ctx context.Context) ([]*storage.CircuitBreakerModel, error) {
+	return nil, nil
+}
+
+func (s *blockingInsertStore) Delete(ctx context.Context, ids []uint64) error {
+	return nil
+}
+
+type blockingDeleteStore struct {
+	deleteStarted     chan struct{}
+	releaseDelete     chan struct{}
+	deleteCtxCanceled chan struct{}
+	messages          []*storage.CircuitBreakerModel
+}
+
+func (s *blockingDeleteStore) Insert(ctx context.Context, topic string, data []byte, metadata map[string]string) error {
+	return nil
+}
+
+func (s *blockingDeleteStore) List(ctx context.Context) ([]*storage.CircuitBreakerModel, error) {
+	result := make([]*storage.CircuitBreakerModel, len(s.messages))
+	copy(result, s.messages)
+	return result, nil
+}
+
+func (s *blockingDeleteStore) Delete(ctx context.Context, ids []uint64) error {
+	select {
+	case s.deleteStarted <- struct{}{}:
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		select {
+		case s.deleteCtxCanceled <- struct{}{}:
+		default:
+		}
+		return ctx.Err()
+	case <-s.releaseDelete:
+		s.messages = nil
+		return nil
+	}
+}
+
+type blockingPublishPublisher struct {
+	publishStarted chan struct{}
+	releasePublish chan struct{}
+}
+
+func (p *blockingPublishPublisher) Publish(topic string, messages ...*message.Message) error {
+	select {
+	case p.publishStarted <- struct{}{}:
+	default:
+	}
+	<-p.releasePublish
+	return nil
+}
+
+func (p *blockingPublishPublisher) Close() error {
+	return nil
+}
+
+type blockingReplayPublisher struct {
+	calls         atomic.Int32
+	firstStarted  chan struct{}
+	releaseFirst  chan struct{}
+	secondStarted chan struct{}
+}
+
+func (p *blockingReplayPublisher) Publish(topic string, messages ...*message.Message) error {
+	if p.calls.Add(1) == 1 {
+		select {
+		case p.firstStarted <- struct{}{}:
+		default:
+		}
+		<-p.releaseFirst
+		return nil
+	}
+
+	select {
+	case p.secondStarted <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (p *blockingReplayPublisher) Close() error {
+	return nil
+}
+
+type trackingReplayStore struct {
+	messages   []*storage.CircuitBreakerModel
+	deletedIDs []uint64
+}
+
+func (s *trackingReplayStore) Insert(ctx context.Context, topic string, data []byte, metadata map[string]string) error {
+	return nil
+}
+
+func (s *trackingReplayStore) List(ctx context.Context) ([]*storage.CircuitBreakerModel, error) {
+	result := make([]*storage.CircuitBreakerModel, len(s.messages))
+	copy(result, s.messages)
+	return result, nil
+}
+
+func (s *trackingReplayStore) Delete(ctx context.Context, ids []uint64) error {
+	s.deletedIDs = append(s.deletedIDs, ids...)
+
+	remaining := s.messages[:0]
+	for _, msg := range s.messages {
+		deleted := false
+		for _, id := range ids {
+			if msg.ID == id {
+				deleted = true
+				break
+			}
+		}
+		if !deleted {
+			remaining = append(remaining, msg)
+		}
+	}
+	s.messages = remaining
+	return nil
 }

--- a/pkg/messaging/publish/circuit/utils_test.go
+++ b/pkg/messaging/publish/circuit/utils_test.go
@@ -22,6 +22,7 @@ type testMessages struct {
 type mockPublisher struct {
 	mu       sync.RWMutex
 	err      error
+	closed   int
 	messages chan *testMessages
 }
 
@@ -64,7 +65,14 @@ func (p *mockPublisher) Publish(topic string, messages ...*message.Message) erro
 func (p *mockPublisher) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.closed++
 	return nil
+}
+
+func (p *mockPublisher) CloseCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.closed
 }
 
 type MockStore struct {

--- a/pkg/service/health/controller.go
+++ b/pkg/service/health/controller.go
@@ -3,7 +3,6 @@ package health
 import (
 	"encoding/json"
 	"net/http"
-	"sync"
 )
 
 type HealthController struct {
@@ -11,34 +10,30 @@ type HealthController struct {
 }
 
 type result struct {
+	Index int
 	Check NamedCheck
 	Err   error
 }
 
 func (ctrl *HealthController) Check(w http.ResponseWriter, r *http.Request) {
-	sg := sync.WaitGroup{}
-	sg.Add(len(ctrl.Checks))
-
+	ctx := r.Context()
 	results := make(chan result, len(ctrl.Checks))
-	for _, ch := range ctrl.Checks {
-		go func(ch NamedCheck) {
-			defer sg.Done()
-			select {
-			case <-r.Context().Done():
-				return
-			case results <- result{
+	for index, ch := range ctrl.Checks {
+		go func(index int, ch NamedCheck) {
+			results <- result{
+				Index: index,
 				Check: ch,
-				Err:   ch.Do(r.Context()),
-			}:
+				Err:   ch.Do(ctx),
 			}
-		}(ch)
+		}(index, ch)
 	}
-	sg.Wait()
-	close(results)
 
 	response := map[string]string{}
+	completed := make([]bool, len(ctrl.Checks))
 	hasError := false
-	for r := range results {
+
+	recordResult := func(r result) {
+		completed[r.Index] = true
 		if r.Err != nil {
 			hasError = true
 			response[r.Check.Name()] = r.Err.Error()
@@ -47,6 +42,36 @@ func (ctrl *HealthController) Check(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	completedCount := 0
+	for completedCount < len(ctrl.Checks) {
+		select {
+		case r := <-results:
+			recordResult(r)
+			completedCount++
+		case <-ctx.Done():
+			for completedCount < len(ctrl.Checks) {
+				select {
+				case r := <-results:
+					recordResult(r)
+					completedCount++
+				default:
+					hasError = true
+					for index, ch := range ctrl.Checks {
+						if !completed[index] {
+							response[ch.Name()] = ctx.Err().Error()
+						}
+					}
+					writeResponse(w, response, hasError)
+					return
+				}
+			}
+		}
+	}
+
+	writeResponse(w, response, hasError)
+}
+
+func writeResponse(w http.ResponseWriter, response map[string]string, hasError bool) {
 	if hasError {
 		w.WriteHeader(http.StatusInternalServerError)
 	} else {

--- a/pkg/service/health/controller_test.go
+++ b/pkg/service/health/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
@@ -86,4 +87,53 @@ func TestHealthController(t *testing.T) {
 		app := fx.New(options...)
 		require.NoError(t, app.Err())
 	}
+}
+
+func TestHealthControllerReturnsWhenContextCanceledDuringHungCheck(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	ctrl := health.NewHealthController(
+		health.NewNamedCheck("hung", health.CheckFn(func(ctx context.Context) error {
+			close(started)
+			<-release
+			return nil
+		})),
+	)
+	t.Cleanup(func() {
+		close(release)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/_health", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		ctrl.Check(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("health check did not start")
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("health controller did not return after request context cancellation")
+	}
+
+	require.Equal(t, http.StatusInternalServerError, rec.Result().StatusCode)
+
+	ret := make(map[string]string)
+	require.NoError(t, json.NewDecoder(rec.Result().Body).Decode(&ret))
+	require.Equal(t, map[string]string{
+		"hung": context.Canceled.Error(),
+	}, ret)
 }

--- a/pkg/storage/migrations/migrator.go
+++ b/pkg/storage/migrations/migrator.go
@@ -319,88 +319,9 @@ func (m *Migrator) upByOne(ctx context.Context, db bun.IDB) error {
 
 	switch conn := actualDB.(type) {
 	case bun.Conn:
-		listeningContext, cancel := context.WithCancel(ctx)
-		listenerStopped := make(chan struct{})
-		defer func() {
-			cancel()
-			<-listenerStopped
-		}()
-
-		if err := conn.Raw(func(driverConn any) error {
-			channel := "migrations-" + m.GetSchema()
-			logging.FromContext(ctx).Debugf("Listening for migrations notifications on " + channel)
-
-			listener := pgxlisten.Listener{
-				Connect: func(ctx context.Context) (*pgx.Conn, error) {
-					return pgx.Connect(ctx, driverConn.(*stdlib.Conn).Conn().Config().ConnString())
-				},
-				LogError: func(ctx context.Context, err error) {
-					if !errors.Is(err, context.Canceled) {
-						logging.FromContext(ctx).Errorf("pgxlisten error: %v", err)
-					}
-				},
-			}
-			listener.Handle(channel, pgxlisten.HandlerFunc(func(ctx context.Context, notification *pgconn.Notification, conn *pgx.Conn) error {
-
-				logging.FromContext(ctx).Debugf("Received notification: %s", notification.Payload)
-
-				switch {
-				case strings.HasPrefix(notification.Payload, "init: "):
-					value := strings.TrimPrefix(notification.Payload, "init: ")
-					maxCounter, err := strconv.ParseInt(value, 10, 64)
-					if err != nil {
-						logging.FromContext(ctx).Errorf("failed to parse max counter: %v", err)
-						return nil
-					}
-
-					_, err = conn.Exec(ctx, `
-						update `+m.getVersionsTable()+`
-						set max_counter = $1
-						where version_id = $2 and max_counter is null
-					`, maxCounter, lastVersion+1)
-					if err != nil {
-						logging.FromContext(ctx).Debugf("failed to update max counter: %v", err)
-						return nil
-					}
-				case strings.HasPrefix(notification.Payload, "continue: "):
-					value := strings.TrimPrefix(notification.Payload, "continue: ")
-					increment, err := strconv.ParseInt(value, 10, 64)
-					if err != nil {
-						logging.FromContext(ctx).Errorf("failed to parse actual counter: %v", err)
-						return nil
-					}
-
-					_, err = conn.Exec(ctx, `
-						update `+m.getVersionsTable()+`
-						set actual_counter = coalesce(actual_counter, 0) + $1
-						where version_id = $2
-					`, increment, lastVersion+1)
-					if err != nil {
-						return err
-					}
-					if err != nil {
-						logging.FromContext(ctx).Debugf("failed to update actual counter: %v", err)
-						return nil
-					}
-				default:
-					logging.FromContext(ctx).Errorf("unknown notification: %s", notification.Payload)
-				}
-
-				return nil
-			}))
-			go func() {
-				if err := listener.Listen(listeningContext); err != nil {
-					if errors.Is(err, context.Canceled) {
-						close(listenerStopped)
-						return
-					}
-					panic(err)
-				}
-			}()
-
-			return nil
-		}); err != nil {
-			logging.FromContext(ctx).Errorf("Failed so setup migrations listener: %v", err)
+		stopMigrationProgressListener := m.startMigrationProgressListener(ctx, conn, lastVersion)
+		if stopMigrationProgressListener != nil {
+			defer stopMigrationProgressListener()
 		}
 	}
 
@@ -422,6 +343,103 @@ func (m *Migrator) upByOne(ctx context.Context, db bun.IDB) error {
 	}
 
 	return nil
+}
+
+type migrationProgressRawConn interface {
+	Raw(func(driverConn any) error) error
+}
+
+func (m *Migrator) startMigrationProgressListener(ctx context.Context, conn migrationProgressRawConn, lastVersion int) func() {
+	var stopMigrationProgressListener func()
+
+	if err := conn.Raw(func(driverConn any) error {
+		channel := "migrations-" + m.GetSchema()
+		logging.FromContext(ctx).Debugf("Listening for migrations notifications on " + channel)
+
+		listener := pgxlisten.Listener{
+			Connect: func(ctx context.Context) (*pgx.Conn, error) {
+				return pgx.Connect(ctx, driverConn.(*stdlib.Conn).Conn().Config().ConnString())
+			},
+			LogError: func(ctx context.Context, err error) {
+				if !errors.Is(err, context.Canceled) {
+					logging.FromContext(ctx).Errorf("pgxlisten error: %v", err)
+				}
+			},
+		}
+		listener.Handle(channel, pgxlisten.HandlerFunc(func(ctx context.Context, notification *pgconn.Notification, conn *pgx.Conn) error {
+
+			logging.FromContext(ctx).Debugf("Received notification: %s", notification.Payload)
+
+			switch {
+			case strings.HasPrefix(notification.Payload, "init: "):
+				value := strings.TrimPrefix(notification.Payload, "init: ")
+				maxCounter, err := strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					logging.FromContext(ctx).Errorf("failed to parse max counter: %v", err)
+					return nil
+				}
+
+				_, err = conn.Exec(ctx, `
+					update `+m.getVersionsTable()+`
+					set max_counter = $1
+					where version_id = $2 and max_counter is null
+				`, maxCounter, lastVersion+1)
+				if err != nil {
+					logging.FromContext(ctx).Debugf("failed to update max counter: %v", err)
+					return nil
+				}
+			case strings.HasPrefix(notification.Payload, "continue: "):
+				value := strings.TrimPrefix(notification.Payload, "continue: ")
+				increment, err := strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					logging.FromContext(ctx).Errorf("failed to parse actual counter: %v", err)
+					return nil
+				}
+
+				_, err = conn.Exec(ctx, `
+					update `+m.getVersionsTable()+`
+					set actual_counter = coalesce(actual_counter, 0) + $1
+					where version_id = $2
+				`, increment, lastVersion+1)
+				if err != nil {
+					return err
+				}
+				if err != nil {
+					logging.FromContext(ctx).Debugf("failed to update actual counter: %v", err)
+					return nil
+				}
+			default:
+				logging.FromContext(ctx).Errorf("unknown notification: %s", notification.Payload)
+			}
+
+			return nil
+		}))
+		stopMigrationProgressListener = runMigrationProgressListener(ctx, listener.Listen)
+
+		return nil
+	}); err != nil {
+		logging.FromContext(ctx).Errorf("failed to set up migrations listener: %v", err)
+	}
+
+	return stopMigrationProgressListener
+}
+
+func runMigrationProgressListener(ctx context.Context, listen func(context.Context) error) func() {
+	listeningContext, cancel := context.WithCancel(ctx)
+	listenerStopped := make(chan struct{})
+
+	go func() {
+		defer close(listenerStopped)
+
+		if err := listen(listeningContext); err != nil && !errors.Is(err, context.Canceled) {
+			logging.FromContext(ctx).Errorf("migrations listener stopped with error: %v", err)
+		}
+	}()
+
+	return func() {
+		cancel()
+		<-listenerStopped
+	}
 }
 
 func (m *Migrator) UpByOne(ctx context.Context) error {

--- a/pkg/storage/migrations/migrator_test.go
+++ b/pkg/storage/migrations/migrator_test.go
@@ -29,6 +29,12 @@ var (
 	bunDB      *bun.DB
 )
 
+type rawConnFunc func(func(driverConn any) error) error
+
+func (f rawConnFunc) Raw(fn func(driverConn any) error) error {
+	return f(fn)
+}
+
 func TestMain(m *testing.M) {
 	utils.WithTestMain(func(t *utils.TestingTForMain) int {
 		var err error
@@ -53,6 +59,39 @@ func TestMain(m *testing.M) {
 
 		return m.Run()
 	})
+}
+
+func TestMigrationProgressListenerRawErrorDoesNotRequireCleanup(t *testing.T) {
+	t.Parallel()
+
+	rawErr := errors.New("raw failed")
+	migrator := &Migrator{}
+
+	stop := migrator.startMigrationProgressListener(logging.TestingContext(), rawConnFunc(func(func(driverConn any) error) error {
+		return rawErr
+	}), 0)
+
+	require.Nil(t, stop)
+}
+
+func TestMigrationProgressListenerListenErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	stop := runMigrationProgressListener(logging.TestingContext(), func(context.Context) error {
+		return errors.New("listen failed")
+	})
+
+	done := make(chan struct{})
+	go func() {
+		stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("listener cleanup blocked")
+	}
 }
 
 func TestMigrationsListen(t *testing.T) {

--- a/pkg/transport/grpcserver/serverport.go
+++ b/pkg/transport/grpcserver/serverport.go
@@ -39,9 +39,19 @@ func startServer(ctx context.Context, s *serverport.Server, serverOptions []grpc
 	}()
 
 	return func(ctx context.Context) error {
-		grpcServer.GracefulStop()
+		stopped := make(chan struct{})
+		go func() {
+			grpcServer.GracefulStop()
+			close(stopped)
+		}()
 
-		return nil
+		select {
+		case <-stopped:
+			return nil
+		case <-ctx.Done():
+			go grpcServer.Stop()
+			return ctx.Err()
+		}
 	}, nil
 }
 

--- a/pkg/transport/grpcserver/serverport_test.go
+++ b/pkg/transport/grpcserver/serverport_test.go
@@ -1,0 +1,106 @@
+package grpcserver
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/transport/serverport"
+)
+
+func TestStartServerStopContextForcesGracefulStop(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := serverport.NewServer(serverPortDiscr, serverport.WithListener(listener))
+	streamStarted := make(chan struct{})
+	var closeStarted sync.Once
+
+	stop, err := startServer(
+		logging.TestingContext(),
+		server,
+		[]grpc.ServerOption{grpc.WaitForHandlers(true)},
+		[]func(*grpc.Server){
+			func(grpcServer *grpc.Server) {
+				grpcServer.RegisterService(&grpc.ServiceDesc{
+					ServiceName: "test.Blocking",
+					HandlerType: (*any)(nil),
+					Streams: []grpc.StreamDesc{
+						{
+							StreamName: "Watch",
+							Handler: func(_ any, stream grpc.ServerStream) error {
+								closeStarted.Do(func() {
+									close(streamStarted)
+								})
+								<-stream.Context().Done()
+								return stream.Context().Err()
+							},
+							ServerStreams: true,
+							ClientStreams: true,
+						},
+					},
+				}, &struct{}{})
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	connCtx, cancelConn := context.WithTimeout(context.Background(), time.Second)
+	defer cancelConn()
+	conn, err := grpc.DialContext(
+		connCtx,
+		listener.Addr().String(),
+		grpc.WithBlock(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	defer cancelStream()
+
+	stream, err := conn.NewStream(
+		streamCtx,
+		&grpc.StreamDesc{
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+		"/test.Blocking/Watch",
+	)
+	require.NoError(t, err)
+	require.NoError(t, stream.SendMsg(&emptypb.Empty{}))
+
+	select {
+	case <-streamStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stream handler did not start")
+	}
+
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelStop()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- stop(stopCtx)
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		cancelStream()
+		t.Fatal("stop did not return after context deadline")
+	}
+}


### PR DESCRIPTION
## Summary

Rollup PR replacing the stacked PRs #634-#639:

- #634 / EN-1185: harden circuit breaker lifecycle
- #635 / EN-1186: honor health check context cancellation
- #636 / EN-1187: bound gRPC graceful stop by context
- #637 / EN-1188: synchronize Temporal worker shutdown
- #638 / EN-1189: make migration progress listener safe
- #639 / EN-1190: wire runtime metrics options

## Review comments addressed

- #634: keep durable circuit breaker store operations draining on close; stop replay safely; prefer accepted publish results during shutdown.
- #636: return once the stop context expires even when `grpc.WaitForHandlers(true)` can make forced `Stop` wait for handlers.
- #639: only provide `runtime.WithMinimumReadMemStatsInterval` when the configured interval is non-zero, preserving OpenTelemetry runtime defaults for direct `ModuleConfig{RuntimeMetrics: true}` users.

## Validation

Passed locally:

- `go test ./pkg/messaging/publish/circuit`
- `go test ./pkg/service/health`
- `go test ./pkg/transport/grpcserver`
- `go test ./pkg/workflow/temporal`
- `go test ./pkg/fx/observefx`

Not run successfully locally:

- `go test ./pkg/storage/migrations` requires Docker; local Docker socket returned `connect: connection refused`.

## Supersedes

Supersedes #634, #635, #636, #637, #638, and #639.
