### PR TITLE
feat(observe/log): add a slog.Handler adapter

### DIFF
--- a/pkg/observe/log/adapter_slog.go
+++ b/pkg/observe/log/adapter_slog.go
@@ -1,0 +1,202 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+)
+
+// NewSlogHandler adapts a Logger to the standard library's slog.Handler, so
+// code written against slog flows through the platform logger instead of
+// slog's stock stderr text handler:
+//
+//	slog.SetDefault(slog.New(logging.NewSlogHandler(logger)))
+//
+// Existing slog call sites need no change; they gain the platform logger's
+// formatting (--json-formatting-logger), its level (--debug) and — because
+// Handle binds the logger to the call's context — the OpenTelemetry hook that
+// stamps trace_id/span_id.
+//
+// A nil logger discards instead of panicking: a logging call is the worst
+// possible place to take a process down.
+func NewSlogHandler(logger Logger) slog.Handler {
+	return &slogHandler{logger: logger}
+}
+
+// slogField is an attribute flattened for emission: a fully group-qualified
+// key and an already-resolved value.
+type slogField struct {
+	key   string
+	value any
+}
+
+type slogHandler struct {
+	// logger is nil for a discarding handler.
+	logger Logger
+	// prefix is the chain of names opened by WithGroup, dot-joined and
+	// dot-terminated ("G." or "G.H."), or empty at the top level.
+	prefix string
+	// attrs holds the attributes accumulated by WithAttrs, flattened and
+	// group-qualified when they were added.
+	attrs []slogField
+}
+
+var _ slog.Handler = (*slogHandler)(nil)
+
+// Enabled consults the underlying logger, so --debug actually gates slog
+// debug calls rather than every record being built and then dropped.
+func (h *slogHandler) Enabled(_ context.Context, level slog.Level) bool {
+	if h.logger == nil {
+		return false
+	}
+
+	return h.logger.Enabled(fromSlogLevel(level))
+}
+
+func (h *slogHandler) Handle(ctx context.Context, record slog.Record) error {
+	if h.logger == nil {
+		return nil
+	}
+
+	// Bind the logger to this call's context. The logrus OTel hook reads the
+	// active span from it, which is what correlates the line with the trace;
+	// a context with no recording span simply adds no trace fields.
+	logger := h.logger.WithContext(ctx)
+
+	if fields := h.fields(record); len(fields) > 0 {
+		logger = logger.WithFields(fields)
+	}
+
+	// record.Time is deliberately dropped: emission goes through Logger, whose
+	// signature is Info(args ...any), so there is no way to carry a timestamp,
+	// and the backing logger stamps its own anyway. See TestSlogHandlerConformance
+	// for the one slogtest case this costs.
+	switch {
+	case record.Level >= slog.LevelError:
+		logger.Error(record.Message)
+	case record.Level >= slog.LevelWarn:
+		// Warn is why Logger grew Warn/Warnf (see the Logger interface).
+		// Folding warnings into Error would turn every warning into an alert.
+		logger.Warn(record.Message)
+	case record.Level >= slog.LevelInfo:
+		logger.Info(record.Message)
+	case record.Level >= slog.LevelDebug:
+		logger.Debug(record.Message)
+	default:
+		logger.Trace(record.Message)
+	}
+
+	return nil
+}
+
+func (h *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+
+	clone := h.clone()
+	for _, attr := range attrs {
+		flattenSlogAttr(h.prefix, attr, func(key string, value any) {
+			clone.attrs = append(clone.attrs, slogField{key: key, value: value})
+		})
+	}
+
+	return clone
+}
+
+func (h *slogHandler) WithGroup(name string) slog.Handler {
+	// The slog.Handler contract: an empty name returns the receiver unchanged.
+	if name == "" {
+		return h
+	}
+
+	clone := h.clone()
+	clone.prefix += name + "."
+
+	return clone
+}
+
+// clone copies the accumulated attributes rather than sharing the slice.
+// slog branches handlers — one logger yields several via WithAttrs — and two
+// branches appending into a shared backing array would overwrite each other's
+// attributes.
+func (h *slogHandler) clone() *slogHandler {
+	return &slogHandler{
+		logger: h.logger,
+		prefix: h.prefix,
+		attrs:  slices.Clone(h.attrs),
+	}
+}
+
+// fields merges the handler's accumulated attributes with the record's own.
+func (h *slogHandler) fields(record slog.Record) map[string]any {
+	fields := make(map[string]any, len(h.attrs)+record.NumAttrs())
+	for _, field := range h.attrs {
+		fields[field.key] = field.value
+	}
+
+	record.Attrs(func(attr slog.Attr) bool {
+		flattenSlogAttr(h.prefix, attr, func(key string, value any) {
+			fields[key] = value
+		})
+		return true
+	})
+
+	return fields
+}
+
+// flattenSlogAttr emits attr as zero or more flat key/value pairs, each key
+// qualified with the enclosing group names.
+//
+// Groups are flattened into dotted keys ("G.H.key") rather than nested maps:
+// Logger carries flat fields, and flat scalar keys are what log search
+// backends index well. It implements the attribute half of the slog.Handler
+// contract: resolve LogValuer values, ignore the empty Attr, ignore empty
+// groups (including their name), and inline a group with an empty name.
+func flattenSlogAttr(prefix string, attr slog.Attr, emit func(key string, value any)) {
+	attr.Value = attr.Value.Resolve()
+
+	if attr.Value.Kind() == slog.KindGroup {
+		group := attr.Value.Group()
+		if len(group) == 0 {
+			return
+		}
+		if attr.Key != "" {
+			prefix += attr.Key + "."
+		}
+		for _, nested := range group {
+			flattenSlogAttr(prefix, nested, emit)
+		}
+
+		return
+	}
+
+	// The zero Attr. Spelled out rather than using attr.Equal(slog.Attr{})
+	// because slog.Value.Equal compares the underlying values with ==, which
+	// panics on non-comparable types.
+	if attr.Key == "" && attr.Value.Any() == nil {
+		return
+	}
+
+	emit(prefix+attr.Key, attr.Value.Any())
+}
+
+// fromSlogLevel maps a slog.Level onto the closest Level.
+//
+// slog.LevelWarn maps to InfoLevel: Level has no warn of its own, and this is
+// only used by Enabled. The mapping is deliberately permissive — a logger that
+// emits Info also emits Warn, and the backing logger filters again at emit, so
+// an over-generous answer costs a wasted field build, never a line that should
+// have been suppressed getting through.
+func fromSlogLevel(level slog.Level) Level {
+	switch {
+	case level < slog.LevelDebug:
+		return TraceLevel
+	case level < slog.LevelInfo:
+		return DebugLevel
+	case level < slog.LevelError:
+		return InfoLevel
+	default:
+		return ErrorLevel
+	}
+}

