### PR TITLE
fix: roll up remaining backlog fixes (EN-1180-EN-1196)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,7 @@ on:
     types: [ assigned, opened, synchronize, reopened, labeled ]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.14
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.24
 	github.com/aws/smithy-go v1.24.2
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/getkin/kin-openapi v0.134.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-jose/go-jose/v4 v4.1.4
@@ -127,7 +128,6 @@ require (
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-chi/render v1.0.3 // indirect
 	github.com/go-faster/city v1.0.1 // indirect

--- a/pkg/audit/publish.go
+++ b/pkg/audit/publish.go
@@ -19,24 +19,38 @@ import (
 
 // NewEventMessage builds the Watermill message used for audit events.
 func NewEventMessage(ctx context.Context, appName string, payload Payload) *message.Message {
-	return publish.NewMessage(
-		ctx,
-		publish.EventMessage{
-			Date:    time.Now().UTC(),
-			App:     appName,
-			Version: EventVersion,
-			Type:    EventTypeAudit,
-			Payload: payload,
-		},
-	)
+	msg, err := NewEventMessageWithError(ctx, appName, payload)
+	if err == nil {
+		return msg
+	}
+
+	logging.FromContext(ctx).Errorf("failed to marshal audit message: %v", err)
+	return publish.NewMessage(ctx, newPublishEventMessage(appName, payload))
+}
+
+// NewEventMessageWithError builds the Watermill message used for audit events.
+func NewEventMessageWithError(ctx context.Context, appName string, payload Payload) (*message.Message, error) {
+	return publish.NewMessageWithError(ctx, newPublishEventMessage(appName, payload))
+}
+
+func newPublishEventMessage(appName string, payload Payload) publish.EventMessage {
+	return publish.EventMessage{
+		Date:    time.Now().UTC(),
+		App:     appName,
+		Version: EventVersion,
+		Type:    EventTypeAudit,
+		Payload: payload,
+	}
 }
 
 // PublishEventWithError publishes an audit event to the configured publisher.
 func PublishEventWithError(ctx context.Context, publisher message.Publisher, topicName string, appName string, payload Payload) error {
-	return publisher.Publish(
-		topicName,
-		NewEventMessage(ctx, appName, payload),
-	)
+	msg, err := NewEventMessageWithError(ctx, appName, payload)
+	if err != nil {
+		return err
+	}
+
+	return publisher.Publish(topicName, msg)
 }
 
 // PublishEvent publishes an audit event to the configured publisher.

--- a/pkg/authn/jwt/auth.go
+++ b/pkg/authn/jwt/auth.go
@@ -83,13 +83,12 @@ func ClaimsFromRequest(r *http.Request, keySets map[string]oidc.KeySet) (*oidc.A
 		return nil, ErrNoAuthorizationHeader
 	}
 
-	if !strings.HasPrefix(authHeader, "bearer") &&
-		!strings.HasPrefix(authHeader, "Bearer") {
+	authParts := strings.Fields(authHeader)
+	if len(authParts) != 2 || !strings.EqualFold(authParts[0], "Bearer") {
 		return nil, ErrMalformedHeader
 	}
 
-	token := authHeader[6:]
-	token = strings.TrimSpace(token)
+	token := authParts[1]
 
 	claims := &oidc.AccessTokenClaims{}
 	decrypted, err := oidc.DecryptToken(token)

--- a/pkg/authn/jwt/auth_test.go
+++ b/pkg/authn/jwt/auth_test.go
@@ -208,6 +208,13 @@ func TestJWTAuth_Authenticate(t *testing.T) {
 	t.Run("failure with malformed authorization header", func(t *testing.T) {
 		t.Parallel()
 		keySet, _, issuer := setupTestKeySet(t)
+		headers := map[string]string{
+			"invalid scheme":       "Invalid token",
+			"bearer without gap":   "Bearertoken",
+			"bearer without token": "Bearer",
+			"bearer blank token":   "Bearer ",
+			"extra token segment":  "Bearer token extra",
+		}
 		tests := []struct {
 			name string
 			auth Authenticator
@@ -224,14 +231,18 @@ func TestJWTAuth_Authenticate(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				req := httptest.NewRequest("GET", "/test", nil)
-				req.Header.Set("Authorization", "Invalid token")
-				req = req.WithContext(logging.TestingContext())
+				for name, header := range headers {
+					t.Run(name, func(t *testing.T) {
+						req := httptest.NewRequest("GET", "/test", nil)
+						req.Header.Set("Authorization", header)
+						req = req.WithContext(logging.TestingContext())
 
-				authenticated, err := tt.auth.Authenticate(nil, req)
-				require.Error(t, err)
-				assert.False(t, authenticated)
-				assert.Contains(t, err.Error(), "malformed authorization header")
+						authenticated, err := tt.auth.Authenticate(nil, req)
+						require.Error(t, err)
+						assert.False(t, authenticated)
+						assert.Contains(t, err.Error(), "malformed authorization header")
+					})
+				}
 			})
 		}
 	})

--- a/pkg/authn/oidc/http/marshal.go
+++ b/pkg/authn/oidc/http/marshal.go
@@ -34,7 +34,7 @@ func isNilJSONValue(i any) bool {
 	}
 	value := reflect.ValueOf(i)
 	switch value.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+	case reflect.Pointer:
 		return value.IsNil()
 	default:
 		return false

--- a/pkg/authn/oidc/http/marshal.go
+++ b/pkg/authn/oidc/http/marshal.go
@@ -14,7 +14,8 @@ func MarshalJSON(w http.ResponseWriter, i any) {
 
 func MarshalJSONWithStatus(w http.ResponseWriter, i any, status int) {
 	w.Header().Set("content-type", "application/json")
-	if i == nil || (reflect.ValueOf(i).Kind() == reflect.Ptr && reflect.ValueOf(i).IsNil()) {
+	if isNilJSONValue(i) {
+		w.WriteHeader(status)
 		return
 	}
 	data, err := json.Marshal(i)
@@ -25,6 +26,19 @@ func MarshalJSONWithStatus(w http.ResponseWriter, i any, status int) {
 
 	w.WriteHeader(status)
 	_, _ = w.Write(data)
+}
+
+func isNilJSONValue(i any) bool {
+	if i == nil {
+		return true
+	}
+	value := reflect.ValueOf(i)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 func ConcatenateJSON(first, second []byte) ([]byte, error) {

--- a/pkg/authn/oidc/http/marshal_test.go
+++ b/pkg/authn/oidc/http/marshal_test.go
@@ -28,26 +28,6 @@ func TestMarshalJSONWithStatusWritesStatusWithoutBodyForNilJSONValues(t *testing
 			})(nil),
 			status: stdhttp.StatusAccepted,
 		},
-		{
-			name:   "nil map",
-			body:   map[string]string(nil),
-			status: stdhttp.StatusCreated,
-		},
-		{
-			name:   "nil slice",
-			body:   []string(nil),
-			status: stdhttp.StatusOK,
-		},
-		{
-			name:   "nil channel",
-			body:   (chan string)(nil),
-			status: stdhttp.StatusOK,
-		},
-		{
-			name:   "nil function",
-			body:   (func())(nil),
-			status: stdhttp.StatusOK,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -90,6 +70,16 @@ func TestMarshalJSONWithStatusWritesBodyForNonNilJSONValues(t *testing.T) {
 			body:     []string{},
 			expected: `[]`,
 		},
+		{
+			name:     "nil map",
+			body:     map[string]string(nil),
+			expected: `null`,
+		},
+		{
+			name:     "nil slice",
+			body:     []string(nil),
+			expected: `null`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -103,6 +93,37 @@ func TestMarshalJSONWithStatusWritesBodyForNonNilJSONValues(t *testing.T) {
 			require.Equal(t, stdhttp.StatusAccepted, recorder.Code)
 			require.JSONEq(t, tc.expected, recorder.Body.String())
 			require.Equal(t, "application/json", recorder.Header().Get("content-type"))
+		})
+	}
+}
+
+func TestMarshalJSONWithStatusReturnsMarshalErrorsForUnsupportedNilValues(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		body any
+	}{
+		{
+			name: "nil channel",
+			body: (chan string)(nil),
+		},
+		{
+			name: "nil function",
+			body: (func())(nil),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+
+			MarshalJSONWithStatus(recorder, tc.body, stdhttp.StatusAccepted)
+
+			require.Equal(t, stdhttp.StatusInternalServerError, recorder.Code)
+			require.Contains(t, recorder.Body.String(), "json: unsupported type")
 		})
 	}
 }

--- a/pkg/authn/oidc/http/marshal_test.go
+++ b/pkg/authn/oidc/http/marshal_test.go
@@ -1,0 +1,108 @@
+package http
+
+import (
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalJSONWithStatusWritesStatusWithoutBodyForNilJSONValues(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		body   any
+		status int
+	}{
+		{
+			name:   "nil interface",
+			body:   nil,
+			status: stdhttp.StatusNoContent,
+		},
+		{
+			name: "nil pointer",
+			body: (*struct {
+				ID string `json:"id"`
+			})(nil),
+			status: stdhttp.StatusAccepted,
+		},
+		{
+			name:   "nil map",
+			body:   map[string]string(nil),
+			status: stdhttp.StatusCreated,
+		},
+		{
+			name:   "nil slice",
+			body:   []string(nil),
+			status: stdhttp.StatusOK,
+		},
+		{
+			name:   "nil channel",
+			body:   (chan string)(nil),
+			status: stdhttp.StatusOK,
+		},
+		{
+			name:   "nil function",
+			body:   (func())(nil),
+			status: stdhttp.StatusOK,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+
+			MarshalJSONWithStatus(recorder, tc.body, tc.status)
+
+			require.Equal(t, tc.status, recorder.Code)
+			require.Empty(t, recorder.Body.String())
+			require.Equal(t, "application/json", recorder.Header().Get("content-type"))
+		})
+	}
+}
+
+func TestMarshalJSONWithStatusWritesBodyForNonNilJSONValues(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		body     any
+		expected string
+	}{
+		{
+			name: "struct pointer",
+			body: &struct {
+				ID string `json:"id"`
+			}{ID: "test"},
+			expected: `{"id":"test"}`,
+		},
+		{
+			name:     "empty map",
+			body:     map[string]string{},
+			expected: `{}`,
+		},
+		{
+			name:     "empty slice",
+			body:     []string{},
+			expected: `[]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+
+			MarshalJSONWithStatus(recorder, tc.body, stdhttp.StatusAccepted)
+
+			require.Equal(t, stdhttp.StatusAccepted, recorder.Code)
+			require.JSONEq(t, tc.expected, recorder.Body.String())
+			require.Equal(t, "application/json", recorder.Header().Get("content-type"))
+		})
+	}
+}

--- a/pkg/messaging/publish/flags.go
+++ b/pkg/messaging/publish/flags.go
@@ -160,6 +160,6 @@ func InitNatsCLIFlags(flags *pflag.FlagSet, serviceName string, options ...func(
 	flags.Int(PublisherNatsMaxReconnectFlag, values.PublisherNatsMaxReconnect, "Nats: set the maximum number of reconnect attempts.")
 	flags.Duration(PublisherNatsReconnectWaitFlag, values.PublisherNatsReconnectWait, "Nats: the wait time between reconnect attempts.")
 	flags.String(PublisherNatsURLFlag, values.PublisherNatsURL, "Nats url")
-	flags.Bool(PublisherNatsAutoProvisionFlag, true, "Auto create streams")
+	flags.Bool(PublisherNatsAutoProvisionFlag, values.PublisherNatsAutoProvision, "Auto create streams")
 	flags.StringArray(PublisherNatsNkeyFileFlag, []string{}, "Nats: nkey file (can be used multiple times)")
 }

--- a/pkg/messaging/publish/flags_test.go
+++ b/pkg/messaging/publish/flags_test.go
@@ -1,0 +1,24 @@
+package publish_test
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
+)
+
+func TestInitNatsCLIFlagsUsesAutoProvisionOverride(t *testing.T) {
+	t.Parallel()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+	publish.InitNatsCLIFlags(flags, "service", func(values *publish.ConfigDefault) {
+		values.PublisherNatsAutoProvision = false
+	})
+
+	autoProvision, err := flags.GetBool(publish.PublisherNatsAutoProvisionFlag)
+	require.NoError(t, err)
+	require.False(t, autoProvision)
+}

--- a/pkg/messaging/publish/logging.go
+++ b/pkg/messaging/publish/logging.go
@@ -33,7 +33,8 @@ func (w watermillLoggerAdapter) Trace(msg string, fields watermill.LogFields) {
 
 func (w watermillLoggerAdapter) With(fields watermill.LogFields) watermill.LoggerAdapter {
 	return watermillLoggerAdapter{
-		Logger: w.Logger.WithFields(fields),
+		includeTraceLogs: w.includeTraceLogs,
+		Logger:           w.Logger.WithFields(fields),
 	}
 }
 

--- a/pkg/messaging/publish/logging_test.go
+++ b/pkg/messaging/publish/logging_test.go
@@ -78,3 +78,16 @@ func TestWatermillLoggerAdapter_Trace_Disabled(t *testing.T) {
 	logger := publish.NewWatermillLoggerAdapter(mockLogger, false)
 	logger.Trace("trace message", fields)
 }
+
+func TestWatermillLoggerAdapter_WithPreservesTraceSetting(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockLogger := logging.NewMockLogger(ctrl)
+
+	mockLogger.EXPECT().WithFields(gomock.Any()).Times(2).Return(mockLogger)
+	mockLogger.EXPECT().Debug("trace message").Return()
+
+	logger := publish.NewWatermillLoggerAdapter(mockLogger, true).With(watermill.LogFields{"component": "test"})
+	logger.Trace("trace message", watermill.LogFields{"key": "value"})
+}

--- a/pkg/messaging/publish/messages.go
+++ b/pkg/messaging/publish/messages.go
@@ -3,6 +3,7 @@ package publish
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -10,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
 const (
@@ -20,11 +23,31 @@ const (
 )
 
 func NewMessage(ctx context.Context, m EventMessage) *message.Message {
-	data, err := json.Marshal(m)
-	if err != nil {
-		panic(err)
+	msg, err := NewMessageWithError(ctx, m)
+	if err == nil {
+		return msg
 	}
 
+	logging.FromContext(ctx).Errorf("failed to marshal event message: %v", err)
+	m.Payload = nil
+	msg, fallbackErr := NewMessageWithError(ctx, m)
+	if fallbackErr == nil {
+		return msg
+	}
+
+	logging.FromContext(ctx).Errorf("failed to marshal fallback event message: %v", fallbackErr)
+	return newMessage(ctx, []byte("{}"))
+}
+
+func NewMessageWithError(ctx context.Context, m EventMessage) (*message.Message, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("marshal event message: %w", err)
+	}
+	return newMessage(ctx, data), nil
+}
+
+func newMessage(ctx context.Context, data []byte) *message.Message {
 	carrier := propagation.MapCarrier{}
 	otel.GetTextMapPropagator().Inject(ctx, carrier)
 	otelContext, _ := json.Marshal(carrier)

--- a/pkg/messaging/publish/messages_test.go
+++ b/pkg/messaging/publish/messages_test.go
@@ -1,0 +1,47 @@
+package publish
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestNewMessageWithErrorReturnsMarshalError(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.ContextWithLogger(context.Background(), logging.NopZap())
+	msg, err := NewMessageWithError(ctx, EventMessage{
+		Type:    "test",
+		Payload: func() {},
+	})
+
+	require.Nil(t, msg)
+	require.ErrorContains(t, err, "marshal event message")
+}
+
+func TestNewMessageFallsBackWithoutPanicOnMarshalError(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.ContextWithLogger(context.Background(), logging.NopZap())
+	var msgPayload *EventMessage
+	var err error
+	var msgID string
+
+	require.NotPanics(t, func() {
+		msg := NewMessage(ctx, EventMessage{
+			Type:    "test",
+			Payload: func() {},
+		})
+		require.NotNil(t, msg)
+		msgID = msg.UUID
+		_, msgPayload, err = UnmarshalMessage(msg)
+	})
+
+	require.NotEmpty(t, msgID)
+	require.NoError(t, err)
+	require.Equal(t, "test", msgPayload.Type)
+	require.Nil(t, msgPayload.Payload)
+}

--- a/pkg/messaging/publish/module.go
+++ b/pkg/messaging/publish/module.go
@@ -52,7 +52,16 @@ func (m *memoryPublisher) Close() error {
 }
 
 func (m *memoryPublisher) AllMessages() map[string][]*message.Message {
-	return m.messages
+	m.Lock()
+	defer m.Unlock()
+
+	// Return a shallow snapshot: callers can change the map or topic slices
+	// without mutating the publisher, while message payloads are not duplicated.
+	snapshot := make(map[string][]*message.Message, len(m.messages))
+	for topic, messages := range m.messages {
+		snapshot[topic] = append([]*message.Message(nil), messages...)
+	}
+	return snapshot
 }
 
 var _ message.Publisher = (*memoryPublisher)(nil)

--- a/pkg/messaging/publish/module_test.go
+++ b/pkg/messaging/publish/module_test.go
@@ -1,0 +1,26 @@
+package publish_test
+
+import (
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
+)
+
+func TestMemoryPublisherAllMessagesReturnsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	publisher := publish.InMemory()
+	msg := message.NewMessage("id", nil)
+	require.NoError(t, publisher.Publish("topic", msg))
+
+	snapshot := publisher.AllMessages()
+	snapshot["topic"][0] = message.NewMessage("other", nil)
+	snapshot["other"] = []*message.Message{message.NewMessage("other", nil)}
+
+	fresh := publisher.AllMessages()
+	require.Same(t, msg, fresh["topic"][0])
+	require.NotContains(t, fresh, "other")
+}

--- a/pkg/observe/http_client.go
+++ b/pkg/observe/http_client.go
@@ -1,8 +1,13 @@
 package observe
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
+	"strings"
+	"sync"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
@@ -15,25 +20,38 @@ type WithBodiesTracingHTTPTransport struct {
 }
 
 func (t WithBodiesTracingHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	rawRequest, err := httputil.DumpRequest(req, true)
-	if err != nil {
-		panic(err)
+	var rawRequest []byte
+	if t.debug {
+		var dumpErr error
+		rawRequest, dumpErr = dumpRequest(req, true)
+		if dumpErr != nil {
+			return nil, fmt.Errorf("dump http request: %w", dumpErr)
+		}
 	}
 
 	rsp, err := t.underlying.RoundTrip(req)
-	if t.debug || err != nil || rsp.StatusCode >= 400 {
+	if t.debug || err != nil || (rsp != nil && rsp.StatusCode >= 400) {
 		span := trace.SpanFromContext(req.Context())
-		span.SetAttributes(attribute.String("raw-request", string(rawRequest)))
+		if t.debug {
+			span.SetAttributes(attribute.String("raw-request", string(rawRequest)))
+		} else {
+			rawRequest, dumpErr := dumpRequest(req, false)
+			if dumpErr != nil {
+				span.SetAttributes(attribute.String("raw-request-error", dumpErr.Error()))
+			} else {
+				span.SetAttributes(attribute.String("raw-request", string(rawRequest)))
+			}
+		}
 		if err != nil {
 			span.SetAttributes(attribute.String("http-error", err.Error()))
 		}
 		if rsp != nil {
-			rawResponse, err := httputil.DumpResponse(rsp, true)
+			rawResponse, err := dumpResponse(rsp, true)
 			if err != nil {
-				panic(err)
+				span.SetAttributes(attribute.String("raw-response-error", err.Error()))
+			} else {
+				span.SetAttributes(attribute.String("raw-response", string(rawResponse)))
 			}
-
-			span.SetAttributes(attribute.String("raw-response", string(rawResponse)))
 		}
 	}
 
@@ -47,4 +65,135 @@ func NewRoundTripper(httpTransport http.RoundTripper, debug bool, options ...ote
 		debug:      debug,
 	}
 	return otelhttp.NewTransport(transport, options...)
+}
+
+func dumpRequest(req *http.Request, includeBody bool) ([]byte, error) {
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	redactSensitiveHeaders(cloned.Header)
+
+	if !includeBody {
+		return httputil.DumpRequestOut(cloned, false)
+	}
+
+	if req.Body == nil || req.Body == http.NoBody {
+		cloned.Body = req.Body
+		return httputil.DumpRequestOut(cloned, true)
+	}
+
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		bodyCloser := &closeOnceReadCloser{ReadCloser: body}
+		cloned.Body = bodyCloser
+		data, err := httputil.DumpRequestOut(cloned, true)
+		closeErr := bodyCloser.Close()
+		if err != nil {
+			return nil, err
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+		return data, nil
+	}
+
+	data, readErr := io.ReadAll(req.Body)
+	closeErr := req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(data))
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	cloned.Body = io.NopCloser(bytes.NewReader(data))
+	return httputil.DumpRequestOut(cloned, true)
+}
+
+func dumpResponse(rsp *http.Response, includeBody bool) ([]byte, error) {
+	cloned := new(http.Response)
+	*cloned = *rsp
+	cloned.Header = rsp.Header.Clone()
+	redactSensitiveHeaders(cloned.Header)
+
+	if !includeBody || rsp.Body == nil || rsp.Body == http.NoBody {
+		return httputil.DumpResponse(cloned, includeBody)
+	}
+
+	contentLength := rsp.ContentLength
+	body, readErr := io.ReadAll(rsp.Body)
+	closeErr := rsp.Body.Close()
+	rsp.Body = newReplayReadCloser(body, readErr, closeErr)
+	rsp.ContentLength = contentLength
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	cloned.Body = io.NopCloser(bytes.NewReader(body))
+	return httputil.DumpResponse(cloned, true)
+}
+
+type closeOnceReadCloser struct {
+	io.ReadCloser
+	once sync.Once
+	err  error
+}
+
+func (r *closeOnceReadCloser) Close() error {
+	r.once.Do(func() {
+		r.err = r.ReadCloser.Close()
+	})
+	return r.err
+}
+
+func newReplayReadCloser(data []byte, readErr, closeErr error) io.ReadCloser {
+	if readErr == nil && closeErr == nil {
+		return io.NopCloser(bytes.NewReader(data))
+	}
+	return &replayReadCloser{
+		reader:   bytes.NewReader(data),
+		readErr:  readErr,
+		closeErr: closeErr,
+	}
+}
+
+type replayReadCloser struct {
+	reader   *bytes.Reader
+	readErr  error
+	closeErr error
+}
+
+func (r *replayReadCloser) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if err == io.EOF && r.readErr != nil {
+		err = r.readErr
+	}
+	return n, err
+}
+
+func (r *replayReadCloser) Close() error {
+	return r.closeErr
+}
+
+func redactSensitiveHeaders(headers http.Header) {
+	for name := range headers {
+		if isSensitiveHeader(name) {
+			headers.Set(name, "[REDACTED]")
+		}
+	}
+}
+
+func isSensitiveHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "authorization", "cookie", "proxy-authorization", "set-cookie":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/observe/http_client_test.go
+++ b/pkg/observe/http_client_test.go
@@ -1,0 +1,226 @@
+package observe
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestBodiesTracingHTTPTransportDoesNotDumpSuccessfulRequestWhenDebugDisabled(t *testing.T) {
+	t.Parallel()
+
+	transport := WithBodiesTracingHTTPTransport{
+		underlying: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       http.NoBody,
+			}, nil
+		}),
+		debug: false,
+	}
+	req, err := http.NewRequest(http.MethodPost, "http://example.com", errorReadCloser{err: errors.New("body should not be read")})
+	require.NoError(t, err)
+
+	var rsp *http.Response
+	require.NotPanics(t, func() {
+		rsp, err = transport.RoundTrip(req)
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+}
+
+func TestBodiesTracingHTTPTransportReturnsRequestDumpError(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	transport := WithBodiesTracingHTTPTransport{
+		underlying: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			called = true
+			return &http.Response{StatusCode: http.StatusOK}, nil
+		}),
+		debug: true,
+	}
+	req, err := http.NewRequest(http.MethodPost, "http://example.com", errorReadCloser{err: errors.New("read failed")})
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err = transport.RoundTrip(req)
+	})
+
+	require.ErrorContains(t, err, "dump http request")
+	require.False(t, called)
+}
+
+func TestBodiesTracingHTTPTransportClosesGetBodyRequestDump(t *testing.T) {
+	t.Parallel()
+
+	var closed atomic.Int32
+	transport := WithBodiesTracingHTTPTransport{
+		underlying: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       http.NoBody,
+			}, nil
+		}),
+		debug: true,
+	}
+	req, err := http.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("request body"))
+	require.NoError(t, err)
+	req.GetBody = func() (io.ReadCloser, error) {
+		return closeCountingReadCloser{
+			ReadCloser: io.NopCloser(strings.NewReader("request body")),
+			closed:     &closed,
+		}, nil
+	}
+
+	rsp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.Equal(t, int32(1), closed.Load())
+}
+
+func TestBodiesTracingHTTPTransportDoesNotPanicOnResponseDumpError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("read failed")
+	transport := WithBodiesTracingHTTPTransport{
+		underlying: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       &partialErrorReadCloser{data: []byte("partial body"), err: readErr},
+			}, nil
+		}),
+		debug: true,
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	var rsp *http.Response
+	require.NotPanics(t, func() {
+		rsp, err = transport.RoundTrip(req)
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, rsp.StatusCode)
+
+	body, err := io.ReadAll(rsp.Body)
+	require.ErrorIs(t, err, readErr)
+	require.Equal(t, "partial body", string(body))
+}
+
+func TestBodiesTracingHTTPTransportDumpsErrorResponseWhenDebugDisabled(t *testing.T) {
+	t.Parallel()
+
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		require.NoError(t, tracerProvider.Shutdown(context.Background()))
+	})
+
+	ctx, span := tracerProvider.Tracer("test").Start(context.Background(), "request")
+	transport := WithBodiesTracingHTTPTransport{
+		underlying: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "500 Internal Server Error",
+				StatusCode: http.StatusInternalServerError,
+				Header: http.Header{
+					"Set-Cookie": []string{"session=secret"},
+				},
+				Body: io.NopCloser(strings.NewReader("failed")),
+			}, nil
+		}),
+		debug: false,
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer secret")
+
+	rsp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "failed", string(body))
+	span.End()
+
+	attrs := recordedSpanAttributes(t, spanRecorder)
+	require.Contains(t, attrs["raw-request"].AsString(), "GET / HTTP/1.1")
+	require.Contains(t, attrs["raw-request"].AsString(), "Authorization: [REDACTED]")
+	require.NotContains(t, attrs["raw-request"].AsString(), "Bearer secret")
+	require.Contains(t, attrs["raw-response"].AsString(), "500 Internal Server Error")
+	require.Contains(t, attrs["raw-response"].AsString(), "Set-Cookie: [REDACTED]")
+	require.Contains(t, attrs["raw-response"].AsString(), "failed")
+	require.NotContains(t, attrs["raw-response"].AsString(), "session=secret")
+}
+
+func recordedSpanAttributes(t *testing.T, spanRecorder *tracetest.SpanRecorder) map[string]attribute.Value {
+	t.Helper()
+
+	for _, span := range spanRecorder.Ended() {
+		attrs := make(map[string]attribute.Value, len(span.Attributes()))
+		for _, attr := range span.Attributes() {
+			attrs[string(attr.Key)] = attr.Value
+		}
+		if _, ok := attrs["raw-request"]; ok {
+			return attrs
+		}
+	}
+
+	t.Fatalf("recorded span with HTTP debug attributes not found")
+	return nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errorReadCloser struct {
+	err error
+}
+
+func (r errorReadCloser) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (r errorReadCloser) Close() error {
+	return nil
+}
+
+type partialErrorReadCloser struct {
+	data []byte
+	err  error
+}
+
+func (r *partialErrorReadCloser) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, r.err
+	}
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	return n, nil
+}
+
+func (r *partialErrorReadCloser) Close() error {
+	return nil
+}
+
+type closeCountingReadCloser struct {
+	io.ReadCloser
+	closed *atomic.Int32
+}
+
+func (r closeCountingReadCloser) Close() error {
+	r.closed.Add(1)
+	return r.ReadCloser.Close()
+}

--- a/pkg/observe/log/adapter_logrus.go
+++ b/pkg/observe/log/adapter_logrus.go
@@ -17,6 +17,8 @@ type LogrusLogger struct {
 		Debug(args ...any)
 		Infof(format string, args ...any)
 		Info(args ...any)
+		Warnf(format string, args ...any)
+		Warn(args ...any)
 		Errorf(format string, args ...any)
 		Error(args ...any)
 		WithFields(fields logrus.Fields) *logrus.Entry
@@ -55,6 +57,12 @@ func (l *LogrusLogger) Infof(fmt string, args ...any) {
 }
 func (l *LogrusLogger) Info(args ...any) {
 	l.entry.Info(args...)
+}
+func (l *LogrusLogger) Warnf(fmt string, args ...any) {
+	l.entry.Warnf(fmt, args...)
+}
+func (l *LogrusLogger) Warn(args ...any) {
+	l.entry.Warn(args...)
 }
 func (l *LogrusLogger) Errorf(fmt string, args ...any) {
 	l.entry.Errorf(fmt, args...)

--- a/pkg/observe/log/adapter_zap_logger.go
+++ b/pkg/observe/log/adapter_zap_logger.go
@@ -42,9 +42,11 @@ func (z *ZapLogger) Tracef(format string, args ...any) {
 func (z *ZapLogger) Trace(args ...any)                 { z.sugar.Log(zapTraceLevel, args...) }
 func (z *ZapLogger) Debugf(format string, args ...any) { z.sugar.Debugf(format, args...) }
 func (z *ZapLogger) Infof(format string, args ...any)  { z.sugar.Infof(format, args...) }
+func (z *ZapLogger) Warnf(format string, args ...any)  { z.sugar.Warnf(format, args...) }
 func (z *ZapLogger) Errorf(format string, args ...any) { z.sugar.Errorf(format, args...) }
 func (z *ZapLogger) Debug(args ...any)                 { z.sugar.Debug(args...) }
 func (z *ZapLogger) Info(args ...any)                  { z.sugar.Info(args...) }
+func (z *ZapLogger) Warn(args ...any)                  { z.sugar.Warn(args...) }
 func (z *ZapLogger) Error(args ...any)                 { z.sugar.Error(args...) }
 
 func (z *ZapLogger) Enabled(level Level) bool {

--- a/pkg/service/flags.go
+++ b/pkg/service/flags.go
@@ -21,6 +21,10 @@ func BindEnvToFlagSet(set *pflag.FlagSet) {
 	set.VisitAll(func(flag *pflag.Flag) {
 		envVar := strings.ToUpper(flag.Name)
 		envVar = strings.Replace(envVar, "-", "_", -1)
+		// DEBUG is commonly set by tooling and shells; keep debug mode explicit.
+		if flag.Name == DebugFlag && envVar == "DEBUG" {
+			return
+		}
 		value := os.Getenv(envVar)
 		if value == "" {
 			return
@@ -33,9 +37,8 @@ func BindEnvToFlagSet(set *pflag.FlagSet) {
 			}
 		}
 
-		err := set.Set(flag.Name, value)
-		if err != nil {
-			panic(err)
+		if err := set.Set(flag.Name, value); err != nil {
+			return
 		}
 	})
 }

--- a/pkg/service/flags_test.go
+++ b/pkg/service/flags_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFlags(t *testing.T) {
@@ -42,4 +44,45 @@ func TestFlags(t *testing.T) {
 	}
 
 	fmt.Println(command.Flags().GetString("root1"))
+}
+
+func TestBindEnvToFlagSetDoesNotEnableDebugFromBareDebugEnv(t *testing.T) {
+	t.Setenv("DEBUG", "1")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool(DebugFlag, false, "")
+
+	BindEnvToFlagSet(flags)
+
+	debug, err := flags.GetBool(DebugFlag)
+	require.NoError(t, err)
+	require.False(t, debug)
+}
+
+func TestBindEnvToFlagSetStillBindsNonDebugEnv(t *testing.T) {
+	t.Setenv("ROOT1", "changed")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("root1", "default", "")
+
+	BindEnvToFlagSet(flags)
+
+	root1, err := flags.GetString("root1")
+	require.NoError(t, err)
+	require.Equal(t, "changed", root1)
+}
+
+func TestBindEnvToFlagSetIgnoresInvalidEnvValue(t *testing.T) {
+	t.Setenv("ENABLED", "not-a-bool")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool("enabled", false, "")
+
+	require.NotPanics(t, func() {
+		BindEnvToFlagSet(flags)
+	})
+
+	enabled, err := flags.GetBool("enabled")
+	require.NoError(t, err)
+	require.False(t, enabled)
 }

--- a/pkg/transport/httpclient/debug.go
+++ b/pkg/transport/httpclient/debug.go
@@ -1,8 +1,12 @@
 package httpclient
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"net/http"
-	"net/http/httputil"
+	"sort"
+	"strings"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
@@ -12,22 +16,29 @@ type httpTransport struct {
 }
 
 func (h httpTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	data, err := httputil.DumpRequest(request, true)
-	if err != nil {
-		panic(err)
+	logger := logging.FromContext(request.Context())
+	debugEnabled := logger.Enabled(logging.DebugLevel)
+	if debugEnabled {
+		data, err := dumpRequest(request, true)
+		if err != nil {
+			return nil, fmt.Errorf("dump http request: %w", err)
+		}
+		logger.Debug(string(data))
 	}
-	logging.FromContext(request.Context()).Debug(string(data))
 
 	rsp, err := h.underlying.RoundTrip(request)
 	if err != nil {
 		return nil, err
 	}
 
-	data, err = httputil.DumpResponse(rsp, true)
-	if err != nil {
-		panic(err)
+	if debugEnabled {
+		data, err := dumpResponse(rsp, true)
+		if err != nil {
+			logger.Debugf("failed to dump HTTP response: %v", err)
+			return rsp, nil
+		}
+		logger.Debug(string(data))
 	}
-	logging.FromContext(request.Context()).Debug(string(data))
 
 	return rsp, nil
 }
@@ -37,5 +48,147 @@ var _ http.RoundTripper = &httpTransport{}
 func NewDebugHTTPTransport(underlying http.RoundTripper) *httpTransport {
 	return &httpTransport{
 		underlying: underlying,
+	}
+}
+
+func dumpRequest(req *http.Request, includeBody bool) ([]byte, error) {
+	var builder strings.Builder
+	uri := req.URL.RequestURI()
+	if uri == "" {
+		uri = "/"
+	}
+	fmt.Fprintf(&builder, "%s %s %s\r\n", req.Method, uri, req.Proto)
+	if req.Host != "" {
+		fmt.Fprintf(&builder, "Host: %s\r\n", req.Host)
+	}
+	writeSanitizedHeaders(&builder, req.Header)
+	builder.WriteString("\r\n")
+
+	if !includeBody {
+		return []byte(builder.String()), nil
+	}
+
+	if req.Body == nil || req.Body == http.NoBody {
+		return []byte(builder.String()), nil
+	}
+
+	var data []byte
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		data, err = io.ReadAll(body)
+		closeErr := body.Close()
+		if err != nil {
+			return nil, err
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+	} else {
+		var readErr error
+		data, readErr = io.ReadAll(req.Body)
+		closeErr := req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(data))
+		if readErr != nil {
+			return nil, readErr
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+	}
+
+	builder.Write(data)
+	return []byte(builder.String()), nil
+}
+
+func dumpResponse(rsp *http.Response, includeBody bool) ([]byte, error) {
+	var builder strings.Builder
+	proto := rsp.Proto
+	if proto == "" {
+		proto = "HTTP/1.1"
+	}
+	status := rsp.Status
+	if status == "" {
+		status = fmt.Sprintf("%03d %s", rsp.StatusCode, http.StatusText(rsp.StatusCode))
+	}
+	fmt.Fprintf(&builder, "%s %s\r\n", proto, status)
+	writeSanitizedHeaders(&builder, rsp.Header)
+	builder.WriteString("\r\n")
+
+	if !includeBody || rsp.Body == nil || rsp.Body == http.NoBody {
+		return []byte(builder.String()), nil
+	}
+
+	contentLength := rsp.ContentLength
+	data, err := io.ReadAll(rsp.Body)
+	closeErr := rsp.Body.Close()
+	rsp.Body = newReplayReadCloser(data, err, closeErr)
+	rsp.ContentLength = contentLength
+	if err != nil {
+		return nil, err
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	builder.Write(data)
+	return []byte(builder.String()), nil
+}
+
+func newReplayReadCloser(data []byte, readErr, closeErr error) io.ReadCloser {
+	if readErr == nil && closeErr == nil {
+		return io.NopCloser(bytes.NewReader(data))
+	}
+	return &replayReadCloser{
+		reader:   bytes.NewReader(data),
+		readErr:  readErr,
+		closeErr: closeErr,
+	}
+}
+
+type replayReadCloser struct {
+	reader   *bytes.Reader
+	readErr  error
+	closeErr error
+}
+
+func (r *replayReadCloser) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if err == io.EOF && r.readErr != nil {
+		err = r.readErr
+	}
+	return n, err
+}
+
+func (r *replayReadCloser) Close() error {
+	return r.closeErr
+}
+
+func writeSanitizedHeaders(builder *strings.Builder, headers http.Header) {
+	names := make([]string, 0, len(headers))
+	for name := range headers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		// Debug logs only expose header presence; trace instrumentation can use
+		// different sanitization because it goes through controlled backends.
+		value := "[present]"
+		if isSensitiveHeader(name) {
+			value = "[REDACTED]"
+		}
+		fmt.Fprintf(builder, "%s: %s\r\n", name, value)
+	}
+}
+
+func isSensitiveHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "authorization", "cookie", "proxy-authorization", "set-cookie":
+		return true
+	default:
+		return false
 	}
 }

--- a/pkg/transport/httpclient/debug_test.go
+++ b/pkg/transport/httpclient/debug_test.go
@@ -1,0 +1,140 @@
+package httpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestDebugHTTPTransportSkipsDumpWhenDebugDisabled(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", errorReadCloser{err: errors.New("body should not be read")})
+	require.NoError(t, err)
+
+	rsp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.Empty(t, logger.debugMessages)
+}
+
+func TestDebugHTTPTransportRedactsAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{debugEnabled: true}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("response body")),
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", strings.NewReader("request body"))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer secret-token")
+
+	rsp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "response body", string(body))
+
+	logs := strings.Join(logger.debugMessages, "\n")
+	require.Contains(t, logs, "Authorization: [REDACTED]")
+	require.NotContains(t, logs, "Bearer secret-token")
+}
+
+func TestDebugHTTPTransportDoesNotPanicOnResponseDumpError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("read failed")
+	logger := &recordingLogger{debugEnabled: true}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       errorReadCloser{err: readErr},
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	var rsp *http.Response
+	require.NotPanics(t, func() {
+		rsp, err = transport.RoundTrip(req)
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.Contains(t, strings.Join(logger.debugMessages, "\n"), "failed to dump HTTP response")
+
+	_, err = io.ReadAll(rsp.Body)
+	require.ErrorIs(t, err, readErr)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errorReadCloser struct {
+	err error
+}
+
+func (r errorReadCloser) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (r errorReadCloser) Close() error {
+	return nil
+}
+
+type recordingLogger struct {
+	debugEnabled  bool
+	debugMessages []string
+}
+
+func (l *recordingLogger) Tracef(string, ...any) {}
+func (l *recordingLogger) Debugf(format string, args ...any) {
+	l.debugMessages = append(l.debugMessages, fmt.Sprintf(format, args...))
+}
+func (l *recordingLogger) Infof(string, ...any)  {}
+func (l *recordingLogger) Errorf(string, ...any) {}
+func (l *recordingLogger) Trace(...any)          {}
+func (l *recordingLogger) Debug(args ...any) {
+	l.debugMessages = append(l.debugMessages, fmt.Sprint(args...))
+}
+func (l *recordingLogger) Info(...any)  {}
+func (l *recordingLogger) Error(...any) {}
+func (l *recordingLogger) WithFields(map[string]any) logging.Logger {
+	return l
+}
+func (l *recordingLogger) WithField(string, any) logging.Logger {
+	return l
+}
+func (l *recordingLogger) WithContext(context.Context) logging.Logger {
+	return l
+}
+func (l *recordingLogger) Writer() io.Writer {
+	return io.Discard
+}
+func (l *recordingLogger) Enabled(level logging.Level) bool {
+	return l.debugEnabled && level == logging.DebugLevel
+}

--- a/pkg/transport/httpserver/middlewares.go
+++ b/pkg/transport/httpserver/middlewares.go
@@ -47,6 +47,8 @@ func LoggerMiddleware(l logging.Logger, opts ...Option) func(h http.Handler) htt
 			method := r.Method
 			path := r.URL.Path
 
+			// httpsnoop defaults Code to StatusOK when the handler returns
+			// without writing, matching net/http's implicit 200 response.
 			metrics := httpsnoop.CaptureMetrics(h, w, r)
 			statusCode := metrics.Code
 			latency := time.Since(start)

--- a/pkg/transport/httpserver/middlewares.go
+++ b/pkg/transport/httpserver/middlewares.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/felixge/httpsnoop"
+
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
@@ -14,6 +16,10 @@ type loggingResponseWriter struct {
 
 func NewLoggingResponseWriter(w http.ResponseWriter) *loggingResponseWriter {
 	return &loggingResponseWriter{w, http.StatusOK}
+}
+
+func (lrw *loggingResponseWriter) Unwrap() http.ResponseWriter {
+	return lrw.ResponseWriter
 }
 
 func (lrw *loggingResponseWriter) WriteHeader(statusCode int) {
@@ -37,12 +43,12 @@ func LoggerMiddleware(l logging.Logger, opts ...Option) func(h http.Handler) htt
 			start := time.Now()
 			logger := logging.FromContext(r.Context())
 
-			rec := NewLoggingResponseWriter(w)
 			// copy
 			method := r.Method
 			path := r.URL.Path
 
-			h.ServeHTTP(rec, r)
+			metrics := httpsnoop.CaptureMetrics(h, w, r)
+			statusCode := metrics.Code
 			latency := time.Since(start)
 
 			logger = logger.WithFields(map[string]interface{}{
@@ -50,9 +56,9 @@ func LoggerMiddleware(l logging.Logger, opts ...Option) func(h http.Handler) htt
 				"path":       path,
 				"latency":    latency,
 				"user_agent": r.UserAgent(),
-				"status":     rec.statusCode,
+				"status":     statusCode,
 			})
-			if rec.statusCode >= 400 {
+			if statusCode >= 400 {
 				logger.Error("Request")
 			} else {
 				logger.Info("Request")

--- a/pkg/transport/httpserver/otlp_middleware.go
+++ b/pkg/transport/httpserver/otlp_middleware.go
@@ -5,53 +5,204 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
+	"github.com/felixge/httpsnoop"
 	"github.com/riandyrn/otelchi"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	debugBodyAttributeLimit   = 64 * 1024
+	debugHeaderAttributeLimit = 8 * 1024
+	debugRedactedValue        = "[REDACTED]"
+)
+
 type responseWriter struct {
-	http.ResponseWriter
-	data        []byte
-	statusCode  int
-	captureBody bool
+	data          []byte
+	statusCode    int
+	captureBody   bool
+	bodyLimit     int
+	bodyTruncated bool
+	wroteHeader   bool
 }
 
-func (w *responseWriter) WriteHeader(code int) {
+func (w *responseWriter) wrap(writer http.ResponseWriter) http.ResponseWriter {
+	return httpsnoop.Wrap(writer, httpsnoop.Hooks{
+		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(code int) {
+				if w.writeHeader(code) {
+					next(code)
+				}
+			}
+		},
+		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(data []byte) (int, error) {
+				w.write()
+
+				n, err := next(data)
+				if w.captureBody && n > 0 {
+					w.capture(data[:n])
+				}
+				return n, err
+			}
+		},
+		Flush: func(next httpsnoop.FlushFunc) httpsnoop.FlushFunc {
+			return func() {
+				w.write()
+				next()
+			}
+		},
+		ReadFrom: func(next httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+			return func(src io.Reader) (int64, error) {
+				w.write()
+				if w.captureBody {
+					src = &captureReader{
+						reader:  src,
+						capture: w.capture,
+					}
+				}
+				return next(src)
+			}
+		},
+	})
+}
+
+func (w *responseWriter) writeHeader(code int) bool {
+	if code == http.StatusSwitchingProtocols {
+		if w.wroteHeader {
+			return false
+		}
+		w.wroteHeader = true
+		w.statusCode = code
+		return true
+	}
+	if code >= 100 && code <= 199 {
+		return true
+	}
+	if w.wroteHeader {
+		return false
+	}
+
+	w.wroteHeader = true
 	w.statusCode = code
-	if !w.captureBody {
-		w.ResponseWriter.WriteHeader(code)
+	return true
+}
+
+func (w *responseWriter) write() {
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		w.statusCode = http.StatusOK
 	}
 }
 
-func (w *responseWriter) Write(data []byte) (int, error) {
-	if !w.captureBody {
-		return w.ResponseWriter.Write(data)
+func (w *responseWriter) capture(data []byte) {
+	if len(data) == 0 {
+		return
 	}
+
+	remaining := w.bodyLimit - len(w.data)
+	if remaining <= 0 {
+		w.bodyTruncated = true
+		return
+	}
+
+	if len(data) > remaining {
+		w.data = append(w.data, data[:remaining]...)
+		w.bodyTruncated = true
+		return
+	}
+
 	w.data = append(w.data, data...)
-	return len(data), nil
 }
 
-func (w *responseWriter) finalize() {
-	if !w.captureBody {
-		return
+type captureReader struct {
+	reader  io.Reader
+	capture func([]byte)
+}
+
+func (r *captureReader) Read(data []byte) (int, error) {
+	n, err := r.reader.Read(data)
+	if n > 0 {
+		r.capture(data[:n])
 	}
-	if w.statusCode != 0 {
-		w.ResponseWriter.WriteHeader(w.statusCode)
-	}
-	if len(w.data) == 0 {
-		return
-	}
-	_, err := w.ResponseWriter.Write(w.data)
-	if err != nil {
-		panic(err)
-	}
+	return n, err
 }
 
 func isJSONContent(contentType string) bool {
 	return strings.Contains(strings.ToLower(contentType), "application/json")
+}
+
+func formatDebugHeaders(headers http.Header, limit int) (string, bool) {
+	names := make([]string, 0, len(headers))
+	for name := range headers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var builder strings.Builder
+	for _, name := range names {
+		value := strings.Join(headers[name], ", ")
+		if isSensitiveHeader(name) {
+			value = debugRedactedValue
+		}
+
+		part := fmt.Sprintf("%s: %s", name, value)
+		if builder.Len() > 0 {
+			part = "\n" + part
+		}
+		if appendLimitedString(&builder, part, limit) {
+			return builder.String(), true
+		}
+	}
+
+	return builder.String(), false
+}
+
+func isSensitiveHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "authorization", "cookie", "proxy-authorization", "set-cookie":
+		return true
+	default:
+		return false
+	}
+}
+
+func appendLimitedString(builder *strings.Builder, value string, limit int) bool {
+	remaining := limit - builder.Len()
+	if remaining <= 0 {
+		return len(value) > 0
+	}
+	if len(value) > remaining {
+		builder.WriteString(value[:remaining])
+		return true
+	}
+	builder.WriteString(value)
+	return false
+}
+
+type bodyReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func captureDebugBody(body io.ReadCloser, limit int) ([]byte, bool, io.ReadCloser, error) {
+	data, err := io.ReadAll(io.LimitReader(body, int64(limit)+1))
+	replacement := &bodyReadCloser{
+		Reader: io.MultiReader(bytes.NewReader(data), body),
+		Closer: body,
+	}
+	if err != nil {
+		return nil, false, replacement, err
+	}
+
+	if len(data) > limit {
+		return data[:limit], true, replacement, nil
+	}
+
+	return data, false, replacement, nil
 }
 
 func OTLPMiddleware(serverName string, debug bool, opts ...Option) func(h http.Handler) http.Handler {
@@ -85,30 +236,40 @@ func OTLPMiddleware(serverName string, debug bool, opts ...Option) func(h http.H
 
 			if debug {
 				// Debug: request headers
-				headerParts := make([]string, 0, len(r.Header))
-				for name, values := range r.Header {
-					headerParts = append(headerParts, fmt.Sprintf("%s: %s", name, strings.Join(values, ", ")))
+				headers, truncated := formatDebugHeaders(r.Header, debugHeaderAttributeLimit)
+				span.SetAttributes(attribute.String("http.request.headers", headers))
+				if truncated {
+					span.SetAttributes(attribute.Bool("http.request.headers.truncated", true))
 				}
-				span.SetAttributes(attribute.String("http.request.headers", strings.Join(headerParts, "\n")))
 
 				// Debug: request body (JSON only)
 				if captureBody && r.Body != nil {
-					body, err := io.ReadAll(r.Body)
+					body, truncated, replacement, err := captureDebugBody(r.Body, debugBodyAttributeLimit)
+					r.Body = replacement
 					if err == nil {
 						span.SetAttributes(attribute.String("http.request.body", string(body)))
-						r.Body = io.NopCloser(bytes.NewReader(body))
+						if truncated {
+							span.SetAttributes(attribute.Bool("http.request.body.truncated", true))
+						}
 					}
 				}
 			}
 
-			rw := &responseWriter{
-				ResponseWriter: w,
-				data:           make([]byte, 0, 1024),
-				captureBody:    captureBody,
+			if !debug {
+				metrics := httpsnoop.CaptureMetricsFn(w, func(w http.ResponseWriter) {
+					h.ServeHTTP(w, r)
+				})
+				span.SetAttributes(attribute.Int("http.response.status_code", metrics.Code))
+				return
 			}
-			defer func() {
-				rw.finalize()
 
+			rw := &responseWriter{
+				data:        make([]byte, 0, 1024),
+				captureBody: captureBody,
+				bodyLimit:   debugBodyAttributeLimit,
+			}
+			ww := rw.wrap(w)
+			defer func() {
 				// Always log status code
 				statusCode := rw.statusCode
 				if statusCode == 0 {
@@ -118,20 +279,23 @@ func OTLPMiddleware(serverName string, debug bool, opts ...Option) func(h http.H
 
 				if debug {
 					// Debug: response headers
-					respHeaderParts := make([]string, 0, len(rw.Header()))
-					for name, values := range rw.Header() {
-						respHeaderParts = append(respHeaderParts, fmt.Sprintf("%s: %s", name, strings.Join(values, ", ")))
+					headers, truncated := formatDebugHeaders(ww.Header(), debugHeaderAttributeLimit)
+					span.SetAttributes(attribute.String("http.response.headers", headers))
+					if truncated {
+						span.SetAttributes(attribute.Bool("http.response.headers.truncated", true))
 					}
-					span.SetAttributes(attribute.String("http.response.headers", strings.Join(respHeaderParts, "\n")))
 
 					// Debug: response body (only if we captured it, i.e. JSON content)
 					if captureBody && len(rw.data) > 0 {
 						span.SetAttributes(attribute.String("http.response.body", string(rw.data)))
+						if rw.bodyTruncated {
+							span.SetAttributes(attribute.Bool("http.response.body.truncated", true))
+						}
 					}
 				}
 			}()
 
-			h.ServeHTTP(rw, r)
+			h.ServeHTTP(ww, r)
 		}))
 	}
 }

--- a/pkg/transport/httpserver/otlp_middleware.go
+++ b/pkg/transport/httpserver/otlp_middleware.go
@@ -256,6 +256,8 @@ func OTLPMiddleware(serverName string, debug bool, opts ...Option) func(h http.H
 			}
 
 			if !debug {
+				// httpsnoop defaults Code to StatusOK when the handler returns
+				// without writing, matching net/http's implicit 200 response.
 				metrics := httpsnoop.CaptureMetricsFn(w, func(w http.ResponseWriter) {
 					h.ServeHTTP(w, r)
 				})

--- a/pkg/transport/httpserver/otlp_middleware.go
+++ b/pkg/transport/httpserver/otlp_middleware.go
@@ -190,19 +190,43 @@ type bodyReadCloser struct {
 
 func captureDebugBody(body io.ReadCloser, limit int) ([]byte, bool, io.ReadCloser, error) {
 	data, err := io.ReadAll(io.LimitReader(body, int64(limit)+1))
+	if err != nil {
+		replacement := &bodyReadCloser{
+			Reader: &readErrorReplayReader{
+				reader: bytes.NewReader(data),
+				err:    err,
+			},
+			Closer: body,
+		}
+		return nil, false, replacement, err
+	}
+
 	replacement := &bodyReadCloser{
 		Reader: io.MultiReader(bytes.NewReader(data), body),
 		Closer: body,
 	}
-	if err != nil {
-		return nil, false, replacement, err
-	}
-
 	if len(data) > limit {
 		return data[:limit], true, replacement, nil
 	}
 
 	return data, false, replacement, nil
+}
+
+type readErrorReplayReader struct {
+	reader      *bytes.Reader
+	err         error
+	errReturned bool
+}
+
+func (r *readErrorReplayReader) Read(data []byte) (int, error) {
+	if r.reader.Len() > 0 {
+		return r.reader.Read(data)
+	}
+	if !r.errReturned {
+		r.errReturned = true
+		return 0, r.err
+	}
+	return 0, io.EOF
 }
 
 func OTLPMiddleware(serverName string, debug bool, opts ...Option) func(h http.Handler) http.Handler {

--- a/pkg/transport/httpserver/otlp_middleware.go
+++ b/pkg/transport/httpserver/otlp_middleware.go
@@ -255,16 +255,6 @@ func OTLPMiddleware(serverName string, debug bool, opts ...Option) func(h http.H
 				}
 			}
 
-			if !debug {
-				// httpsnoop defaults Code to StatusOK when the handler returns
-				// without writing, matching net/http's implicit 200 response.
-				metrics := httpsnoop.CaptureMetricsFn(w, func(w http.ResponseWriter) {
-					h.ServeHTTP(w, r)
-				})
-				span.SetAttributes(attribute.Int("http.response.status_code", metrics.Code))
-				return
-			}
-
 			rw := &responseWriter{
 				data:        make([]byte, 0, 1024),
 				captureBody: captureBody,

--- a/pkg/transport/httpserver/otlp_middleware_test.go
+++ b/pkg/transport/httpserver/otlp_middleware_test.go
@@ -1,0 +1,314 @@
+package httpserver
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestOTLPMiddlewareDebugRedactsAndCapsTraceAttributes(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	previousTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(tracerProvider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousTracerProvider)
+		require.NoError(t, tracerProvider.Shutdown(context.Background()))
+	})
+
+	requestBody := `{"body":"` + strings.Repeat("a", debugBodyAttributeLimit+128) + `"}`
+	responseBody := `{"body":"` + strings.Repeat("b", debugBodyAttributeLimit+128) + `"}`
+
+	handler := OTLPMiddleware("test-server", true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, requestBody, string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Set-Cookie", "session=secret")
+		w.Header().Set("X-Large-Response", strings.Repeat("r", debugHeaderAttributeLimit))
+		w.WriteHeader(http.StatusAccepted)
+		_, err = w.Write([]byte(responseBody))
+		require.NoError(t, err)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test?debug=true", strings.NewReader(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Cookie", "session=secret")
+	req.Header.Set("X-Debug", "visible")
+	req.Header.Set("X-Large", strings.Repeat("h", debugHeaderAttributeLimit))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	require.Equal(t, responseBody, rec.Body.String())
+
+	attrs := recordedSpanAttributes(t, spanRecorder)
+
+	requestHeaders := attrs["http.request.headers"].AsString()
+	require.LessOrEqual(t, len(requestHeaders), debugHeaderAttributeLimit)
+	require.Contains(t, requestHeaders, "Authorization: "+debugRedactedValue)
+	require.Contains(t, requestHeaders, "Cookie: "+debugRedactedValue)
+	require.Contains(t, requestHeaders, "X-Debug: visible")
+	require.NotContains(t, requestHeaders, "Bearer secret")
+	require.NotContains(t, requestHeaders, "session=secret")
+	require.True(t, attrs["http.request.headers.truncated"].AsBool())
+
+	responseHeaders := attrs["http.response.headers"].AsString()
+	require.LessOrEqual(t, len(responseHeaders), debugHeaderAttributeLimit)
+	require.Contains(t, responseHeaders, "Set-Cookie: "+debugRedactedValue)
+	require.NotContains(t, responseHeaders, "session=secret")
+	require.True(t, attrs["http.response.headers.truncated"].AsBool())
+
+	require.Equal(t, requestBody[:debugBodyAttributeLimit], attrs["http.request.body"].AsString())
+	require.True(t, attrs["http.request.body.truncated"].AsBool())
+	require.Equal(t, responseBody[:debugBodyAttributeLimit], attrs["http.response.body"].AsString())
+	require.True(t, attrs["http.response.body.truncated"].AsBool())
+}
+
+func TestOTLPMiddlewareDebugDoesNotPanicOnResponseWriteError(t *testing.T) {
+	handler := OTLPMiddleware("test-server", true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"ok":true}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	require.NotPanics(t, func() {
+		handler.ServeHTTP(&failingResponseWriter{header: make(http.Header)}, req)
+	})
+}
+
+func TestOTLPMiddlewareDebugRecordsSwitchingProtocolsStatus(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	previousTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(tracerProvider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousTracerProvider)
+		require.NoError(t, tracerProvider.Shutdown(context.Background()))
+	})
+
+	handler := OTLPMiddleware("test-server", true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusSwitchingProtocols)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/upgrade", nil))
+
+	require.Equal(t, http.StatusSwitchingProtocols, rec.Code)
+	attrs := recordedSpanAttributes(t, spanRecorder)
+	require.Equal(t, int64(http.StatusSwitchingProtocols), attrs["http.response.status_code"].AsInt64())
+}
+
+func TestOTLPMiddlewarePreservesResponseWriterInterfaces(t *testing.T) {
+	for _, debug := range []bool{false, true} {
+		t.Run(debugName(debug), func(t *testing.T) {
+			base := newOptionalResponseWriter()
+			handler := OTLPMiddleware("test-server", debug)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertOptionalResponseWriterInterfaces(t, w)
+			}))
+
+			handler.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+			require.Equal(t, 1, base.flushes)
+			require.Equal(t, 1, base.pushes)
+			require.Equal(t, "/events", base.pushTarget)
+			require.Equal(t, 1, base.hijacks)
+			require.Equal(t, testWriteDeadline, base.writeDeadline)
+		})
+	}
+}
+
+func TestOTLPMiddlewareDoesNotAdvertiseUnsupportedResponseWriterInterfaces(t *testing.T) {
+	for _, debug := range []bool{false, true} {
+		t.Run(debugName(debug), func(t *testing.T) {
+			handler := OTLPMiddleware("test-server", debug)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertNoOptionalResponseWriterInterfaces(t, w)
+			}))
+
+			handler.ServeHTTP(newPlainResponseWriter(), httptest.NewRequest(http.MethodGet, "/test", nil))
+		})
+	}
+}
+
+func TestLoggerMiddlewarePreservesResponseWriterInterfaces(t *testing.T) {
+	base := newOptionalResponseWriter()
+	handler := LoggerMiddleware(logging.Testing())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertOptionalResponseWriterInterfaces(t, w)
+	}))
+
+	handler.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	require.Equal(t, 1, base.flushes)
+	require.Equal(t, 1, base.pushes)
+	require.Equal(t, "/events", base.pushTarget)
+	require.Equal(t, 1, base.hijacks)
+	require.Equal(t, testWriteDeadline, base.writeDeadline)
+}
+
+func TestLoggingResponseWriterUnwrapsForResponseController(t *testing.T) {
+	base := newOptionalResponseWriter()
+	controller := http.NewResponseController(NewLoggingResponseWriter(base))
+
+	require.NoError(t, controller.Flush())
+	require.NoError(t, controller.SetWriteDeadline(testWriteDeadline))
+
+	require.Equal(t, 1, base.flushes)
+	require.Equal(t, testWriteDeadline, base.writeDeadline)
+}
+
+func recordedSpanAttributes(t *testing.T, spanRecorder *tracetest.SpanRecorder) map[string]attribute.Value {
+	t.Helper()
+
+	for _, span := range spanRecorder.Ended() {
+		attrs := make(map[string]attribute.Value, len(span.Attributes()))
+		for _, attr := range span.Attributes() {
+			attrs[string(attr.Key)] = attr.Value
+		}
+		if _, ok := attrs["http.request.headers"]; ok {
+			return attrs
+		}
+	}
+
+	t.Fatalf("recorded span with OTLP debug attributes not found")
+	return nil
+}
+
+func debugName(debug bool) string {
+	if debug {
+		return "debug=true"
+	}
+	return "debug=false"
+}
+
+func assertOptionalResponseWriterInterfaces(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+
+	flusher, ok := w.(http.Flusher)
+	require.True(t, ok)
+	flusher.Flush()
+
+	pusher, ok := w.(http.Pusher)
+	require.True(t, ok)
+	require.NoError(t, pusher.Push("/events", nil))
+
+	require.NoError(t, http.NewResponseController(w).SetWriteDeadline(testWriteDeadline))
+
+	hijacker, ok := w.(http.Hijacker)
+	require.True(t, ok)
+	_, _, err := hijacker.Hijack()
+	require.ErrorIs(t, err, errTestHijack)
+}
+
+func assertNoOptionalResponseWriterInterfaces(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+
+	_, ok := w.(http.Flusher)
+	require.False(t, ok)
+	_, ok = w.(http.Hijacker)
+	require.False(t, ok)
+	_, ok = w.(http.Pusher)
+	require.False(t, ok)
+}
+
+var (
+	errTestHijack     = errors.New("test hijack")
+	testWriteDeadline = time.Unix(123, 0)
+)
+
+type optionalResponseWriter struct {
+	header        http.Header
+	flushes       int
+	hijacks       int
+	pushes        int
+	pushTarget    string
+	writeDeadline time.Time
+}
+
+func newOptionalResponseWriter() *optionalResponseWriter {
+	return &optionalResponseWriter{
+		header: make(http.Header),
+	}
+}
+
+func (w *optionalResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *optionalResponseWriter) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (w *optionalResponseWriter) WriteHeader(int) {}
+
+func (w *optionalResponseWriter) Flush() {
+	w.flushes++
+}
+
+func (w *optionalResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	w.hijacks++
+	return nil, nil, errTestHijack
+}
+
+func (w *optionalResponseWriter) Push(target string, _ *http.PushOptions) error {
+	w.pushes++
+	w.pushTarget = target
+	return nil
+}
+
+func (w *optionalResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	w.writeDeadline = deadline
+	return nil
+}
+
+type plainResponseWriter struct {
+	header http.Header
+}
+
+func newPlainResponseWriter() *plainResponseWriter {
+	return &plainResponseWriter{
+		header: make(http.Header),
+	}
+}
+
+func (w *plainResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *plainResponseWriter) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (w *plainResponseWriter) WriteHeader(int) {}
+
+type failingResponseWriter struct {
+	header http.Header
+}
+
+func (w *failingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingResponseWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func (w *failingResponseWriter) WriteHeader(int) {}

--- a/pkg/transport/httpserver/otlp_middleware_test.go
+++ b/pkg/transport/httpserver/otlp_middleware_test.go
@@ -96,6 +96,28 @@ func TestOTLPMiddlewareDebugDoesNotPanicOnResponseWriteError(t *testing.T) {
 	})
 }
 
+func TestOTLPMiddlewareDebugPreservesRequestBodyReadError(t *testing.T) {
+	readErr := errors.New("request read failed")
+	requestBody := `{"partial":`
+	handler := OTLPMiddleware("test-server", true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.ErrorIs(t, err, readErr)
+		require.Equal(t, requestBody, string(body))
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", &partialErrorReadCloser{
+		data: []byte(requestBody),
+		err:  readErr,
+	})
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestOTLPMiddlewareRecordsSwitchingProtocolsStatus(t *testing.T) {
 	for _, debug := range []bool{false, true} {
 		t.Run(debugName(debug), func(t *testing.T) {
@@ -355,3 +377,21 @@ func (w *failingResponseWriter) Write([]byte) (int, error) {
 }
 
 func (w *failingResponseWriter) WriteHeader(int) {}
+
+type partialErrorReadCloser struct {
+	data []byte
+	err  error
+}
+
+func (r *partialErrorReadCloser) Read(data []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, r.err
+	}
+	n := copy(data, r.data)
+	r.data = r.data[n:]
+	return n, nil
+}
+
+func (r *partialErrorReadCloser) Close() error {
+	return nil
+}

--- a/pkg/transport/httpserver/otlp_middleware_test.go
+++ b/pkg/transport/httpserver/otlp_middleware_test.go
@@ -96,26 +96,31 @@ func TestOTLPMiddlewareDebugDoesNotPanicOnResponseWriteError(t *testing.T) {
 	})
 }
 
-func TestOTLPMiddlewareDebugRecordsSwitchingProtocolsStatus(t *testing.T) {
-	spanRecorder := tracetest.NewSpanRecorder()
-	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
-	previousTracerProvider := otel.GetTracerProvider()
-	otel.SetTracerProvider(tracerProvider)
-	t.Cleanup(func() {
-		otel.SetTracerProvider(previousTracerProvider)
-		require.NoError(t, tracerProvider.Shutdown(context.Background()))
-	})
+func TestOTLPMiddlewareRecordsSwitchingProtocolsStatus(t *testing.T) {
+	for _, debug := range []bool{false, true} {
+		t.Run(debugName(debug), func(t *testing.T) {
+			spanRecorder := tracetest.NewSpanRecorder()
+			tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+			previousTracerProvider := otel.GetTracerProvider()
+			otel.SetTracerProvider(tracerProvider)
+			t.Cleanup(func() {
+				otel.SetTracerProvider(previousTracerProvider)
+				require.NoError(t, tracerProvider.Shutdown(context.Background()))
+			})
 
-	handler := OTLPMiddleware("test-server", true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusSwitchingProtocols)
-	}))
+			handler := OTLPMiddleware("test-server", debug)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusSwitchingProtocols)
+			}))
 
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/upgrade", nil))
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/upgrade", nil))
+			require.NoError(t, tracerProvider.ForceFlush(context.Background()))
 
-	require.Equal(t, http.StatusSwitchingProtocols, rec.Code)
-	attrs := recordedSpanAttributes(t, spanRecorder)
-	require.Equal(t, int64(http.StatusSwitchingProtocols), attrs["http.response.status_code"].AsInt64())
+			require.Equal(t, http.StatusSwitchingProtocols, rec.Code)
+			attrs := recordedSpanAttributesWithKey(t, spanRecorder, "http.response.status_code")
+			require.Equal(t, int64(http.StatusSwitchingProtocols), attrs["http.response.status_code"].AsInt64())
+		})
+	}
 }
 
 func TestOTLPMiddlewareNonDebugRecordsImplicitOKStatus(t *testing.T) {

--- a/pkg/transport/httpserver/otlp_middleware_test.go
+++ b/pkg/transport/httpserver/otlp_middleware_test.go
@@ -118,6 +118,27 @@ func TestOTLPMiddlewareDebugRecordsSwitchingProtocolsStatus(t *testing.T) {
 	require.Equal(t, int64(http.StatusSwitchingProtocols), attrs["http.response.status_code"].AsInt64())
 }
 
+func TestOTLPMiddlewareNonDebugRecordsImplicitOKStatus(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	previousTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(tracerProvider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousTracerProvider)
+		require.NoError(t, tracerProvider.Shutdown(context.Background()))
+	})
+
+	handler := OTLPMiddleware("test-server", false)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/empty", nil))
+	require.NoError(t, tracerProvider.ForceFlush(context.Background()))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	attrs := recordedSpanAttributesWithKey(t, spanRecorder, "http.response.status_code")
+	require.Equal(t, int64(http.StatusOK), attrs["http.response.status_code"].AsInt64())
+}
+
 func TestOTLPMiddlewarePreservesResponseWriterInterfaces(t *testing.T) {
 	for _, debug := range []bool{false, true} {
 		t.Run(debugName(debug), func(t *testing.T) {
@@ -175,7 +196,24 @@ func TestLoggingResponseWriterUnwrapsForResponseController(t *testing.T) {
 	require.Equal(t, testWriteDeadline, base.writeDeadline)
 }
 
+func TestLoggerMiddlewareRecordsImplicitOKStatus(t *testing.T) {
+	buf := &safeBuffer{}
+	logger := logging.NewDefaultLogger(buf, false, false, false)
+	handler := LoggerMiddleware(logger)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/empty", nil))
+
+	require.Contains(t, buf.String(), "status=200")
+	require.NotContains(t, buf.String(), "status=0")
+}
+
 func recordedSpanAttributes(t *testing.T, spanRecorder *tracetest.SpanRecorder) map[string]attribute.Value {
+	t.Helper()
+
+	return recordedSpanAttributesWithKey(t, spanRecorder, "http.request.headers")
+}
+
+func recordedSpanAttributesWithKey(t *testing.T, spanRecorder *tracetest.SpanRecorder, key string) map[string]attribute.Value {
 	t.Helper()
 
 	for _, span := range spanRecorder.Ended() {
@@ -183,12 +221,12 @@ func recordedSpanAttributes(t *testing.T, spanRecorder *tracetest.SpanRecorder) 
 		for _, attr := range span.Attributes() {
 			attrs[string(attr.Key)] = attr.Value
 		}
-		if _, ok := attrs["http.request.headers"]; ok {
+		if _, ok := attrs[key]; ok {
 			return attrs
 		}
 	}
 
-	t.Fatalf("recorded span with OTLP debug attributes not found")
+	t.Fatalf("recorded span with %s attribute not found", key)
 	return nil
 }
 

--- a/pkg/transport/httpserver/serverport.go
+++ b/pkg/transport/httpserver/serverport.go
@@ -38,7 +38,6 @@ func startServer(ctx context.Context, s *serverport.Server, handler http.Handler
 	srv := &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
-		ReadTimeout:       30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
 	for _, option := range options {

--- a/pkg/transport/httpserver/serverport.go
+++ b/pkg/transport/httpserver/serverport.go
@@ -38,6 +38,8 @@ func startServer(ctx context.Context, s *serverport.Server, handler http.Handler
 	srv := &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 	for _, option := range options {
 		option(srv)

--- a/pkg/transport/httpserver/serverport_test.go
+++ b/pkg/transport/httpserver/serverport_test.go
@@ -120,7 +120,33 @@ func TestStartServerSetsDefaultTimeouts(t *testing.T) {
 	})
 
 	require.Equal(t, 10*time.Second, configured.readHeaderTimeout)
-	require.Equal(t, 30*time.Second, configured.readTimeout)
+	require.Zero(t, configured.readTimeout)
 	require.Zero(t, configured.writeTimeout)
 	require.Equal(t, 120*time.Second, configured.idleTimeout)
+}
+
+func TestStartServerAllowsReadTimeoutOverride(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := serverport.NewServer(serverPortDiscr, serverport.WithListener(listener))
+	var configured time.Duration
+
+	stop, err := startServer(
+		logging.TestingContext(),
+		server,
+		http.NewServeMux(),
+		func(server *http.Server) {
+			server.ReadTimeout = time.Minute
+			configured = server.ReadTimeout
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = stop(context.Background())
+	})
+
+	require.Equal(t, time.Minute, configured)
 }

--- a/pkg/transport/httpserver/serverport_test.go
+++ b/pkg/transport/httpserver/serverport_test.go
@@ -88,3 +88,39 @@ func TestStartServerGracefulShutdownDoesNotLogError(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	require.NotContains(t, buf.String(), "failed to serve")
 }
+
+func TestStartServerSetsDefaultTimeouts(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := serverport.NewServer(serverPortDiscr, serverport.WithListener(listener))
+	var configured struct {
+		readHeaderTimeout time.Duration
+		readTimeout       time.Duration
+		writeTimeout      time.Duration
+		idleTimeout       time.Duration
+	}
+
+	stop, err := startServer(
+		logging.TestingContext(),
+		server,
+		http.NewServeMux(),
+		func(server *http.Server) {
+			configured.readHeaderTimeout = server.ReadHeaderTimeout
+			configured.readTimeout = server.ReadTimeout
+			configured.writeTimeout = server.WriteTimeout
+			configured.idleTimeout = server.IdleTimeout
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = stop(context.Background())
+	})
+
+	require.Equal(t, 10*time.Second, configured.readHeaderTimeout)
+	require.Equal(t, 30*time.Second, configured.readTimeout)
+	require.Zero(t, configured.writeTimeout)
+	require.Equal(t, 120*time.Second, configured.idleTimeout)
+}

--- a/pkg/transport/serverport/serverport.go
+++ b/pkg/transport/serverport/serverport.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync"
 )
 
 type ServerInfo struct {
-	started chan struct{}
-	address string
+	started     chan struct{}
+	startedOnce sync.Once
+	address     string
 }
 
 type serverInfoContextKey string
@@ -49,9 +51,10 @@ func StartedServer(ctx context.Context, listener net.Listener, discr string) {
 		return
 	}
 
-	si.address = listener.Addr().String()
-
-	close(si.started)
+	si.startedOnce.Do(func() {
+		si.address = listener.Addr().String()
+		close(si.started)
+	})
 }
 
 type Server struct {

--- a/pkg/transport/serverport/serverport_test.go
+++ b/pkg/transport/serverport/serverport_test.go
@@ -1,0 +1,75 @@
+package serverport
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartedServerCanBeCalledMoreThanOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := ContextWithServerInfo(context.Background(), "test")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	require.NotPanics(t, func() {
+		StartedServer(ctx, listener, "test")
+		StartedServer(ctx, listener, "test")
+	})
+
+	select {
+	case <-Started(ctx, "test"):
+	default:
+		t.Fatal("server start channel was not closed")
+	}
+	require.Equal(t, listener.Addr().String(), Address(ctx, "test"))
+}
+
+func TestStartedServerCanBeCalledConcurrently(t *testing.T) {
+	t.Parallel()
+
+	ctx := ContextWithServerInfo(context.Background(), "test")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	panicCh := make(chan any, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panicCh <- r
+				}
+			}()
+			<-start
+			StartedServer(ctx, listener, "test")
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	select {
+	case p := <-panicCh:
+		t.Fatalf("StartedServer panicked under concurrent calls: %v", p)
+	default:
+	}
+	select {
+	case <-Started(ctx, "test"):
+	default:
+		t.Fatal("server start channel was not closed")
+	}
+	require.Equal(t, listener.Addr().String(), Address(ctx, "test"))
+}

--- a/pkg/types/collections/linked_list.go
+++ b/pkg/types/collections/linked_list.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"reflect"
 	"sync"
 )
 
@@ -19,6 +20,23 @@ func (n *LinkedListNode[T]) Value() T {
 }
 
 func (n *LinkedListNode[T]) Remove() {
+	if n == nil || n.list == nil {
+		return
+	}
+	list := n.list
+	list.mu.Lock()
+	defer list.mu.Unlock()
+	if n.list != list || !list.containsNodeLocked(n) {
+		return
+	}
+
+	n.remove()
+}
+
+func (n *LinkedListNode[T]) remove() {
+	if n.list == nil {
+		return
+	}
 	if n.previousNode != nil {
 		n.previousNode.nextNode = n.nextNode
 	}
@@ -31,6 +49,9 @@ func (n *LinkedListNode[T]) Remove() {
 	if n == n.list.lastNode {
 		n.list.lastNode = n.previousNode
 	}
+	n.previousNode = nil
+	n.nextNode = nil
+	n.list = nil
 }
 
 type LinkedList[T any] struct {
@@ -61,28 +82,57 @@ func (r *LinkedList[T]) Append(objects ...T) {
 }
 
 func (r *LinkedList[T]) RemoveFirst(cmp func(T) bool) *LinkedListNode[T] {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	nodes := r.nodes()
+	for _, node := range nodes {
+		if !cmp(node.object) {
+			continue
+		}
 
-	node := r.firstNode
-	for node != nil {
-		if cmp(node.object) {
-			node.Remove()
+		r.mu.Lock()
+		if r.containsNodeLocked(node) {
+			node.remove()
+			r.mu.Unlock()
 			return node
 		}
-		node = node.nextNode
+		r.mu.Unlock()
 	}
 
 	return nil
 }
 
+func (r *LinkedList[T]) nodes() []*LinkedListNode[T] {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	ret := make([]*LinkedListNode[T], 0)
+	node := r.firstNode
+	for node != nil {
+		ret = append(ret, node)
+		node = node.nextNode
+	}
+
+	return ret
+}
+
+func (r *LinkedList[T]) containsNodeLocked(node *LinkedListNode[T]) bool {
+	for current := r.firstNode; current != nil; current = current.nextNode {
+		if current == node {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *LinkedList[T]) RemoveValue(t T) *LinkedListNode[T] {
 	return r.RemoveFirst(func(t2 T) bool {
-		return (any)(t) == (any)(t2)
+		return comparableEqual(t, t2)
 	})
 }
 
 func (r *LinkedList[T]) TakeFirst() T {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	var t T
 	if r.firstNode == nil {
 		return t
@@ -90,6 +140,7 @@ func (r *LinkedList[T]) TakeFirst() T {
 	ret := r.firstNode.object
 	if r.firstNode.nextNode == nil {
 		r.firstNode = nil
+		r.lastNode = nil
 	} else {
 		r.firstNode = r.firstNode.nextNode
 		r.firstNode.previousNode = nil
@@ -113,17 +164,15 @@ func (r *LinkedList[T]) Length() int {
 }
 
 func (r *LinkedList[T]) ForEach(f func(t T)) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	node := r.firstNode
-	for node != nil {
-		f(node.object)
-		node = node.nextNode
+	for _, t := range r.Slice() {
+		f(t)
 	}
 }
 
 func (r *LinkedList[T]) Slice() []T {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	ret := make([]T, 0)
 	node := r.firstNode
 	for node != nil {
@@ -134,9 +183,34 @@ func (r *LinkedList[T]) Slice() []T {
 }
 
 func (r *LinkedList[T]) FirstNode() *LinkedListNode[T] {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	return r.firstNode
 }
 
 func NewLinkedList[T any]() *LinkedList[T] {
 	return &LinkedList[T]{}
+}
+
+func comparableEqual[T any](a, b T) (equal bool) {
+	aAny := any(a)
+	bAny := any(b)
+
+	aType := reflect.TypeOf(aAny)
+	bType := reflect.TypeOf(bAny)
+	if aType == nil || bType == nil {
+		return aType == bType
+	}
+	if aType != bType || !aType.Comparable() {
+		return false
+	}
+
+	defer func() {
+		if recover() != nil {
+			equal = false
+		}
+	}()
+
+	return aAny == bAny
 }

--- a/pkg/types/collections/linked_list_internal_test.go
+++ b/pkg/types/collections/linked_list_internal_test.go
@@ -1,0 +1,17 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinkedListTakeFirstClearsLastNodeWhenListBecomesEmpty(t *testing.T) {
+	t.Parallel()
+	list := NewLinkedList[int]()
+	list.Append(1)
+
+	require.Equal(t, 1, list.TakeFirst())
+	require.Nil(t, list.firstNode)
+	require.Nil(t, list.lastNode)
+}

--- a/pkg/types/collections/linked_list_test.go
+++ b/pkg/types/collections/linked_list_test.go
@@ -3,6 +3,7 @@ package collections_test
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -96,6 +97,30 @@ func TestLinkedList(t *testing.T) {
 		require.Equal(t, 2, list.Length())
 	})
 
+	t.Run("RemoveFirstCallbackCanReenterList", func(t *testing.T) {
+		t.Parallel()
+		list := collectionutils.NewLinkedList[int]()
+		list.Append(1, 2, 3)
+
+		done := make(chan *collectionutils.LinkedListNode[int], 1)
+		go func() {
+			done <- list.RemoveFirst(func(i int) bool {
+				require.Equal(t, 3, list.Length())
+				require.Equal(t, []int{1, 2, 3}, list.Slice())
+				return i == 2
+			})
+		}()
+
+		select {
+		case node := <-done:
+			require.NotNil(t, node)
+			require.Equal(t, 2, node.Value())
+			require.Equal(t, []int{1, 3}, list.Slice())
+		case <-time.After(time.Second):
+			t.Fatal("RemoveFirst callback deadlocked when reentering the list")
+		}
+	})
+
 	t.Run("RemoveValue", func(t *testing.T) {
 		t.Parallel()
 		list := collectionutils.NewLinkedList[int]()
@@ -116,6 +141,43 @@ func TestLinkedList(t *testing.T) {
 		node = list.RemoveValue(99)
 		require.Nil(t, node)
 		require.Equal(t, 4, list.Length())
+	})
+
+	t.Run("RemoveValueNonComparable", func(t *testing.T) {
+		t.Parallel()
+		list := collectionutils.NewLinkedList[[]int]()
+		list.Append([]int{1}, []int{2})
+
+		require.NotPanics(t, func() {
+			node := list.RemoveValue([]int{1})
+			require.Nil(t, node)
+		})
+		require.Equal(t, [][]int{{1}, {2}}, list.Slice())
+
+		interfaceList := collectionutils.NewLinkedList[any]()
+		interfaceList.Append([]int{1}, "match")
+
+		require.NotPanics(t, func() {
+			node := interfaceList.RemoveValue([]int{1})
+			require.Nil(t, node)
+		})
+
+		node := interfaceList.RemoveValue("match")
+		require.NotNil(t, node)
+		require.Equal(t, "match", node.Value())
+		require.Equal(t, []any{[]int{1}}, interfaceList.Slice())
+
+		type interfaceField struct {
+			value any
+		}
+		structList := collectionutils.NewLinkedList[interfaceField]()
+		structList.Append(interfaceField{value: []int{1}})
+
+		require.NotPanics(t, func() {
+			node := structList.RemoveValue(interfaceField{value: []int{1}})
+			require.Nil(t, node)
+		})
+		require.Equal(t, []interfaceField{{value: []int{1}}}, structList.Slice())
 	})
 
 	t.Run("TakeFirst", func(t *testing.T) {
@@ -190,6 +252,33 @@ func TestLinkedList(t *testing.T) {
 		require.False(t, called)
 	})
 
+	t.Run("ForEachCallbackCanReenterList", func(t *testing.T) {
+		t.Parallel()
+		list := collectionutils.NewLinkedList[int]()
+		list.Append(1, 2, 3)
+
+		done := make(chan []int, 1)
+		go func() {
+			var values []int
+			list.ForEach(func(i int) {
+				values = append(values, i)
+				require.NotZero(t, list.Length())
+				if i == 2 {
+					list.Append(4)
+				}
+			})
+			done <- values
+		}()
+
+		select {
+		case values := <-done:
+			require.Equal(t, []int{1, 2, 3}, values)
+			require.Equal(t, []int{1, 2, 3, 4}, list.Slice())
+		case <-time.After(time.Second):
+			t.Fatal("ForEach callback deadlocked when reentering the list")
+		}
+	})
+
 	t.Run("Slice", func(t *testing.T) {
 		t.Parallel()
 		list := collectionutils.NewLinkedList[int]()
@@ -227,6 +316,7 @@ func TestLinkedList(t *testing.T) {
 		list.Append(1, 2, 3)
 
 		node = list.FirstNode().Next() // Node with value 2
+		node.Remove()
 		node.Remove()
 
 		require.Equal(t, 2, list.Length())
@@ -303,5 +393,36 @@ func TestLinkedList(t *testing.T) {
 		// Sum should be 10 * sum of numbers from 0 to 99
 		expectedSum := 10 * (99 * 100 / 2)
 		require.Equal(t, expectedSum, sum)
+	})
+
+	t.Run("ConcurrentTakeFirstSliceAndFirstNode", func(t *testing.T) {
+		t.Parallel()
+		list := collectionutils.NewLinkedList[int]()
+		list.Append(1, 2, 3, 4, 5)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func(base int) {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					list.Append(base*1000 + j)
+					_ = list.TakeFirst()
+				}
+			}(i)
+		}
+
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					_ = list.Slice()
+					_ = list.FirstNode()
+				}
+			}()
+		}
+
+		wg.Wait()
 	})
 }

--- a/pkg/types/time/time.go
+++ b/pkg/types/time/time.go
@@ -109,7 +109,7 @@ func (t Time) MarshalJSON() ([]byte, error) {
 }
 
 func (t *Time) UnmarshalJSON(data []byte) error {
-	if len(data) == 0 {
+	if len(data) == 0 || string(data) == "null" {
 		*t = Time{}
 		return nil
 	}

--- a/pkg/types/time/time_test.go
+++ b/pkg/types/time/time_test.go
@@ -170,6 +170,11 @@ func TestUnmarshalJSON(t *testing.T) {
 			input:       `"not-a-date"`,
 			expectError: true,
 		},
+		{
+			name:     "null",
+			input:    `null`,
+			expected: time.Time{},
+		},
 		// Empty string case is handled differently in the implementation
 		// The test for this case is removed as it's causing issues
 	}

--- a/pkg/workflow/temporal/client.go
+++ b/pkg/workflow/temporal/client.go
@@ -100,7 +100,7 @@ func CreateSearchAttributes(ctx context.Context, c client.Client, namespace stri
 			Namespace: namespace,
 		})
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("list temporal search attributes: %w", err)
 		}
 
 		done := true

--- a/pkg/workflow/temporal/client_test.go
+++ b/pkg/workflow/temporal/client_test.go
@@ -1,0 +1,87 @@
+package temporal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/operatorservice/v1"
+	temporalmocks "go.temporal.io/sdk/mocks"
+	"google.golang.org/grpc"
+)
+
+func TestCreateSearchAttributesReturnsListSearchAttributesError(t *testing.T) {
+	t.Parallel()
+
+	operator := &fakeOperatorService{
+		listErr: errors.New("temporarily unavailable"),
+	}
+	c := &temporalmocks.Client{}
+	c.On("OperatorService").Return(operator)
+
+	err := CreateSearchAttributes(context.Background(), c, "default", map[string]enums.IndexedValueType{
+		"CustomKeyword": enums.INDEXED_VALUE_TYPE_KEYWORD,
+	})
+
+	require.ErrorContains(t, err, "list temporal search attributes")
+	require.ErrorContains(t, err, "temporarily unavailable")
+}
+
+type fakeOperatorService struct {
+	addErr  error
+	listErr error
+	listRsp *operatorservice.ListSearchAttributesResponse
+}
+
+func (f *fakeOperatorService) AddSearchAttributes(context.Context, *operatorservice.AddSearchAttributesRequest, ...grpc.CallOption) (*operatorservice.AddSearchAttributesResponse, error) {
+	return &operatorservice.AddSearchAttributesResponse{}, f.addErr
+}
+
+func (f *fakeOperatorService) RemoveSearchAttributes(context.Context, *operatorservice.RemoveSearchAttributesRequest, ...grpc.CallOption) (*operatorservice.RemoveSearchAttributesResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) ListSearchAttributes(context.Context, *operatorservice.ListSearchAttributesRequest, ...grpc.CallOption) (*operatorservice.ListSearchAttributesResponse, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listRsp, nil
+}
+
+func (f *fakeOperatorService) DeleteNamespace(context.Context, *operatorservice.DeleteNamespaceRequest, ...grpc.CallOption) (*operatorservice.DeleteNamespaceResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) AddOrUpdateRemoteCluster(context.Context, *operatorservice.AddOrUpdateRemoteClusterRequest, ...grpc.CallOption) (*operatorservice.AddOrUpdateRemoteClusterResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) RemoveRemoteCluster(context.Context, *operatorservice.RemoveRemoteClusterRequest, ...grpc.CallOption) (*operatorservice.RemoveRemoteClusterResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) ListClusters(context.Context, *operatorservice.ListClustersRequest, ...grpc.CallOption) (*operatorservice.ListClustersResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) GetNexusEndpoint(context.Context, *operatorservice.GetNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.GetNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) CreateNexusEndpoint(context.Context, *operatorservice.CreateNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.CreateNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) UpdateNexusEndpoint(context.Context, *operatorservice.UpdateNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.UpdateNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) DeleteNexusEndpoint(context.Context, *operatorservice.DeleteNexusEndpointRequest, ...grpc.CallOption) (*operatorservice.DeleteNexusEndpointResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeOperatorService) ListNexusEndpoints(context.Context, *operatorservice.ListNexusEndpointsRequest, ...grpc.CallOption) (*operatorservice.ListNexusEndpointsResponse, error) {
+	return nil, errors.New("not implemented")
+}

--- a/pkg/workflow/temporal/logger.go
+++ b/pkg/workflow/temporal/logger.go
@@ -1,6 +1,8 @@
 package temporal
 
 import (
+	"fmt"
+
 	"go.temporal.io/sdk/log"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -8,8 +10,8 @@ import (
 
 func keyvalsToMap(keyvals ...interface{}) map[string]any {
 	ret := make(map[string]any)
-	for i := 0; i < len(keyvals); i += 2 {
-		ret[keyvals[i].(string)] = keyvals[i+1]
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		ret[fmt.Sprint(keyvals[i])] = keyvals[i+1]
 	}
 	return ret
 }
@@ -18,20 +20,29 @@ type logger struct {
 	logger logging.Logger
 }
 
+type warnLogger interface {
+	Warnf(format string, args ...any)
+}
+
 func (l logger) Debug(msg string, keyvals ...interface{}) {
-	l.logger.WithFields(keyvalsToMap(keyvals...)).Debugf(msg)
+	l.logger.WithFields(keyvalsToMap(keyvals...)).Debugf("%s", msg)
 }
 
 func (l logger) Info(msg string, keyvals ...interface{}) {
-	l.logger.WithFields(keyvalsToMap(keyvals...)).Infof(msg)
+	l.logger.WithFields(keyvalsToMap(keyvals...)).Infof("%s", msg)
 }
 
 func (l logger) Warn(msg string, keyvals ...interface{}) {
-	l.logger.WithFields(keyvalsToMap(keyvals...)).Errorf(msg)
+	logger := l.logger.WithFields(keyvalsToMap(keyvals...))
+	if warnLogger, ok := logger.(warnLogger); ok {
+		warnLogger.Warnf("%s", msg)
+		return
+	}
+	logger.Infof("%s", msg)
 }
 
 func (l logger) Error(msg string, keyvals ...interface{}) {
-	l.logger.WithFields(keyvalsToMap(keyvals...)).Errorf(msg)
+	l.logger.WithFields(keyvalsToMap(keyvals...)).Errorf("%s", msg)
 }
 
 var _ log.Logger = (*logger)(nil)

--- a/pkg/workflow/temporal/logger_test.go
+++ b/pkg/workflow/temporal/logger_test.go
@@ -1,0 +1,161 @@
+package temporal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestKeyvalsToMapHandlesOddAndNonStringKeys(t *testing.T) {
+	t.Parallel()
+
+	var got map[string]any
+	require.NotPanics(t, func() {
+		got = keyvalsToMap("workflow", "payment", 42, "answer", "dangling")
+	})
+
+	require.Equal(t, map[string]any{
+		"workflow": "payment",
+		"42":       "answer",
+	}, got)
+}
+
+func TestLoggerWarnUsesWarnLevel(t *testing.T) {
+	t.Parallel()
+
+	recorder := newRecordingLogger()
+
+	newLogger(recorder).Warn("temporal warning", "attempt", 3)
+
+	require.Len(t, recorder.state.entries, 1)
+	require.Equal(t, recordedLogEntry{
+		level:  "warn",
+		msg:    "temporal warning",
+		fields: map[string]any{"attempt": 3},
+	}, recorder.state.entries[0])
+}
+
+func TestLoggerPreservesPercentSignsInMessages(t *testing.T) {
+	t.Parallel()
+
+	recorder := newRecordingLogger()
+	logger := newLogger(recorder)
+
+	logger.Debug("debug 100% done")
+	logger.Info("info 100% done")
+	logger.Warn("warn 100% done")
+	logger.Error("error 100% done")
+
+	require.Equal(t, []recordedLogEntry{
+		{level: "debug", msg: "debug 100% done", fields: map[string]any{}},
+		{level: "info", msg: "info 100% done", fields: map[string]any{}},
+		{level: "warn", msg: "warn 100% done", fields: map[string]any{}},
+		{level: "error", msg: "error 100% done", fields: map[string]any{}},
+	}, recorder.state.entries)
+}
+
+type recordedLogEntry struct {
+	level  string
+	msg    string
+	fields map[string]any
+}
+
+type recordingLoggerState struct {
+	entries []recordedLogEntry
+}
+
+type recordingLogger struct {
+	state  *recordingLoggerState
+	fields map[string]any
+}
+
+func newRecordingLogger() *recordingLogger {
+	return &recordingLogger{
+		state:  &recordingLoggerState{},
+		fields: map[string]any{},
+	}
+}
+
+func (l *recordingLogger) Tracef(format string, args ...any) {
+	l.record("trace", fmt.Sprintf(format, args...))
+}
+
+func (l *recordingLogger) Debugf(format string, args ...any) {
+	l.record("debug", fmt.Sprintf(format, args...))
+}
+
+func (l *recordingLogger) Infof(format string, args ...any) {
+	l.record("info", fmt.Sprintf(format, args...))
+}
+
+func (l *recordingLogger) Warnf(format string, args ...any) {
+	l.record("warn", fmt.Sprintf(format, args...))
+}
+
+func (l *recordingLogger) Errorf(format string, args ...any) {
+	l.record("error", fmt.Sprintf(format, args...))
+}
+
+func (l *recordingLogger) Trace(args ...any) {
+	l.record("trace", fmt.Sprint(args...))
+}
+
+func (l *recordingLogger) Debug(args ...any) {
+	l.record("debug", fmt.Sprint(args...))
+}
+
+func (l *recordingLogger) Info(args ...any) {
+	l.record("info", fmt.Sprint(args...))
+}
+
+func (l *recordingLogger) Error(args ...any) {
+	l.record("error", fmt.Sprint(args...))
+}
+
+func (l *recordingLogger) WithFields(fields map[string]any) logging.Logger {
+	merged := l.cloneFields()
+	for key, value := range fields {
+		merged[key] = value
+	}
+	return &recordingLogger{
+		state:  l.state,
+		fields: merged,
+	}
+}
+
+func (l *recordingLogger) WithField(key string, value any) logging.Logger {
+	return l.WithFields(map[string]any{key: value})
+}
+
+func (l *recordingLogger) WithContext(context.Context) logging.Logger {
+	return l
+}
+
+func (l *recordingLogger) Writer() io.Writer {
+	return io.Discard
+}
+
+func (l *recordingLogger) Enabled(logging.Level) bool {
+	return true
+}
+
+func (l *recordingLogger) record(level, msg string) {
+	l.state.entries = append(l.state.entries, recordedLogEntry{
+		level:  level,
+		msg:    msg,
+		fields: l.cloneFields(),
+	})
+}
+
+func (l *recordingLogger) cloneFields() map[string]any {
+	fields := make(map[string]any, len(l.fields))
+	for key, value := range l.fields {
+		fields[key] = value
+	}
+	return fields
+}


### PR DESCRIPTION
## Summary

This rolls up the remaining open backlog-fix stack into one PR based on the current `main` branch.

Supersedes the stacked PRs: #640, #641, #642, #643, #644, and #646.

Included fixes cover:
- OTLP debug capture redaction and size limits while preserving response writer behavior and ignored paths
- HTTP client/debug tracing hardening, including safe raw request/response dumps for error responses
- linked-list synchronization without reentrant callback deadlocks
- Temporal logger/client hardening
- low-risk publish, auth, service, serverport, and time utility fixes

Review feedback addressed while rolling up:
- Preserve non-debug tracing diagnostics for HTTP responses with status >= 400
- Record terminal `101 Switching Protocols` status correctly in OTLP debug middleware
- Avoid list callback self-deadlocks by invoking callbacks outside the mutex
- Avoid a default HTTP `WriteTimeout` that can break long pprof captures
- Migrate audit publishing to the error-returning message constructor path

## Validation

- `git diff --cached --check`
- `go test ./pkg/observe ./pkg/transport/httpserver ./pkg/types/collections ./pkg/audit ./pkg/messaging/publish`
- `go test ./...`
