### PR TITLE
feat: Add query params to audit logs

### DIFF
--- a/pkg/audit/httpaudit/middleware.go
+++ b/pkg/audit/httpaudit/middleware.go
@@ -9,6 +9,7 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -27,12 +28,21 @@ type httpOptions struct {
 	eventPublisher      auditEventPublisher
 	handledHeaderSecret string
 	maxBodyBytes        int
+	maxQueryParamsBytes int
 }
 
-// DefaultMaxCapturedBodyBytes bounds how many bytes of each request and response
-// body are stored in an audit event when WithMaxBodyBytes is not set. It keeps the
-// serialized audit message well within broker payload limits (e.g. NATS max_payload).
-const DefaultMaxCapturedBodyBytes = 64 * 1024
+const (
+	// DefaultMaxCapturedBodyBytes bounds how many bytes of each request and
+	// response body are stored in an audit event when WithMaxBodyBytes is not
+	// set. It keeps the serialized audit message well within broker payload
+	// limits (e.g. NATS max_payload).
+	DefaultMaxCapturedBodyBytes = 64 * 1024
+
+	// DefaultMaxCapturedQueryParamsBytes bounds how many raw query string bytes
+	// are parsed into audit query parameters when WithMaxQueryParamsBytes is not
+	// set.
+	DefaultMaxCapturedQueryParamsBytes = DefaultMaxCapturedBodyBytes
+)
 
 // WithSensitivePaths sets path prefixes for which request and response bodies should not be captured.
 func WithSensitivePaths(paths ...string) HTTPOption {
@@ -54,6 +64,18 @@ func WithMaxBodyBytes(maxBytes int) HTTPOption {
 	return func(o *httpOptions) {
 		if maxBytes > 0 {
 			o.maxBodyBytes = maxBytes
+		}
+	}
+}
+
+// WithMaxQueryParamsBytes caps how many raw query string bytes are parsed into
+// audit query parameters. Query strings larger than the cap are truncated before
+// parsing and flagged via HTTPRequest.QueryParamsTruncated. A value <= 0 keeps
+// the default cap (DefaultMaxCapturedQueryParamsBytes).
+func WithMaxQueryParamsBytes(maxBytes int) HTTPOption {
+	return func(o *httpOptions) {
+		if maxBytes > 0 {
+			o.maxQueryParamsBytes = maxBytes
 		}
 	}
 }
@@ -117,8 +139,9 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 	auditOpts := audit.NewOptions(opts...)
 
 	ho := &httpOptions{
-		sensitivePaths: make(map[string]struct{}),
-		maxBodyBytes:   DefaultMaxCapturedBodyBytes,
+		sensitivePaths:      make(map[string]struct{}),
+		maxBodyBytes:        DefaultMaxCapturedBodyBytes,
+		maxQueryParamsBytes: DefaultMaxCapturedQueryParamsBytes,
 	}
 	for _, opt := range httpOpts {
 		opt(ho)
@@ -174,9 +197,10 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 			)
 
 			sensitivePath := ho.isSensitivePath(r.URL.Path)
-			queryParams := r.URL.Query()
+			queryParams, queryParamsTruncated := captureQueryParams(r.URL.RawQuery, ho.maxQueryParamsBytes)
 			if sensitivePath {
 				queryParams = nil
+				queryParamsTruncated = false
 			}
 
 			if !isStreamRequest(r) && !sensitivePath {
@@ -221,13 +245,14 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 				Actor:   actor,
 				HTTP: audit.HTTP{
 					Request: audit.HTTPRequest{
-						Method:        r.Method,
-						Path:          r.URL.Path,
-						QueryParams:   queryParams,
-						Host:          r.Host,
-						Header:        requestHeaders,
-						Body:          string(body),
-						BodyTruncated: requestBodyTruncated,
+						Method:               r.Method,
+						Path:                 r.URL.Path,
+						QueryParams:          queryParams,
+						QueryParamsTruncated: queryParamsTruncated,
+						Host:                 r.Host,
+						Header:               requestHeaders,
+						Body:                 string(body),
+						BodyTruncated:        requestBodyTruncated,
 					},
 					Response: audit.HTTPResponse{
 						StatusCode:    rww.statusCode,
@@ -276,6 +301,34 @@ func pathMatchesPrefix(requestPath string, sensitivePath string) bool {
 func isStreamRequest(r *http.Request) bool {
 	ct := r.Header.Get("Content-Type")
 	return strings.HasPrefix(ct, "application/vnd.formance") && strings.HasSuffix(ct, "-stream")
+}
+
+func captureQueryParams(rawQuery string, maxBytes int) (url.Values, bool) {
+	if rawQuery == "" {
+		return nil, false
+	}
+
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxCapturedQueryParamsBytes
+	}
+
+	truncated := false
+	captured := rawQuery
+	if len(rawQuery) > maxBytes {
+		captured = trimIncompleteTrailingEscape(rawQuery[:maxBytes])
+		truncated = true
+	}
+
+	values, _ := url.ParseQuery(captured)
+	return values, truncated
+}
+
+func trimIncompleteTrailingEscape(s string) string {
+	percent := strings.LastIndexByte(s, '%')
+	if percent == -1 || len(s)-percent >= 3 {
+		return s
+	}
+	return s[:percent]
 }
 
 // captureRequestBody reads up to maxBytes of the request body for audit capture

--- a/pkg/audit/httpaudit/middleware.go
+++ b/pkg/audit/httpaudit/middleware.go
@@ -174,6 +174,10 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 			)
 
 			sensitivePath := ho.isSensitivePath(r.URL.Path)
+			queryParams := r.URL.Query()
+			if sensitivePath {
+				queryParams = nil
+			}
 
 			if !isStreamRequest(r) && !sensitivePath {
 				body, requestBodyTruncated, err = captureRequestBody(r, ho.maxBodyBytes)
@@ -219,6 +223,7 @@ func Middleware(publisher message.Publisher, topicName string, appName string, o
 					Request: audit.HTTPRequest{
 						Method:        r.Method,
 						Path:          r.URL.Path,
+						QueryParams:   queryParams,
 						Host:          r.Host,
 						Header:        requestHeaders,
 						Body:          string(body),

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -160,6 +160,44 @@ func TestMiddleware_QueryParamsCapture(t *testing.T) {
 		"status": {"pending", "posted"},
 		"empty":  {""},
 	}, payload.HTTP.Request.QueryParams)
+	assert.False(t, payload.HTTP.Request.QueryParamsTruncated)
+}
+
+func TestMiddleware_CapsQueryParamsAndFlagsTruncation(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	const limit = 24
+	handler := Middleware(pub, topic, "test-app", nil,
+		WithEnabled(true),
+		WithMaxQueryParamsBytes(limit),
+	)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test?first=one&large="+strings.Repeat("x", 100)+"&last=ignored", nil)
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	assert.Equal(t, url.Values{
+		"first": {"one"},
+		"large": {strings.Repeat("x", 8)},
+	}, payload.HTTP.Request.QueryParams)
+	assert.True(t, payload.HTTP.Request.QueryParamsTruncated)
+	assert.NotContains(t, string(messages[0].Payload), "last")
+	assert.NotContains(t, string(messages[0].Payload), strings.Repeat("x", 20))
 }
 
 func TestMiddleware_CapsRequestBodyAndFlagsTruncation(t *testing.T) {
@@ -398,6 +436,7 @@ func TestMiddleware_SensitivePaths(t *testing.T) {
 	assert.Empty(t, payload.HTTP.Response.Body)
 	assert.Empty(t, payload.HTTP.Request.Body)
 	assert.Empty(t, payload.HTTP.Request.QueryParams)
+	assert.False(t, payload.HTTP.Request.QueryParamsTruncated)
 	assert.NotContains(t, string(messages[0].Payload), "client_credentials")
 	assert.NotContains(t, string(messages[0].Payload), "access_token")
 	assert.NotContains(t, string(messages[0].Payload), "query-secret")

--- a/pkg/audit/httpaudit/middleware_test.go
+++ b/pkg/audit/httpaudit/middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -127,6 +128,38 @@ func TestMiddleware_BasicCapture(t *testing.T) {
 	assert.Equal(t, `{"status":"ok"}`, payload.HTTP.Response.Body)
 	assert.False(t, payload.HTTP.Request.BodyTruncated)
 	assert.False(t, payload.HTTP.Response.BodyTruncated)
+}
+
+func TestMiddleware_QueryParamsCapture(t *testing.T) {
+	t.Parallel()
+
+	pub := publish.InMemory()
+	topic := "audit-events"
+
+	handler := Middleware(pub, topic, "test-app", nil, WithEnabled(true))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/api/test?limit=10&status=pending&status=posted&empty=", nil)
+	req = req.WithContext(logging.TestingContext())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	messages := pub.AllMessages()[topic]
+	require.Len(t, messages, 1)
+	payload := auditPayloadFromMessage(t, messages[0])
+
+	assert.Equal(t, "/api/test", payload.HTTP.Request.Path)
+	assert.Equal(t, url.Values{
+		"limit":  {"10"},
+		"status": {"pending", "posted"},
+		"empty":  {""},
+	}, payload.HTTP.Request.QueryParams)
 }
 
 func TestMiddleware_CapsRequestBodyAndFlagsTruncation(t *testing.T) {
@@ -344,7 +377,7 @@ func TestMiddleware_SensitivePaths(t *testing.T) {
 		}),
 	)
 
-	req := httptest.NewRequest("POST", "/api/auth/oauth/token", strings.NewReader(`grant_type=client_credentials`))
+	req := httptest.NewRequest("POST", "/api/auth/oauth/token?client_secret=query-secret", strings.NewReader(`grant_type=client_credentials`))
 	req = req.WithContext(logging.TestingContext())
 
 	rr := httptest.NewRecorder()
@@ -364,8 +397,10 @@ func TestMiddleware_SensitivePaths(t *testing.T) {
 
 	assert.Empty(t, payload.HTTP.Response.Body)
 	assert.Empty(t, payload.HTTP.Request.Body)
+	assert.Empty(t, payload.HTTP.Request.QueryParams)
 	assert.NotContains(t, string(messages[0].Payload), "client_credentials")
 	assert.NotContains(t, string(messages[0].Payload), "access_token")
+	assert.NotContains(t, string(messages[0].Payload), "query-secret")
 }
 
 func TestMiddleware_SensitivePathsMatchPrefixAndPassRequestBodyThrough(t *testing.T) {

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -45,13 +45,14 @@ type HTTP struct {
 }
 
 type HTTPRequest struct {
-	Method        string      `json:"method"`
-	Path          string      `json:"path"`
-	QueryParams   url.Values  `json:"query_params,omitempty"`
-	Host          string      `json:"host"`
-	Header        http.Header `json:"header"`
-	Body          string      `json:"body,omitempty"`
-	BodyTruncated bool        `json:"body_truncated,omitempty"`
+	Method               string      `json:"method"`
+	Path                 string      `json:"path"`
+	QueryParams          url.Values  `json:"query_params,omitempty"`
+	QueryParamsTruncated bool        `json:"query_params_truncated,omitempty"`
+	Host                 string      `json:"host"`
+	Header               http.Header `json:"header"`
+	Body                 string      `json:"body,omitempty"`
+	BodyTruncated        bool        `json:"body_truncated,omitempty"`
 }
 
 type HTTPResponse struct {

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
 )
@@ -46,6 +47,7 @@ type HTTP struct {
 type HTTPRequest struct {
 	Method        string      `json:"method"`
 	Path          string      `json:"path"`
+	QueryParams   url.Values  `json:"query_params,omitempty"`
 	Host          string      `json:"host"`
 	Header        http.Header `json:"header"`
 	Body          string      `json:"body,omitempty"`


### PR DESCRIPTION
## What changed

- Added `query_params` to HTTP audit request payloads.
- Captures query parameters as `url.Values`, preserving repeated values.
- Omits query params for configured sensitive paths to avoid leaking secrets from URLs.

## Impact

Audit log consumers can now inspect request query parameters without parsing them from the path. Existing `path` behavior remains unchanged and continues to exclude the query string.

## Validation

- `go test ./pkg/audit/...`
- `go test ./...`