--- a/pkg/observe/log/adapter_slog_test.go
+++ b/pkg/observe/log/adapter_slog_test.go
@@ -1,0 +1,305 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"testing/slogtest"
+
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// newSlogTestLogger builds a JSON-formatting LogrusLogger writing to buf.
+// Logrus' JSON keys happen to be exactly slog's: time, level, msg.
+func newSlogTestLogger(buf *bytes.Buffer, level Level, otelTraces bool) *LogrusLogger {
+	return NewDefaultLoggerWithLevel(buf, level, true, otelTraces)
+}
+
+// decodeLines parses the JSON lines written to buf.
+func decodeLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+
+	raw := strings.TrimSpace(buf.String())
+	if raw == "" {
+		return nil
+	}
+
+	lines := strings.Split(raw, "\n")
+	out := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		entry := map[string]any{}
+		require.NoError(t, json.Unmarshal([]byte(line), &entry), "line: %s", line)
+		out = append(out, entry)
+	}
+
+	return out
+}
+
+// decodeLine parses the single JSON line written to buf.
+func decodeLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+
+	lines := decodeLines(t, buf)
+	require.Len(t, lines, 1)
+
+	return lines[0]
+}
+
+// nestGroups turns the handler's dot-qualified keys ("G.H.e") back into the
+// nested maps slogtest expects. The handler flattens groups on purpose (see
+// flattenSlogAttr); slogtest documents that the results function is where a
+// handler's own format is translated into the shape the checks assume.
+func nestGroups(flat map[string]any) map[string]any {
+	nested := map[string]any{}
+	for key, value := range flat {
+		parts := strings.Split(key, ".")
+		target := nested
+		for _, part := range parts[:len(parts)-1] {
+			child, ok := target[part].(map[string]any)
+			if !ok {
+				child = map[string]any{}
+				target[part] = child
+			}
+			target = child
+		}
+		target[parts[len(parts)-1]] = value
+	}
+
+	return nested
+}
+
+// TestSlogHandlerConformance runs the standard library's own slog.Handler
+// conformance suite against the adapter.
+func TestSlogHandlerConformance(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	handler := NewSlogHandler(newSlogTestLogger(buf, TraceLevel, false))
+
+	err := slogtest.TestHandler(handler, func() []map[string]any {
+		results := decodeLines(t, buf)
+		for i, entry := range results {
+			results[i] = nestGroups(entry)
+		}
+		return results
+	})
+
+	// The one case that cannot pass. Emission goes through Logger, whose
+	// signature is Info(args ...any): there is no way to pass or suppress a
+	// timestamp, and the backing logger always stamps its own. That is correct
+	// in production and unreachable in practice — slog.Logger always sets
+	// Record.Time from the clock, so only a hand-built Record has a zero one.
+	//
+	// Allow-listed by exact message rather than skipping the suite, so every
+	// other case stays enforced and a second deviation fails the test.
+	const allowedDeviation = "a Handler should ignore a zero Record.Time"
+
+	var sawAllowedDeviation bool
+	for _, problem := range unwrapJoined(err) {
+		if strings.Contains(problem.Error(), allowedDeviation) {
+			sawAllowedDeviation = true
+			continue
+		}
+		t.Errorf("slogtest: %v", problem)
+	}
+
+	require.True(t, sawAllowedDeviation,
+		"the documented %q deviation no longer occurs — remove the allow-list", allowedDeviation)
+}
+
+// unwrapJoined splits an errors.Join result back into its parts.
+func unwrapJoined(err error) []error {
+	if err == nil {
+		return nil
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		return joined.Unwrap()
+	}
+
+	return []error{err}
+}
+
+// TestSlogHandlerTraceCorrelation is the point of the adapter: a line logged
+// through slog inside a span carries the trace, because Handle binds the
+// logger to the call's context and the OTel hook reads the span from it.
+func TestSlogHandlerTraceCorrelation(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(NewSlogHandler(newSlogTestLogger(buf, InfoLevel, true)))
+
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+
+	ctx, span := provider.Tracer("slog-adapter-test").Start(context.Background(), "operation")
+	logger.InfoContext(ctx, "inside the span", "k", "v")
+	span.End()
+
+	entry := decodeLine(t, buf)
+	require.Equal(t, "inside the span", entry["msg"])
+	require.Equal(t, "v", entry["k"])
+	require.Equal(t, span.SpanContext().TraceID().String(), entry["trace_id"])
+	require.Equal(t, span.SpanContext().SpanID().String(), entry["span_id"])
+}
+
+// TestSlogHandlerNoSpanNoTraceFields: a context with no span produces no trace
+// fields, not empty ones.
+func TestSlogHandlerNoSpanNoTraceFields(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(NewSlogHandler(newSlogTestLogger(buf, InfoLevel, true)))
+
+	logger.InfoContext(context.Background(), "no span here")
+
+	entry := decodeLine(t, buf)
+	require.NotContains(t, entry, "trace_id")
+	require.NotContains(t, entry, "span_id")
+}
+
+func TestSlogHandlerLevelGating(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without debug", func(t *testing.T) {
+		t.Parallel()
+
+		buf := &bytes.Buffer{}
+		handler := NewSlogHandler(newSlogTestLogger(buf, InfoLevel, false))
+
+		require.False(t, handler.Enabled(context.Background(), slog.LevelDebug))
+		require.True(t, handler.Enabled(context.Background(), slog.LevelInfo))
+		// Warn maps to InfoLevel for the Enabled check — deliberately permissive.
+		require.True(t, handler.Enabled(context.Background(), slog.LevelWarn))
+		require.True(t, handler.Enabled(context.Background(), slog.LevelError))
+
+		slog.New(handler).Debug("suppressed")
+		require.Empty(t, buf.String())
+	})
+
+	t.Run("with debug", func(t *testing.T) {
+		t.Parallel()
+
+		buf := &bytes.Buffer{}
+		handler := NewSlogHandler(newSlogTestLogger(buf, DebugLevel, false))
+
+		require.True(t, handler.Enabled(context.Background(), slog.LevelDebug))
+
+		slog.New(handler).Debug("emitted")
+		require.Equal(t, "emitted", decodeLine(t, buf)["msg"])
+	})
+}
+
+// TestSlogHandlerWarnIsNotError pins the Warn decision: a slog warning is
+// emitted at the backing logger's warn level, not folded into Error.
+func TestSlogHandlerWarnIsNotError(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	slog.New(NewSlogHandler(newSlogTestLogger(buf, InfoLevel, false))).Warn("careful")
+
+	entry := decodeLine(t, buf)
+	require.Equal(t, "careful", entry["msg"])
+	require.Equal(t, "warning", entry["level"]) // logrus spells warn "warning"
+}
+
+func TestSlogHandlerLevelMapping(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(NewSlogHandler(newSlogTestLogger(buf, TraceLevel, false)))
+
+	logger.Log(context.Background(), slog.LevelDebug-4, "trace")
+	logger.Debug("debug")
+	logger.Info("info")
+	logger.Warn("warn")
+	logger.Error("error")
+
+	levels := make([]string, 0, 5)
+	for _, entry := range decodeLines(t, buf) {
+		levels = append(levels, entry["level"].(string))
+	}
+
+	require.Equal(t, []string{"trace", "debug", "info", "warning", "error"}, levels)
+}
+
+// TestSlogHandlerWithAttrsBranchesAreIndependent guards the append-aliasing
+// trap: slog branches handlers, and two branches appending into a shared
+// backing array would overwrite each other's attributes.
+func TestSlogHandlerWithAttrsBranchesAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+
+	// Build the root in several steps so its attrs slice has spare capacity —
+	// that is the state in which a missing copy actually corrupts a sibling.
+	root := NewSlogHandler(newSlogTestLogger(buf, InfoLevel, false)).
+		WithAttrs([]slog.Attr{slog.String("a", "1")}).
+		WithAttrs([]slog.Attr{slog.String("b", "2")}).
+		WithAttrs([]slog.Attr{slog.String("c", "3")})
+
+	left := root.WithAttrs([]slog.Attr{slog.String("branch", "left")})
+	right := root.WithAttrs([]slog.Attr{slog.String("branch", "right")})
+
+	slog.New(left).Info("left")
+	slog.New(right).Info("right")
+	slog.New(root).Info("root")
+
+	entries := decodeLines(t, buf)
+	require.Len(t, entries, 3)
+
+	for _, entry := range entries {
+		require.Equal(t, "1", entry["a"])
+		require.Equal(t, "2", entry["b"])
+		require.Equal(t, "3", entry["c"])
+	}
+
+	require.Equal(t, "left", entries[0]["branch"])
+	require.Equal(t, "right", entries[1]["branch"])
+	require.NotContains(t, entries[2], "branch", "the root handler must not see a branch's attributes")
+}
+
+// TestSlogHandlerWithGroupBranchesAreIndependent: the same for group prefixes.
+func TestSlogHandlerWithGroupBranchesAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	root := NewSlogHandler(newSlogTestLogger(buf, InfoLevel, false)).
+		WithAttrs([]slog.Attr{slog.String("shared", "yes")})
+
+	slog.New(root.WithGroup("G")).Info("grouped", "k", "v")
+	slog.New(root).Info("ungrouped", "k", "v")
+
+	entries := decodeLines(t, buf)
+	require.Len(t, entries, 2)
+
+	require.Equal(t, "v", entries[0]["G.k"])
+	require.Equal(t, "yes", entries[0]["shared"], "attrs added before WithGroup stay unqualified")
+	require.NotContains(t, entries[0], "k")
+
+	require.Equal(t, "v", entries[1]["k"])
+	require.NotContains(t, entries[1], "G.k")
+}
+
+// TestSlogHandlerNilLoggerDiscards: a logging call is the worst place to take
+// a process down.
+func TestSlogHandlerNilLoggerDiscards(t *testing.T) {
+	t.Parallel()
+
+	handler := NewSlogHandler(nil)
+
+	require.False(t, handler.Enabled(context.Background(), slog.LevelError))
+	require.NotPanics(t, func() {
+		logger := slog.New(handler).With("a", "b").WithGroup("G")
+		logger.Info("discarded", "k", "v")
+		logger.Error("discarded too")
+
+		// Handle is also reachable directly, bypassing the Enabled check.
+		require.NoError(t, handler.Handle(context.Background(), slog.Record{}))
+	})
+}

