### PR TITLE
refactor: replace github.com/pkg/errors with stdlib errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/ory/dockertest/v3 v3.12.0
-	github.com/pkg/errors v0.9.1
 	github.com/riandyrn/otelchi v0.12.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
@@ -189,6 +188,7 @@ require (
 	github.com/paulmach/orb v0.12.0 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect

--- a/pkg/authn/licence/jwt.go
+++ b/pkg/authn/licence/jwt.go
@@ -4,10 +4,10 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/pkg/errors"
 )
 
 type validateTokenOptions struct {
@@ -40,7 +40,7 @@ func getKeyFromEmbeddedPublicKey() (interface{}, error) {
 
 	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse embedded Formance public key")
+		return nil, fmt.Errorf("failed to parse embedded Formance public key: %w", err)
 	}
 
 	rsaPub, ok := pub.(*rsa.PublicKey)

--- a/pkg/fx/messagingfx/publish.go
+++ b/pkg/fx/messagingfx/publish.go
@@ -24,7 +24,6 @@ import (
 	sqsservice "github.com/aws/aws-sdk-go-v2/service/sqs"
 	transport "github.com/aws/smithy-go/endpoints"
 	"github.com/nats-io/nats.go"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/uptrace/bun"
 	"github.com/xdg-go/scram"
@@ -89,7 +88,7 @@ func Module(topics map[string]string) fx.Option {
 				OnStop: func(ctx context.Context) error {
 					logging.FromContext(ctx).Infof("Stopping router...")
 					if err := router.Close(); err != nil {
-						return errors.Wrap(err, "stopping router")
+						return fmt.Errorf("stopping router: %w", err)
 					}
 					logging.FromContext(ctx).Infof("Router stopped...")
 

--- a/pkg/messaging/publish/nats.go
+++ b/pkg/messaging/publish/nats.go
@@ -1,10 +1,11 @@
 package publish
 
 import (
+	"fmt"
+
 	"github.com/ThreeDotsLabs/watermill"
 	wNats "github.com/ThreeDotsLabs/watermill-nats/v2/pkg/nats"
 	"github.com/nats-io/nats.go"
-	"github.com/pkg/errors"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
@@ -16,7 +17,7 @@ func NewNatsConn(config wNats.PublisherConfig) (*nats.Conn, error) {
 
 	conn, err := nats.Connect(config.URL, config.NatsOptions...)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot connect to nats-core")
+		return nil, fmt.Errorf("cannot connect to nats-core: %w", err)
 	}
 
 	return conn, nil

--- a/pkg/observe/log/stream.go
+++ b/pkg/observe/log/stream.go
@@ -2,9 +2,8 @@ package logging
 
 import (
 	"bufio"
+	"errors"
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 func StreamReader(logger Logger, r io.Reader, fn func(Logger, ...any)) {

--- a/pkg/query/expression.go
+++ b/pkg/query/expression.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 type Context interface {
@@ -289,19 +287,19 @@ func mapMapToExpression(m map[string]any) (Builder, error) {
 	case "$and", "$or":
 		and, err := parseSet(operator, value)
 		if err != nil {
-			return nil, errors.Wrap(err, "parsing $and")
+			return nil, fmt.Errorf("parsing $and: %w", err)
 		}
 		return &and, nil
 	case "$match", "$gte", "$lte", "$gt", "$lt", "$exists", "$like", "$in":
 		match, err := parseKeyValue(operator, value)
 		if err != nil {
-			return nil, errors.Wrapf(err, "parsing %s", operator)
+			return nil, fmt.Errorf("parsing %s: %w", operator, err)
 		}
 		return &match, nil
 	case "$not":
 		match, err := parseNot(value)
 		if err != nil {
-			return nil, errors.Wrapf(err, "parsing %s", operator)
+			return nil, fmt.Errorf("parsing %s: %w", operator, err)
 		}
 		return &match, nil
 	default:

--- a/pkg/storage/bun/connect/flags.go
+++ b/pkg/storage/bun/connect/flags.go
@@ -3,13 +3,13 @@ package connect
 import (
 	"context"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/jackc/pgx/v5"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
 	"github.com/formancehq/go-libs/v5/pkg/cloud/aws/iam"

--- a/pkg/storage/bun/connect/iam.go
+++ b/pkg/storage/bun/connect/iam.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"context"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jackc/pgx/v5"
-	"github.com/pkg/errors"
 	"github.com/xo/dburl"
 	"go.opentelemetry.io/otel"
 
@@ -73,7 +73,7 @@ func (i *iamConnector) Connect(ctx context.Context) (driver.Conn, error) {
 		return ret, err
 	}()
 	if err != nil {
-		return nil, errors.Wrap(err, "building aws auth token")
+		return nil, fmt.Errorf("building aws auth token: %w", err)
 	}
 
 	dsn := buildIAMAuthDSN(&databaseURL.URL, authenticationToken)

--- a/pkg/storage/bun/migrate/run.go
+++ b/pkg/storage/bun/migrate/run.go
@@ -3,10 +3,10 @@ package migrate
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/uptrace/bun"
 	"github.com/xo/dburl"
@@ -19,12 +19,12 @@ import (
 func isDatabaseExists(ctx context.Context, db *bun.DB, name string) (bool, error) {
 	row := db.QueryRowContext(ctx, `SELECT datname FROM pg_database WHERE datname = ?`, name)
 	if row.Err() != nil {
-		return false, errors.Wrap(row.Err(), "checking database list")
+		return false, fmt.Errorf("checking database list: %w", row.Err())
 	}
 
 	if err := row.Scan(pointer.For("")); err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
-			return false, errors.Wrap(err, "scanning database row")
+			return false, fmt.Errorf("scanning database row: %w", err)
 		}
 
 		return false, nil
@@ -36,7 +36,7 @@ func isDatabaseExists(ctx context.Context, db *bun.DB, name string) (bool, error
 func onPostgresDB(ctx context.Context, connectionOptions bunconnect.ConnectionOptions, callback func(db *bun.DB) error) error {
 	url, err := dburl.Parse(connectionOptions.DatabaseSourceName)
 	if err != nil {
-		return errors.Wrapf(err, "parsing dsn: %s", connectionOptions.DatabaseSourceName)
+		return fmt.Errorf("parsing dsn: %s: %w", connectionOptions.DatabaseSourceName, err)
 	}
 
 	url.Path = "postgres" // notes(gfyrag): default "postgres" database (most of the time?)
@@ -44,7 +44,7 @@ func onPostgresDB(ctx context.Context, connectionOptions bunconnect.ConnectionOp
 
 	db, err := bunconnect.OpenSQLDB(ctx, connectionOptions)
 	if err != nil {
-		return errors.Wrap(err, "opening database")
+		return fmt.Errorf("opening database: %w", err)
 	}
 	defer func() {
 		err := db.Close()
@@ -61,18 +61,18 @@ func EnsureDatabaseNotExists(ctx context.Context, connectionOptions bunconnect.C
 
 		url, err := dburl.Parse(connectionOptions.DatabaseSourceName)
 		if err != nil {
-			return errors.Wrapf(err, "parsing dsn: %s", connectionOptions.DatabaseSourceName)
+			return fmt.Errorf("parsing dsn: %s: %w", connectionOptions.DatabaseSourceName, err)
 		}
 
 		databaseExists, err := isDatabaseExists(ctx, db, url.Path[1:])
 		if err != nil {
-			return errors.Wrap(err, "checking if database exists")
+			return fmt.Errorf("checking if database exists: %w", err)
 		}
 
 		if databaseExists {
 			_, err = db.ExecContext(ctx, fmt.Sprintf(`DROP DATABASE "%s"`, url.Path[1:]))
 			if err != nil {
-				return errors.Wrap(err, "dropping database")
+				return fmt.Errorf("dropping database: %w", err)
 			}
 		}
 
@@ -85,18 +85,18 @@ func EnsureDatabaseExists(ctx context.Context, connectionOptions bunconnect.Conn
 
 		url, err := dburl.Parse(connectionOptions.DatabaseSourceName)
 		if err != nil {
-			return errors.Wrapf(err, "parsing dsn: %s", connectionOptions.DatabaseSourceName)
+			return fmt.Errorf("parsing dsn: %s: %w", connectionOptions.DatabaseSourceName, err)
 		}
 
 		databaseExists, err := isDatabaseExists(ctx, db, url.Path[1:])
 		if err != nil {
-			return errors.Wrap(err, "checking if database exists")
+			return fmt.Errorf("checking if database exists: %w", err)
 		}
 
 		if !databaseExists {
 			_, err = db.ExecContext(ctx, fmt.Sprintf(`CREATE DATABASE "%s"`, url.Path[1:]))
 			if err != nil {
-				return errors.Wrap(err, "creating database")
+				return fmt.Errorf("creating database: %w", err)
 			}
 		}
 
@@ -113,19 +113,22 @@ func run(ctx context.Context, output io.Writer, args []string, connectionOptions
 
 	db, err := bunconnect.OpenSQLDB(ctx, *connectionOptions)
 	if err != nil {
-		return errors.Wrap(err, "opening database")
+		return fmt.Errorf("opening database: %w", err)
 	}
 	defer func() {
 		_ = db.Close()
 	}()
 
-	return errors.Wrap(executor(args, db), "executing migration")
+	if err := executor(args, db); err != nil {
+		return fmt.Errorf("executing migration: %w", err)
+	}
+	return nil
 }
 
 func Run(cmd *cobra.Command, args []string, executor Executor) error {
 	connectionOptions, err := bunconnect.ConnectionOptionsFromFlags(cmd.Flags(), cmd.Context())
 	if err != nil {
-		return errors.Wrap(err, "evaluating connection options")
+		return fmt.Errorf("evaluating connection options: %w", err)
 	}
 	return run(cmd.Context(), cmd.OutOrStdout(), args, connectionOptions, func(args []string, db *bun.DB) error {
 		return executor(cmd, args, db)

--- a/pkg/storage/bun/paginate/iterate.go
+++ b/pkg/storage/bun/paginate/iterate.go
@@ -2,9 +2,8 @@ package paginate
 
 import (
 	"context"
+	"fmt"
 	"reflect"
-
-	"github.com/pkg/errors"
 )
 
 func Iterate[T any, Q any](ctx context.Context, q Q, iterator func(ctx context.Context, q Q) (*Cursor[T], error), cb func(cursor *Cursor[T]) error) error {
@@ -25,7 +24,7 @@ func Iterate[T any, Q any](ctx context.Context, q Q, iterator func(ctx context.C
 
 		newQuery := reflect.New(reflect.TypeOf(q))
 		if err := UnmarshalCursor(cursor.Next, newQuery.Interface()); err != nil {
-			return errors.Wrap(err, "paginating next request")
+			return fmt.Errorf("paginating next request: %w", err)
 		}
 
 		q = newQuery.Elem().Interface().(Q)

--- a/pkg/storage/bun/paginate/pagination.go
+++ b/pkg/storage/bun/paginate/pagination.go
@@ -3,12 +3,11 @@ package paginate
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
 	"strconv"
-
-	"github.com/pkg/errors"
 )
 
 const (

--- a/pkg/storage/postgres/errors.go
+++ b/pkg/storage/postgres/errors.go
@@ -2,10 +2,10 @@ package postgres
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/pkg/errors"
 )
 
 // ResolveError is an helper to wrap postgres errors into storage errors

--- a/pkg/testing/api/matchers.go
+++ b/pkg/testing/api/matchers.go
@@ -2,11 +2,11 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 
 	"github.com/onsi/gomega/types"
-	"github.com/pkg/errors"
 
 	"github.com/formancehq/go-libs/v5/pkg/transport/api"
 )

--- a/pkg/testing/migrations/testing.go
+++ b/pkg/testing/migrations/testing.go
@@ -2,9 +2,9 @@ package migrations
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 

--- a/pkg/testing/platform/clickhousetesting/clickhouse.go
+++ b/pkg/testing/platform/clickhousetesting/clickhouse.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/formancehq/go-libs/v5/pkg/testing/docker"
@@ -99,14 +98,14 @@ func CreateServer(pool *docker.Pool, opts ...ServerOption) *Server {
 
 			db, err := clickhouse.Open(options)
 			if err != nil {
-				return errors.Wrap(err, "opening database")
+				return fmt.Errorf("opening database: %w", err)
 			}
 			defer func() {
 				_ = db.Close()
 			}()
 
 			if err := db.Ping(context.Background()); err != nil {
-				return errors.Wrap(err, "pinging database")
+				return fmt.Errorf("pinging database: %w", err)
 			}
 
 			return nil

--- a/pkg/testing/platform/elastictesting/elastic.go
+++ b/pkg/testing/platform/elastictesting/elastic.go
@@ -2,11 +2,11 @@ package elastictesting
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/olivere/elastic/v7"
 	"github.com/ory/dockertest/v3"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/formancehq/go-libs/v5/pkg/testing/docker"
@@ -63,7 +63,7 @@ func CreateServer(pool *docker.Pool, options ...Option) *Server {
 		CheckFn: func(ctx context.Context, resource *dockertest.Resource) error {
 			client, err := elastic.NewClient(elastic.SetURL("http://127.0.0.1:" + resource.GetPort("9200/tcp")))
 			if err != nil {
-				return errors.Wrap(err, "connecting to server")
+				return fmt.Errorf("connecting to server: %w", err)
 			}
 			client.Stop()
 			return nil

--- a/pkg/testing/platform/pgtesting/postgres.go
+++ b/pkg/testing/platform/pgtesting/postgres.go
@@ -3,6 +3,7 @@ package pgtesting
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	sharedlogging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -295,14 +295,14 @@ func CreatePostgresServer(t T, pool *docker.Pool, opts ...Option) *PostgresServe
 			)
 			db, err := sql.Open("pgx", dsn)
 			if err != nil {
-				return errors.Wrap(err, "opening database")
+				return fmt.Errorf("opening database: %w", err)
 			}
 			defer func() {
 				_ = db.Close()
 			}()
 
 			if err := db.Ping(); err != nil {
-				return errors.Wrap(err, "pinging database")
+				return fmt.Errorf("pinging database: %w", err)
 			}
 
 			return nil

--- a/pkg/transport/api/response.go
+++ b/pkg/transport/api/response.go
@@ -3,12 +3,11 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-
-	"github.com/pkg/errors"
 
 	bunpaginate "github.com/formancehq/go-libs/v5/pkg/storage/bun/paginate"
 )
@@ -75,7 +74,7 @@ func decodePaginatedResponse[T any](rsp *http.Response) (*BaseResponse[T], error
 	}
 	apiResponse := &BaseResponse[T]{}
 	if err := json.NewDecoder(rsp.Body).Decode(apiResponse); err != nil {
-		return nil, errors.Wrap(err, "decoding cursor")
+		return nil, fmt.Errorf("decoding cursor: %w", err)
 	}
 	if apiResponse.Cursor == nil {
 		return nil, errors.New("missing cursor in paginated response")

--- a/pkg/types/currency/amount.go
+++ b/pkg/types/currency/amount.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // This package provides a way to convert a string amount to a big.Int
@@ -30,11 +28,11 @@ var (
 
 func GetAmountWithPrecisionFromString(amountString string, precision int) (*big.Int, error) {
 	if precision < 0 {
-		return nil, errors.Wrap(ErrInvalidPrecision, fmt.Sprintf("precision is negative: %d", precision))
+		return nil, fmt.Errorf("precision is negative: %d: %w", precision, ErrInvalidPrecision)
 	}
 
 	if amountString == "" {
-		return nil, errors.Wrap(ErrInvalidAmount, "amount string is empty")
+		return nil, fmt.Errorf("amount string is empty: %w", ErrInvalidAmount)
 	}
 
 	parts := strings.Split(amountString, ".")
@@ -42,7 +40,7 @@ func GetAmountWithPrecisionFromString(amountString string, precision int) (*big.
 
 	if lengthParts > 2 || lengthParts == 0 {
 		// More than one dot, invalid amount
-		return nil, errors.Wrap(ErrInvalidAmount, fmt.Sprintf("got multiple dots in amount: %s", amountString))
+		return nil, fmt.Errorf("got multiple dots in amount: %s: %w", amountString, ErrInvalidAmount)
 	}
 
 	if lengthParts == 1 {
@@ -52,7 +50,7 @@ func GetAmountWithPrecisionFromString(amountString string, precision int) (*big.
 		}
 		res, ok := new(big.Int).SetString(amountString, 10)
 		if !ok {
-			return nil, errors.Wrap(ErrInvalidAmount, fmt.Sprintf("invalid amount: %s", amountString))
+			return nil, fmt.Errorf("invalid amount: %s: %w", amountString, ErrInvalidAmount)
 		}
 		return res, nil
 	}
@@ -67,7 +65,7 @@ func GetAmountWithPrecisionFromString(amountString string, precision int) (*big.
 		// concatenate the two parts and return the result
 		res, ok := new(big.Int).SetString(parts[0]+decimalPart, 10)
 		if !ok {
-			return nil, errors.Wrap(ErrInvalidAmount, fmt.Sprintf("invalid amount computed: %s from amount %s", parts[0]+decimalPart, amountString))
+			return nil, fmt.Errorf("invalid amount computed: %s from amount %s: %w", parts[0]+decimalPart, amountString, ErrInvalidAmount)
 		}
 		return res, nil
 
@@ -79,7 +77,7 @@ func GetAmountWithPrecisionFromString(amountString string, precision int) (*big.
 		}
 		res, ok := new(big.Int).SetString(parts[0]+decimalPart, 10)
 		if !ok {
-			return nil, errors.Wrap(ErrInvalidAmount, fmt.Sprintf("invalid amount computed: %s from amount %s", parts[0]+decimalPart, amountString))
+			return nil, fmt.Errorf("invalid amount computed: %s from amount %s: %w", parts[0]+decimalPart, amountString, ErrInvalidAmount)
 		}
 		return res, nil
 
@@ -92,7 +90,7 @@ func GetAmountWithPrecisionFromString(amountString string, precision int) (*big.
 
 func GetStringAmountFromBigIntWithPrecision(amount *big.Int, precision int) (string, error) {
 	if precision < 0 {
-		return "", errors.Wrap(ErrInvalidPrecision, fmt.Sprintf("precision is negative: %d", precision))
+		return "", fmt.Errorf("precision is negative: %d: %w", precision, ErrInvalidPrecision)
 	}
 	if amount == nil {
 		return "", fmt.Errorf("amount is nil")

--- a/pkg/types/time/time.go
+++ b/pkg/types/time/time.go
@@ -2,11 +2,11 @@ package time
 
 import (
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/invopop/jsonschema"
-	"github.com/pkg/errors"
 )
 
 const (


### PR DESCRIPTION
## Summary

Removes the direct dependency on `github.com/pkg/errors`, replacing all internal usages with the Go standard library across 19 files.

## Changes

- `errors.New`, `errors.Is`, `errors.As` → stdlib `errors` (identical signatures, import swapped)
- `errors.Wrap(err, "msg")` → `fmt.Errorf("msg: %w", err)`
- `errors.Wrapf(err, "fmt", args...)` → `fmt.Errorf("fmt: %w", args..., err)`
- `errors.Wrap(sentinel, fmt.Sprintf(...))` (currency `amount.go`) → `fmt.Errorf("...: %w", ..., sentinel)`, preserving `errors.Is` matchability on the sentinels
- `run.go`'s `errors.Wrap(executor(...), "executing migration")` rewritten as an explicit `if err != nil` block, since `fmt.Errorf` (unlike `pkg/errors.Wrap`) returns non-nil on a nil input

`github.com/pkg/errors` is no longer a direct dependency. It remains `// indirect` in `go.mod` because `github.com/ThreeDotsLabs/watermill/message` pulls it in transitively.

## Verification

- `go build ./...` passes
- `go vet` on all affected packages passes
- Tests for `currency`, `storage/postgres`, and `query` pass