--- a/pkg/observe/log/logging.go
+++ b/pkg/observe/log/logging.go
@@ -10,6 +10,9 @@ import (
 // Level represents a logging severity level. Lower values are more verbose.
 type Level int
 
+// There is deliberately no WarnLevel: Logger can emit warnings (see Warn), but
+// nothing gates on them. Callers checking Enabled for a warning should ask for
+// InfoLevel, which is what the slog adapter does (see fromSlogLevel).
 const (
 	TraceLevel Level = iota - 1 // -1, more verbose than Debug; reserved for per-event/per-request logs.
 	DebugLevel                  // 0
@@ -54,10 +57,23 @@ type Logger interface {
 	Tracef(fmt string, args ...any)
 	Debugf(fmt string, args ...any)
 	Infof(fmt string, args ...any)
+	// Warnf, like Warn, exists so adapters that receive a warning from an
+	// upstream API have somewhere correct to put it.
+	Warnf(fmt string, args ...any)
 	Errorf(fmt string, args ...any)
 	Trace(args ...any)
 	Debug(args ...any)
 	Info(args ...any)
+	// Warn emits a warning. Both bundled adapters already implemented
+	// Warn/Warnf before they were part of this interface — the omission was
+	// accidental — but until they were declared here, an adapter holding a
+	// Logger had nowhere correct to send a warning: routing it to Error turns
+	// every warning into an alert, and routing it to Info loses the severity.
+	// NewSlogHandler needs this to map slog.LevelWarn faithfully.
+	//
+	// Adding these is a breaking change for out-of-tree implementations of
+	// Logger, which must now provide Warn and Warnf.
+	Warn(args ...any)
 	Error(args ...any)
 	WithFields(map[string]any) Logger
 	WithField(key string, value any) Logger
@@ -81,6 +97,9 @@ func Debugf(format string, args ...any) {
 func Infof(format string, args ...any) {
 	FromContext(context.TODO()).Infof(format, args...)
 }
+func Warnf(format string, args ...any) {
+	FromContext(context.TODO()).Warnf(format, args...)
+}
 func Errorf(format string, args ...any) {
 	FromContext(context.TODO()).Errorf(format, args...)
 }
@@ -92,6 +111,9 @@ func Debug(args ...any) {
 }
 func Info(args ...any) {
 	FromContext(context.TODO()).Info(args...)
+}
+func Warn(args ...any) {
+	FromContext(context.TODO()).Warn(args...)
 }
 func Error(args ...any) {
 	FromContext(context.TODO()).Error(args...)

--- a/pkg/observe/log/logging_generated.go
+++ b/pkg/observe/log/logging_generated.go
@@ -187,6 +187,39 @@ func (mr *MockLoggerMockRecorder) Tracef(fmt any, args ...any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tracef", reflect.TypeOf((*MockLogger)(nil).Tracef), varargs...)
 }
 
+// Warn mocks base method.
+func (m *MockLogger) Warn(args ...any) {
+	m.ctrl.T.Helper()
+	varargs := []any{}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Warn", varargs...)
+}
+
+// Warn indicates an expected call of Warn.
+func (mr *MockLoggerMockRecorder) Warn(args ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Warn", reflect.TypeOf((*MockLogger)(nil).Warn), args...)
+}
+
+// Warnf mocks base method.
+func (m *MockLogger) Warnf(fmt string, args ...any) {
+	m.ctrl.T.Helper()
+	varargs := []any{fmt}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Warnf", varargs...)
+}
+
+// Warnf indicates an expected call of Warnf.
+func (mr *MockLoggerMockRecorder) Warnf(fmt any, args ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{fmt}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Warnf", reflect.TypeOf((*MockLogger)(nil).Warnf), varargs...)
+}
+
 // WithContext mocks base method.
 func (m *MockLogger) WithContext(ctx context.Context) Logger {
 	m.ctrl.T.Helper()

--- a/pkg/transport/httpclient/debug_test.go
+++ b/pkg/transport/httpclient/debug_test.go
@@ -116,12 +116,14 @@ func (l *recordingLogger) Debugf(format string, args ...any) {
 	l.debugMessages = append(l.debugMessages, fmt.Sprintf(format, args...))
 }
 func (l *recordingLogger) Infof(string, ...any)  {}
+func (l *recordingLogger) Warnf(string, ...any)  {}
 func (l *recordingLogger) Errorf(string, ...any) {}
 func (l *recordingLogger) Trace(...any)          {}
 func (l *recordingLogger) Debug(args ...any) {
 	l.debugMessages = append(l.debugMessages, fmt.Sprint(args...))
 }
 func (l *recordingLogger) Info(...any)  {}
+func (l *recordingLogger) Warn(...any)  {}
 func (l *recordingLogger) Error(...any) {}
 func (l *recordingLogger) WithFields(map[string]any) logging.Logger {
 	return l

--- a/pkg/workflow/temporal/logger_test.go
+++ b/pkg/workflow/temporal/logger_test.go
@@ -113,6 +113,10 @@ func (l *recordingLogger) Info(args ...any) {
 	l.record("info", fmt.Sprint(args...))
 }
 
+func (l *recordingLogger) Warn(args ...any) {
+	l.record("warn", fmt.Sprint(args...))
+}
+
 func (l *recordingLogger) Error(args ...any) {
 	l.record("error", fmt.Sprint(args...))
 }


### PR DESCRIPTION
## What

Adds `logging.NewSlogHandler(logging.Logger) slog.Handler` to `pkg/observe/log`, alongside the existing logrus and zap adapters.

```go
slog.SetDefault(slog.New(logging.NewSlogHandler(logger)))
```

Existing `slog` call sites then gain the platform logger's formatting, level control and trace correlation with no changes.

## Why

`pkg/service` builds a `logging.Logger` from `--debug` and `--json-formatting-logger`, installs the OTel hook that stamps `trace_id`/`span_id`, and injects it into fx — but a service whose own code calls `slog.Default()` never touches any of it. `slog.Default()` stays Go's stock stderr text handler.

Measured in one consumer (`formancehq/connectivity-plugins`): 58 non-test files logging via `slog.Default()`. Every one of those lines ignored `--json-formatting-logger`, ignored `--debug`, and carried no `trace_id` — requests were traced, but their logs could not be joined to the trace. That consumer wrote an adapter locally; `slog` is the stdlib default and new services will keep hitting this, so it belongs here.

## Design notes

- **Context binding.** `Handle` calls `logger.WithContext(ctx)` before emitting. That is what lets the existing logrus `traceHook` read the active span — without it there is no trace correlation, which is most of the point. A context with no recording span adds no trace fields rather than empty ones.
- **`Enabled` consults the underlying logger**, so `--debug` actually gates slog debug calls instead of every record being built and then dropped. `slog.LevelWarn` maps to `InfoLevel` for that check — deliberately permissive, since the backing logger filters again at emit, so an over-generous answer costs a wasted field build, never a suppressed line getting through.
- **Groups flatten to dotted keys** (`G.H.key`) rather than nested maps. `Logger` carries flat fields, and flat scalar keys are what log search backends index well. Worth a second opinion if you'd rather have nested maps.
- **`clone()` copies the attrs slice.** `slog` branches handlers, and two branches appending into a shared backing array overwrite each other's attributes.
- **A nil `Logger` discards** rather than panicking — a logging call is the worst place to take a process down.

## ⚠️ Breaking change: `Logger` gains `Warn`/`Warnf`

A slog `Warn` had nowhere correct to go. The interface declared `Trace/Debug/Info/Error` (+`f` variants) but not `Warn`, while `LogrusLogger` and `ZapLogger` both already implemented `Warn`/`Warnf` — the omission from the interface looks accidental. Routing warnings to `Error` would turn every warning into an alert; routing them to `Info` loses the severity. So the interface now declares both, with the rationale in the source.

**Out-of-tree implementations of `logging.Logger` must add `Warn(args ...any)` and `Warnf(fmt string, args ...any)`.** In-tree adapters already had them; only the generated mock and three test doubles needed updating.

No `WarnLevel` was added to `Level`: nothing gates on warn, and it would renumber `ErrorLevel`.

This repo has no automated semantic-release, so the `BREAKING CHANGE:` footer on the commit is documentary. **Flagging for a versioning call** per the usual process for interface breaks.

## Testing

`testing/slogtest`, the stdlib's own conformance suite — the strongest available check, covering group nesting, empty-attr elision, inline groups and `LogValuer` resolution.

It passes with **exactly one deviation**, allow-listed by exact message rather than skipping the suite, so every other case stays enforced and a second deviation fails the test:

> `a Handler should ignore a zero Record.Time`

This one cannot pass. Emission goes through `logging.Logger`, whose signature is `Info(args ...any)` — there is no way to pass or suppress a timestamp, and the backing logger always stamps its own. That is correct behaviour in production and unreachable in practice: `slog.Logger` always sets `Record.Time` from the clock, so only a hand-built `Record` has a zero one. The test also fails if the deviation ever *stops* occurring, so the allow-list cannot go stale.

Also covered: trace correlation end to end against a real recorded span (`sdktrace` with `AlwaysSample`, asserting `trace_id`/`span_id` match `span.SpanContext()`); the no-span case; level gating with and without `--debug`; warn landing at warn and not error; the full level mapping; and `WithAttrs`/`WithGroup` branch independence.

I mutation-checked the suite rather than trusting a green run — sharing the attrs slice instead of cloning makes the branch test report `right` where `left` was expected, and dropping either the inline-group or the empty-Attr handling produces a slogtest failure. The tests bite.

`just pre-commit` is clean (`0 issues`); `go vet ./...` and the tests for `pkg/observe/...`, `pkg/transport/httpclient`, `pkg/workflow/temporal` and `pkg/authn/licence` pass under `-race`.

## Not included

`pkg/observe/log` stays Layer 1 — stdlib plus existing dependencies, no `fx`.

This only takes effect once a service calls `slog.SetDefault(...)` itself. Wiring it into `pkg/service` startup would be a Layer 3 change and is out of scope here; happy to follow up if you want it on by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
