### PR TITLE
fix(httpclient): redact credentials and bound bodies in debug dumps

### DIFF
--- a/pkg/transport/httpclient/debug.go
+++ b/pkg/transport/httpclient/debug.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
 	"strings"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -19,11 +18,7 @@ func (h httpTransport) RoundTrip(request *http.Request) (*http.Response, error) 
 	logger := logging.FromContext(request.Context())
 	debugEnabled := logger.Enabled(logging.DebugLevel)
 	if debugEnabled {
-		data, err := dumpRequest(request, true)
-		if err != nil {
-			return nil, fmt.Errorf("dump http request: %w", err)
-		}
-		logger.Debug(string(data))
+		logger.Debug(dumpRequest(request))
 	}
 
 	rsp, err := h.underlying.RoundTrip(request)
@@ -32,12 +27,7 @@ func (h httpTransport) RoundTrip(request *http.Request) (*http.Response, error) 
 	}
 
 	if debugEnabled {
-		data, err := dumpResponse(rsp, true)
-		if err != nil {
-			logger.Debugf("failed to dump HTTP response: %v", err)
-			return rsp, nil
-		}
-		logger.Debug(string(data))
+		logger.Debug(dumpResponse(rsp))
 	}
 
 	return rsp, nil
@@ -51,9 +41,15 @@ func NewDebugHTTPTransport(underlying http.RoundTripper) *httpTransport {
 	}
 }
 
-func dumpRequest(req *http.Request, includeBody bool) ([]byte, error) {
+// dumpRequest renders one request as an HTTP-shaped dump: the request line with
+// path and query redacted, the headers with credential-bearing values masked, and
+// a bounded, secret-redacted body.
+//
+// It never fails the request. A dump is a diagnostic, so a body that cannot be
+// read is recorded in the dump rather than turned into a RoundTrip error.
+func dumpRequest(req *http.Request) string {
 	var builder strings.Builder
-	uri := req.URL.RequestURI()
+	uri := redactRequestURI(req.URL)
 	if uri == "" {
 		uri = "/"
 	}
@@ -61,49 +57,16 @@ func dumpRequest(req *http.Request, includeBody bool) ([]byte, error) {
 	if req.Host != "" {
 		fmt.Fprintf(&builder, "Host: %s\r\n", req.Host)
 	}
-	writeSanitizedHeaders(&builder, req.Header)
+	writeRedactedHeaders(&builder, req.Header)
 	builder.WriteString("\r\n")
+	builder.WriteString(dumpRequestBody(req))
 
-	if !includeBody {
-		return []byte(builder.String()), nil
-	}
-
-	if req.Body == nil || req.Body == http.NoBody {
-		return []byte(builder.String()), nil
-	}
-
-	var data []byte
-	if req.GetBody != nil {
-		body, err := req.GetBody()
-		if err != nil {
-			return nil, err
-		}
-		data, err = io.ReadAll(body)
-		closeErr := body.Close()
-		if err != nil {
-			return nil, err
-		}
-		if closeErr != nil {
-			return nil, closeErr
-		}
-	} else {
-		var readErr error
-		data, readErr = io.ReadAll(req.Body)
-		closeErr := req.Body.Close()
-		req.Body = io.NopCloser(bytes.NewReader(data))
-		if readErr != nil {
-			return nil, readErr
-		}
-		if closeErr != nil {
-			return nil, closeErr
-		}
-	}
-
-	builder.Write(data)
-	return []byte(builder.String()), nil
+	return builder.String()
 }
 
-func dumpResponse(rsp *http.Response, includeBody bool) ([]byte, error) {
+// dumpResponse renders one response the same way, and leaves rsp.Body readable in
+// full: only the dump is truncated.
+func dumpResponse(rsp *http.Response) string {
 	var builder strings.Builder
 	proto := rsp.Proto
 	if proto == "" {
@@ -114,81 +77,90 @@ func dumpResponse(rsp *http.Response, includeBody bool) ([]byte, error) {
 		status = fmt.Sprintf("%03d %s", rsp.StatusCode, http.StatusText(rsp.StatusCode))
 	}
 	fmt.Fprintf(&builder, "%s %s\r\n", proto, status)
-	writeSanitizedHeaders(&builder, rsp.Header)
+	writeRedactedHeaders(&builder, rsp.Header)
 	builder.WriteString("\r\n")
+	builder.WriteString(dumpResponseBody(rsp))
 
-	if !includeBody || rsp.Body == nil || rsp.Body == http.NoBody {
-		return []byte(builder.String()), nil
-	}
-
-	contentLength := rsp.ContentLength
-	data, err := io.ReadAll(rsp.Body)
-	closeErr := rsp.Body.Close()
-	rsp.Body = newReplayReadCloser(data, err, closeErr)
-	rsp.ContentLength = contentLength
-	if err != nil {
-		return nil, err
-	}
-	if closeErr != nil {
-		return nil, closeErr
-	}
-
-	builder.Write(data)
-	return []byte(builder.String()), nil
+	return builder.String()
 }
 
-func newReplayReadCloser(data []byte, readErr, closeErr error) io.ReadCloser {
-	if readErr == nil && closeErr == nil {
-		return io.NopCloser(bytes.NewReader(data))
+// dumpRequestBody renders a bounded, redacted view of the request body while
+// leaving the body the transport is about to send intact.
+//
+// GetBody is the clean path: it hands back an independent reader. Without it the
+// body is read once, bounded, and re-wrapped so the remaining bytes still stream
+// to the server.
+func dumpRequestBody(req *http.Request) string {
+	if req.Body == nil || req.Body == http.NoBody {
+		return ""
 	}
-	return &replayReadCloser{
-		reader:   bytes.NewReader(data),
-		readErr:  readErr,
-		closeErr: closeErr,
-	}
-}
 
-type replayReadCloser struct {
-	reader   *bytes.Reader
-	readErr  error
-	closeErr error
-}
-
-func (r *replayReadCloser) Read(p []byte) (int, error) {
-	n, err := r.reader.Read(p)
-	if err == io.EOF && r.readErr != nil {
-		err = r.readErr
-	}
-	return n, err
-}
-
-func (r *replayReadCloser) Close() error {
-	return r.closeErr
-}
-
-func writeSanitizedHeaders(builder *strings.Builder, headers http.Header) {
-	names := make([]string, 0, len(headers))
-	for name := range headers {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
-		// Debug logs only expose header presence; trace instrumentation can use
-		// different sanitization because it goes through controlled backends.
-		value := "[present]"
-		if isSensitiveHeader(name) {
-			value = "[REDACTED]"
+	if req.GetBody != nil {
+		rc, err := req.GetBody()
+		if err != nil {
+			return fmt.Sprintf("[failed to dump HTTP request body: %v]", err)
 		}
-		fmt.Fprintf(builder, "%s: %s\r\n", name, value)
+		defer func() { _ = rc.Close() }()
+
+		return RedactBody(rc, DefaultMaxDumpBody)
+	}
+
+	head, err := io.ReadAll(io.LimitReader(req.Body, DefaultMaxDumpBody+1))
+	req.Body = &joinReadCloser{head: head, tail: req.Body}
+	if err != nil {
+		return fmt.Sprintf("[failed to dump HTTP request body: %v]", err)
+	}
+
+	// Redact a copy: the bytes handed to the transport must be untouched.
+	return RedactBody(bytes.NewReader(head), DefaultMaxDumpBody)
+}
+
+// dumpResponseBody renders a bounded, redacted view of the response body and
+// re-wraps rsp.Body so the caller still reads every byte. That is the part a naive
+// dump gets wrong: io.ReadAll into a log line both copies an unbounded payload and
+// forces the whole body to be buffered before the caller sees any of it.
+func dumpResponseBody(rsp *http.Response) string {
+	if rsp.Body == nil || rsp.Body == http.NoBody {
+		return ""
+	}
+
+	head, err := io.ReadAll(io.LimitReader(rsp.Body, DefaultMaxDumpBody+1))
+	rsp.Body = &joinReadCloser{head: head, tail: rsp.Body}
+	if err != nil {
+		return fmt.Sprintf("[failed to dump HTTP response body: %v]", err)
+	}
+
+	// Redact a copy: the bytes handed back to the caller must be untouched.
+	return RedactBody(bytes.NewReader(head), DefaultMaxDumpBody)
+}
+
+// writeRedactedHeaders writes headers as sorted "Name: value" lines with
+// credential-bearing values masked, keeping the dump wire-shaped. RedactHeaders is
+// the single-line equivalent for callers logging structured attributes.
+func writeRedactedHeaders(builder *strings.Builder, headers http.Header) {
+	for _, name := range sortedHeaderNames(headers) {
+		fmt.Fprintf(builder, "%s: %s\r\n", name, redactedHeaderValue(headers, name))
 	}
 }
 
-func isSensitiveHeader(name string) bool {
-	switch strings.ToLower(name) {
-	case "authorization", "cookie", "proxy-authorization", "set-cookie":
-		return true
-	default:
-		return false
-	}
+// joinReadCloser serves a buffered head then the remaining tail, closing the
+// tail. It lets the dump inspect the head of a body while the caller still reads
+// it whole.
+type joinReadCloser struct {
+	head []byte
+	off  int
+	tail io.ReadCloser
 }
+
+func (j *joinReadCloser) Read(p []byte) (int, error) {
+	if j.off < len(j.head) {
+		n := copy(p, j.head[j.off:])
+		j.off += n
+
+		return n, nil
+	}
+
+	return j.tail.Read(p)
+}
+
+func (j *joinReadCloser) Close() error { return j.tail.Close() }

--- a/pkg/transport/httpclient/debug_test.go
+++ b/pkg/transport/httpclient/debug_test.go
@@ -88,6 +88,159 @@ func TestDebugHTTPTransportDoesNotPanicOnResponseDumpError(t *testing.T) {
 	require.ErrorIs(t, err, readErr)
 }
 
+// TestDebugHTTPTransportDoesNotLeakAPIKeyInPath is the end-to-end guard for the
+// finding: a connector whose credential lives in the base-URL path must not have
+// it appear in a dump. The URL is the Alchemy shape, where the API key is a path
+// segment of every request.
+func TestDebugHTTPTransportDoesNotLeakAPIKeyInPath(t *testing.T) {
+	t.Parallel()
+
+	const apiKey = "alcht_0123456789abcdefghijklmnop"
+
+	logger := &recordingLogger{debugEnabled: true}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"result":"0x1"}`)),
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://eth-mainnet.g.alchemy.com/v2/"+apiKey, strings.NewReader(`{"method":"eth_blockNumber"}`))
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	logs := strings.Join(logger.debugMessages, "\n")
+	require.NotEmpty(t, logs)
+	require.NotContains(t, logs, apiKey)
+	require.Contains(t, logs, "/v2/[REDACTED]")
+	// The dump is only worth having if the rest of it stays legible.
+	require.Contains(t, logs, "eth_blockNumber")
+}
+
+// TestDebugHTTPTransportTruncatesDumpButKeepsBodyReadable pins the part a naive
+// dump breaks: bounding the log line must not shorten what the caller decodes.
+func TestDebugHTTPTransportTruncatesDumpButKeepsBodyReadable(t *testing.T) {
+	t.Parallel()
+
+	// Far larger than the cap, so the re-wrap has both a buffered head and a tail.
+	full := strings.Repeat("y", DefaultMaxDumpBody*8)
+
+	logger := &recordingLogger{debugEnabled: true}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(full)),
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	rsp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	// The caller still reads every byte.
+	body, err := io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, full, string(body))
+	require.NoError(t, rsp.Body.Close())
+
+	// The dump does not.
+	logs := strings.Join(logger.debugMessages, "\n")
+	require.Equal(t, DefaultMaxDumpBody, strings.Count(logs, "y"))
+	require.Contains(t, logs, "...[truncated]")
+}
+
+// TestDebugHTTPTransportShowsNonSensitiveHeadersInFull pins that the dump reports
+// values rather than mere presence: a Content-Type or a rate-limit header is
+// usually the thing being looked for.
+func TestDebugHTTPTransportShowsNonSensitiveHeadersInFull(t *testing.T) {
+	t.Parallel()
+
+	const apiKey = "bitstamp-api-key-abc123"
+
+	logger := &recordingLogger{debugEnabled: true}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type":        {"application/json"},
+				"Etag":                {`W/"686897696a7c876b7e"`},
+				"Ratelimit-Remaining": {"42"},
+				"Set-Cookie":          {"session=super-secret"},
+			},
+			Body: io.NopCloser(strings.NewReader("{}")),
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", strings.NewReader("limit=10"))
+	require.NoError(t, err)
+	// Bitstamp puts "BITSTAMP <apiKey>" in a bare X-Auth, so the value is the
+	// credential; its siblings carry no secret and must stay legible.
+	req.Header.Set("X-Auth", "BITSTAMP "+apiKey)
+	req.Header.Set("X-Auth-Timestamp", "1690000000000")
+	req.Header.Set("X-Auth-Version", "v2")
+	req.Header.Set("Accept", "application/json")
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	logs := strings.Join(logger.debugMessages, "\n")
+	require.NotContains(t, logs, apiKey)
+	require.NotContains(t, logs, "super-secret")
+	require.Contains(t, logs, "X-Auth: [REDACTED]")
+	require.Contains(t, logs, "Set-Cookie: [REDACTED]")
+	for _, want := range []string{
+		"Accept: application/json",
+		"X-Auth-Timestamp: 1690000000000",
+		"X-Auth-Version: v2",
+		"Content-Type: application/json",
+		`Etag: W/"686897696a7c876b7e"`,
+		"Ratelimit-Remaining: 42",
+	} {
+		require.Contains(t, logs, want)
+	}
+	require.NotContains(t, logs, "[present]")
+}
+
+// TestDebugHTTPTransportRedactsRequestBodySecrets covers the payload half: an
+// OAuth exchange carries its credential in the body, not in a header.
+func TestDebugHTTPTransportRedactsRequestBodySecrets(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{debugEnabled: true}
+	ctx := logging.ContextWithLogger(context.Background(), logger)
+	transport := NewDebugHTTPTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		// The transport still sends the body verbatim.
+		sent, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(sent), "sk-live-secret")
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"leak-me-not","expires_in":3600}`)),
+		}, nil
+	}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com/oauth/token",
+		strings.NewReader(`{"client_secret":"sk-live-secret","grant_type":"client_credentials"}`))
+	require.NoError(t, err)
+
+	rsp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "leak-me-not")
+
+	logs := strings.Join(logger.debugMessages, "\n")
+	require.NotContains(t, logs, "sk-live-secret")
+	require.NotContains(t, logs, "leak-me-not")
+	require.Contains(t, logs, "client_credentials")
+	require.Contains(t, logs, "expires_in")
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/pkg/transport/httpclient/redact.go
+++ b/pkg/transport/httpclient/redact.go
@@ -1,0 +1,279 @@
+package httpclient
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// DefaultMaxDumpBody caps how much of a request or response body a debug dump
+// renders. A dump is a diagnostic, not an archive: the cap is what keeps a
+// 32 MiB payload from being copied into a log line.
+const DefaultMaxDumpBody = 4096
+
+// RedactedMarker replaces every masked value in a dump.
+const RedactedMarker = "[REDACTED]"
+
+// minOpaqueSegment is the length below which a path segment is never treated as
+// a credential. It is a floor, not the test: see opaqueSegment.
+const minOpaqueSegment = 16
+
+// secretKey is the shared secret-name vocabulary. Header names, query-parameter
+// names and body keys are all classified against it, so the three surfaces
+// cannot drift apart. The key matcher allows a leading word segment so
+// camelCase/compound names (clientSecret, secretAccessKey, X-CB-ACCESS-KEY) are
+// covered, not just the bare keyword.
+const secretKey = `(?:api[_-]?key|access[_-]?key|secret[_-]?access[_-]?key|client[_-]?secret|secret|passphrase|passcode|password|token|authorization|signature)`
+
+// sensitiveHeaderRe matches header NAMES whose value must never be logged. It
+// covers the standard credential carriers plus the vendor spellings connectors
+// meet in practice (X-CB-ACCESS-KEY, X-API-Key, X-Auth, X-Auth-Signature,
+// X-Auth-Nonce). TestSensitiveHeaderNames holds it against those real spellings.
+//
+// The bare-auth alternative is anchored exactly rather than matched as a prefix,
+// and that distinction is load-bearing in both directions. Bitstamp's X-Auth
+// carries "BITSTAMP <apiKey>", so the credential IS the value and the header must
+// be masked. Its siblings X-Auth-Timestamp, X-Auth-Version and
+// X-Auth-Subaccount-Id carry no secret and stay legible, while X-Auth-Signature
+// and X-Auth-Nonce are caught by the word list below.
+var sensitiveHeaderRe = regexp.MustCompile(
+	`(?i)^(?:(?:x-)?auth(?:entication)?|` +
+		`authorization|proxy-authorization|cookie|set-cookie|` +
+		`x-[a-z0-9-]*(?:key|secret|token|signature|passphrase|nonce)[a-z0-9-]*|` +
+		`[a-z0-9-]*` + secretKey + `[a-z0-9-]*)$`)
+
+// sensitiveParamRe matches query-parameter NAMES whose value must not be logged.
+// A parameter is self-describing, so it is classified by name exactly like a
+// header; only path segments need the shape heuristic below.
+var sensitiveParamRe = regexp.MustCompile(`(?i)^[a-z0-9_-]*` + secretKey + `[a-z0-9_-]*$`)
+
+// Body redaction patterns: a payload can echo back a credential it was sent (an
+// OAuth token response is exactly that), so anything that follows a
+// secret-bearing key is masked before it can reach a log line.
+var (
+	kvSecretRe     = regexp.MustCompile(`(?i)("?[a-z0-9]*` + secretKey + `"?\s*[:=]\s*")([^"]*)(")`)
+	bearerRe       = regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._\-]+`)
+	headerSecretRe = regexp.MustCompile(`(?i)((?:x-[a-z0-9-]*(?:key|secret|token|signature|passphrase)|authorization|` + secretKey + `)\s*[:=]\s*)([^\s",}]+)`)
+	// danglingSecretRe catches a secret value left unterminated at the very end
+	// of a truncated read: the closing quote lies beyond the read window, so
+	// neither kvSecretRe (needs the quote) nor headerSecretRe (quoted values)
+	// would mask it.
+	danglingSecretRe = regexp.MustCompile(`(?i)("?[a-z0-9]*` + secretKey + `"?\s*[:=]\s*"?)[^"]*$`)
+)
+
+// IsSensitiveHeader reports whether a header's VALUE is a credential and must be
+// masked before it reaches a log line. Exported so a caller with its own
+// transport or dump format reuses this vocabulary instead of re-deriving it.
+func IsSensitiveHeader(name string) bool {
+	return sensitiveHeaderRe.MatchString(name)
+}
+
+// RedactHeaders renders headers as a sorted, single-line "name: value" list with
+// credential-bearing values masked.
+//
+// Non-sensitive values are shown in full, which is the point of a dump: a
+// Content-Type, an ETag or a rate-limit header is what you are usually looking
+// for, and reducing every header to a presence marker makes the dump useless.
+func RedactHeaders(h http.Header) string {
+	if len(h) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for i, name := range sortedHeaderNames(h) {
+		if i > 0 {
+			b.WriteString("; ")
+		}
+		b.WriteString(name)
+		b.WriteString(": ")
+		b.WriteString(redactedHeaderValue(h, name))
+	}
+
+	return b.String()
+}
+
+// sortedHeaderNames returns the header names in a stable order, so two dumps of
+// the same exchange are comparable.
+func sortedHeaderNames(h http.Header) []string {
+	names := make([]string, 0, len(h))
+	for name := range h {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return names
+}
+
+// redactedHeaderValue renders one header's value, masked if the name says the
+// value is a credential. It indexes the map directly rather than going through
+// Header.Values, so a non-canonical key set by hand still resolves.
+func redactedHeaderValue(h http.Header, name string) string {
+	if IsSensitiveHeader(name) {
+		return RedactedMarker
+	}
+
+	return strings.Join(h[name], ",")
+}
+
+// RedactURL renders a URL safe to put in a log line.
+//
+// url.URL.Redacted is NOT sufficient here: it masks the userinfo password and
+// nothing else, so a credential carried in the path or the query survives it
+// verbatim. That is not hypothetical - Alchemy's base URL is
+// https://<chain>.g.alchemy.com/v2/<apiKey>, so the API key IS a path segment on
+// every JSON-RPC call, and the NFT surface rewrites it to /nft/v3/<apiKey>/...
+//
+// Three rules, matching how much each part of a URL tells us about itself:
+//   - userinfo is dropped entirely, not masked, since even the username is a
+//     credential half.
+//   - query values are masked by parameter NAME, the same way headers are, because
+//     a parameter says what it is. Cursors, limits and filters stay readable.
+//   - path segments have no name, so they are masked by shape: long plus
+//     mixed letters-and-digits means masked. This over-masks, taking opaque
+//     resource ids with it, while keeping endpoint names legible.
+//
+// Losing an id from the dump is an accepted cost: it is still in the response
+// body the dump prints, and the span carries the full URL to a controlled
+// backend. A credential in a log line is not recoverable in the same way.
+func RedactURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	if u.Scheme != "" {
+		b.WriteString(u.Scheme)
+		b.WriteString("://")
+	}
+	b.WriteString(u.Host) // userinfo deliberately omitted
+	b.WriteString(redactRequestURI(u))
+
+	return b.String()
+}
+
+// redactRequestURI renders the origin-form "path?query" of a URL with the same
+// rules as RedactURL. It is what an HTTP-shaped dump puts on the request line,
+// where the host already appears on its own Host line.
+func redactRequestURI(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+
+	out := redactPath(u.EscapedPath())
+	if q := redactQuery(u.Query()); q != "" {
+		out += "?" + q
+	}
+
+	return out
+}
+
+// redactPath masks the path segments that could be credentials.
+func redactPath(p string) string {
+	if p == "" {
+		return ""
+	}
+
+	segments := strings.Split(p, "/")
+	for i, segment := range segments {
+		if opaqueSegment(segment) {
+			segments[i] = RedactedMarker
+		}
+	}
+
+	return strings.Join(segments, "/")
+}
+
+// opaqueSegment reports whether a path segment looks like a credential.
+//
+// A path segment has no name, so the only available signal is shape. Length alone
+// is not it: real endpoint names reach 16 characters and beyond
+// (getContractMetadata, positions_paginated, withdrawal-requests, ...), and
+// masking those would hide the single most useful part of a dump.
+//
+// What separates them is digits. A credential is random, so at this length it
+// mixes digits into letters: an Alchemy key (alcht_0123456789abcdef...), a UUID
+// resource id. A name someone typed is words, and long endpoint segments are
+// letters only. So the test is long AND mixed letters-and-digits, with two
+// exemptions for shapes that cannot be credentials and that a dump most needs: a
+// 0x-prefixed chain address or transaction hash, and an all-digits id.
+//
+// The residual gap is a letters-only credential of 16 or more characters, which
+// would read as an endpoint name and survive. If a vendor issues one, mask it by
+// declaring the value rather than by widening this heuristic, which would start
+// eating endpoint names.
+func opaqueSegment(segment string) bool {
+	if len(segment) < minOpaqueSegment {
+		return false
+	}
+	if strings.HasPrefix(segment, "0x") || strings.HasPrefix(segment, "0X") {
+		return false
+	}
+
+	var hasDigit, hasLetter bool
+	for _, r := range segment {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+			hasLetter = true
+		}
+	}
+
+	return hasDigit && hasLetter
+}
+
+// redactQuery re-encodes a query with credential-bearing values masked by name.
+func redactQuery(q url.Values) string {
+	if len(q) == 0 {
+		return ""
+	}
+
+	out := make(url.Values, len(q))
+	for name, values := range q {
+		if sensitiveParamRe.MatchString(name) {
+			out[name] = []string{RedactedMarker}
+
+			continue
+		}
+		out[name] = values
+	}
+
+	return out.Encode()
+}
+
+// RedactBody reads at most maxBytes of a body and returns it trimmed,
+// secret-redacted, and marked when truncated. A non-positive maxBytes uses
+// DefaultMaxDumpBody. Redaction runs on the full read buffer BEFORE the display
+// cut: truncating first would slice a secret in half and leave the visible head
+// unmatched by every pattern.
+//
+// The reader is bounded here rather than by the caller, so a dump of a 32 MiB
+// response never materialises more than the cap.
+func RedactBody(r io.Reader, maxBytes int) string {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxDumpBody
+	}
+	data, _ := io.ReadAll(io.LimitReader(r, int64(maxBytes)+1))
+	truncated := len(data) > maxBytes
+	if truncated {
+		// The read window itself may have cut a value: mask an unterminated
+		// secret at the buffer tail before the pattern passes.
+		data = danglingSecretRe.ReplaceAll(data, []byte("${1}"+RedactedMarker))
+	}
+
+	out := kvSecretRe.ReplaceAll(data, []byte("${1}"+RedactedMarker+"${3}"))
+	out = bearerRe.ReplaceAll(out, []byte("${1}"+RedactedMarker))
+	out = headerSecretRe.ReplaceAll(out, []byte("${1}"+RedactedMarker))
+	s := strings.TrimSpace(string(out))
+	if truncated {
+		if len(s) > maxBytes {
+			s = s[:maxBytes]
+		}
+		s += "...[truncated]"
+	}
+
+	return s
+}

--- a/pkg/transport/httpclient/redact_test.go
+++ b/pkg/transport/httpclient/redact_test.go
@@ -1,0 +1,243 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRedactURL pins URL redaction against the shapes connectors actually send.
+// url.URL.Redacted masks only the userinfo password, so a credential in the path
+// or query survives it: Alchemy carries its API key as a path segment on every
+// call, which is the case this exists for.
+func TestRedactURL(t *testing.T) {
+	t.Parallel()
+
+	const alchemyKey = "abcdef0123456789abcdef0123456789"
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "alchemy json-rpc key in the path",
+			raw:  "https://eth-mainnet.g.alchemy.com/v2/" + alchemyKey,
+			want: "https://eth-mainnet.g.alchemy.com/v2/[REDACTED]",
+		},
+		{
+			name: "alchemy nft key in the path, address kept",
+			raw:  "https://eth-mainnet.g.alchemy.com/nft/v3/" + alchemyKey + "/getContractMetadata?contractAddress=0xdac17f958d2ee523a2206206994597c13d831ec7",
+			want: "https://eth-mainnet.g.alchemy.com/nft/v3/[REDACTED]/getContractMetadata?contractAddress=0xdac17f958d2ee523a2206206994597c13d831ec7",
+		},
+		{
+			name: "credential query parameter masked by name",
+			raw:  "https://api.example.com/v1/things?api_key=sk-live-secret&limit=10",
+			want: "https://api.example.com/v1/things?api_key=%5BREDACTED%5D&limit=10",
+		},
+		{
+			name: "access_token masked by name",
+			raw:  "https://api.example.com/v1/things?access_token=tok-secret",
+			want: "https://api.example.com/v1/things?access_token=%5BREDACTED%5D",
+		},
+		{
+			name: "userinfo dropped entirely, not masked to user:xxxxx",
+			raw:  "https://svcuser:svcpass@api.example.com/v1/things",
+			want: "https://api.example.com/v1/things",
+		},
+		{
+			name: "ordinary endpoint path untouched",
+			raw:  "https://api.circle.com/v1/businessAccount/deposits",
+			want: "https://api.circle.com/v1/businessAccount/deposits",
+		},
+		{
+			name: "long endpoint names survive: masking those would gut the dump",
+			raw:  "https://api.example.com/v1/positions_paginated/withdrawal-requests",
+			want: "https://api.example.com/v1/positions_paginated/withdrawal-requests",
+		},
+		{
+			name: "chain hash kept: it cannot be a credential and is what you need",
+			raw:  "https://eth-mainnet.g.alchemy.com/v2/" + alchemyKey + "/tx/0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b",
+			want: "https://eth-mainnet.g.alchemy.com/v2/[REDACTED]/tx/0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b",
+		},
+		{
+			name: "numeric id kept",
+			raw:  "https://api.example.com/v1/accounts/1234567890123456789",
+			want: "https://api.example.com/v1/accounts/1234567890123456789",
+		},
+		{
+			name: "opaque resource id masked, which over-masks on purpose",
+			raw:  "https://api.circle.com/v1/businessAccount/deposits/b8627ae4-4c4b-4b1a-8d4e-2f0e6a9a1c33",
+			want: "https://api.circle.com/v1/businessAccount/deposits/[REDACTED]",
+		},
+		{
+			name: "cursor stays readable: a parameter says what it is",
+			raw:  "https://api.example.com/v1/things?cursor=eyJpZCI6ImFiYzEyMyJ9&pageSize=100",
+			want: "https://api.example.com/v1/things?cursor=eyJpZCI6ImFiYzEyMyJ9&pageSize=100",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tc.raw)
+			require.NoError(t, err)
+
+			got := RedactURL(u)
+			require.Equal(t, tc.want, got)
+			// Whatever the rule, the key must never survive.
+			require.NotContains(t, got, alchemyKey)
+		})
+	}
+}
+
+func TestRedactURLNil(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, RedactURL(nil))
+}
+
+// TestSensitiveHeaderNames pins the classifier, since a miss here is a credential
+// in a log file. The tables are the vendor spellings connectors actually set,
+// split by whether the VALUE is a secret.
+//
+// X-Auth is the case that motivated grounding this in a real inventory rather than
+// in plausible-looking examples: it reads like the harmless prefix of
+// X-Auth-Timestamp, but Bitstamp sets it to "BITSTAMP <apiKey>", so the value IS
+// the credential.
+func TestSensitiveHeaderNames(t *testing.T) {
+	t.Parallel()
+
+	// Credential-bearing vendor spellings in use today.
+	sensitive := []string{
+		"Authorization",          // apideck, circle, formancepayments, fireblocks
+		"X-Api-Key",              // fireblocks
+		"X-API-Key",              // same header, vendor casing
+		"X-Auth",                 // bitstamp: "BITSTAMP <apiKey>"
+		"X-Auth-Signature",       // bitstamp HMAC
+		"X-Auth-Nonce",           // bitstamp single-use nonce
+		"X-Nonce",                // coinbaseprime
+		"X-Cb-Access-Key",        // coinbaseprime
+		"X-CB-ACCESS-KEY",        // same header, vendor casing
+		"X-Cb-Access-Passphrase", //
+		"X-Cb-Access-Signature",  //
+		// Shapes not in use yet but cheap to keep covered, so a new connector
+		// spelling does not arrive unmasked.
+		"authorization", "Proxy-Authorization", "Cookie", "Set-Cookie",
+		"Auth", "X-Authentication", "X-Authorization",
+		"Api-Key", "Client-Secret", "Secret-Access-Key", "Passphrase",
+		"X-Fireblocks-Api-Key", "X-Ratelimit-Token",
+	}
+	// Not secret, and a dump is worth less without them.
+	safe := []string{
+		"Accept",               // every connector
+		"Content-Type",         // bitstamp, alchemy, circle, formancepayments
+		"X-Auth-Timestamp",     // bitstamp: signed, not secret
+		"X-Auth-Version",       // bitstamp
+		"X-Auth-Subaccount-Id", // bitstamp: a scope, not a credential
+		"X-Cb-Access-Timestamp",
+		"X-Consumer-Id", // apideck per-call header
+		"X-Apideck-App-Id",
+		"Ratelimit-Remaining", "Ratelimit-Reset", "Retry-After",
+		"X-Request-Id", "Etag", "Content-Length", "User-Agent",
+	}
+
+	for _, name := range sensitive {
+		require.True(t, IsSensitiveHeader(name),
+			"%q not classified as sensitive: its value would reach the log", name)
+	}
+	for _, name := range safe {
+		require.False(t, IsSensitiveHeader(name),
+			"%q wrongly classified as sensitive, which makes dumps less useful", name)
+	}
+}
+
+// TestRedactHeadersShowsNonSensitiveValuesInFull pins the second half of the
+// contract: masking credentials is worth nothing if it costs every other value.
+func TestRedactHeadersShowsNonSensitiveValuesInFull(t *testing.T) {
+	t.Parallel()
+
+	got := RedactHeaders(http.Header{
+		"Authorization":        {"Bearer super-secret-token"},
+		"X-Auth":               {"BITSTAMP api-key-abc123"},
+		"X-Auth-Version":       {"v2"},
+		"Content-Type":         {"application/json"},
+		"Etag":                 {`W/"686897696a7c876b7e"`},
+		"Ratelimit-Remaining":  {"42"},
+		"X-Multi":              {"one", "two"},
+		"X-Auth-Subaccount-Id": {"sub-42"},
+	})
+
+	require.Equal(t, strings.Join([]string{
+		"Authorization: [REDACTED]",
+		`Content-Type: application/json`,
+		`Etag: W/"686897696a7c876b7e"`,
+		"Ratelimit-Remaining: 42",
+		"X-Auth: [REDACTED]",
+		"X-Auth-Subaccount-Id: sub-42",
+		"X-Auth-Version: v2",
+		"X-Multi: one,two",
+	}, "; "), got)
+	require.NotContains(t, got, "super-secret-token")
+	require.NotContains(t, got, "api-key-abc123")
+}
+
+func TestRedactHeadersEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, RedactHeaders(nil))
+}
+
+// TestRedactBody covers the two things a body dump owes: it must not echo a
+// credential the payload carries, and it must stop at the cap.
+func TestRedactBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("masks secrets by key name", func(t *testing.T) {
+		t.Parallel()
+
+		got := RedactBody(strings.NewReader(
+			`{"data":[{"id":"txn-1"}],"session_token":"leak-me-not","access_token":"also-not"}`,
+		), DefaultMaxDumpBody)
+
+		require.NotContains(t, got, "leak-me-not")
+		require.NotContains(t, got, "also-not")
+		// The useful part of the payload survives.
+		require.Contains(t, got, "txn-1")
+	})
+
+	t.Run("masks a bearer token echoed in an error body", func(t *testing.T) {
+		t.Parallel()
+
+		got := RedactBody(strings.NewReader(`invalid header "Bearer abc.def-123"`), DefaultMaxDumpBody)
+		require.NotContains(t, got, "abc.def-123")
+	})
+
+	t.Run("stops at the cap and says so", func(t *testing.T) {
+		t.Parallel()
+
+		got := RedactBody(strings.NewReader(strings.Repeat("y", DefaultMaxDumpBody*8)), DefaultMaxDumpBody)
+		require.True(t, strings.HasSuffix(got, "...[truncated]"))
+		require.Equal(t, DefaultMaxDumpBody, strings.Count(got, "y"))
+	})
+
+	t.Run("masks a secret the cap cut in half", func(t *testing.T) {
+		t.Parallel()
+
+		// The value runs past the read window, so its closing quote is never seen.
+		body := `{"pad":"` + strings.Repeat("p", DefaultMaxDumpBody-24) + `","api_key":"` + strings.Repeat("s", 64) + `"}`
+		got := RedactBody(strings.NewReader(body), DefaultMaxDumpBody)
+		require.NotContains(t, got, strings.Repeat("s", 8))
+	})
+
+	t.Run("non-positive cap falls back to the default", func(t *testing.T) {
+		t.Parallel()
+
+		got := RedactBody(strings.NewReader(strings.Repeat("z", DefaultMaxDumpBody*2)), 0)
+		require.Equal(t, DefaultMaxDumpBody, strings.Count(got, "z"))
+	})
+}


### PR DESCRIPTION
## Why

`NewDebugHTTPTransport` has three properties that make it unsafe or unusable for a connector talking to third-party APIs.

**URLs are not redacted at all.** `dumpRequest` writes `req.URL.RequestURI()` verbatim, so a credential carried in the path or the query lands in the log in full. This is not hypothetical: Alchemy's base URL is `https://<chain>.g.alchemy.com/v2/<apiKey>`, so the API key is a path segment on every request, and enabling debug logging writes it to disk. `url.URL.Redacted()` is not sufficient — it masks the userinfo password and nothing else.

**Bodies are read whole into a log line.** `io.ReadAll` on the body means a 32 MiB response becomes a 32 MiB log line.

**Every non-sensitive header is reduced to `[present]`**, which makes the dump nearly useless — `Content-Type`, `ETag` and the rate-limit headers are usually exactly what you are looking for. The sensitive set was four literals, missing every vendor spelling in practice.

## What changed

New `redact.go` holds the redaction layer, exporting `RedactURL`, `RedactHeaders`, `IsSensitiveHeader` and `RedactBody` (plus `RedactedMarker` / `DefaultMaxDumpBody`) so callers with their own transports reuse the vocabulary instead of re-deriving it.

**1. URL redaction, by the amount each part tells you about itself**

- userinfo: dropped entirely, not masked — even the username is half a credential.
- query: masked by parameter name, the same way headers are. Cursors, limits and filters stay readable, which is what makes a dump useful.
- path segments: no name available, so masked by shape — long **and** mixing letters with digits. Length alone is wrong: real endpoint names reach 16+ characters (`getContractMetadata`, `positions_paginated`, `withdrawal-requests`) and masking those hides the most useful part of the dump. What separates a credential is that it is random. `0x`-prefixed values (chain addresses, tx hashes) and all-digit ids are exempt.

This over-masks — opaque resource ids get caught too. That is the right trade: a lost id is still in the response body the dump prints and in the span sent to a controlled backend; a credential in a log line is not recoverable in the same way.

**2. Bounded bodies, still replayable in full**

Dumps are capped at 4 KiB via `io.LimitReader` and marked `...[truncated]`. `resp.Body` is re-wrapped with a `joinReadCloser` (buffered head, then tail) so the caller still reads every byte — only the dump is truncated. The request path reads through `GetBody` when available and uses the same re-wrap otherwise.

**3. Headers show their values**

`[present]` is gone; non-sensitive values print in full. The sensitive set is now a pattern over name/secret vocabulary (\`key|secret|token|signature|passphrase|nonce\`), with the bare-auth alternative **anchored exactly** rather than as a prefix. That distinction is load-bearing in both directions: Bitstamp sets \`X-Auth\` to \`BITSTAMP <apiKey>\`, so the value *is* the credential and must be masked, while its harmless siblings \`X-Auth-Timestamp\` and \`X-Auth-Version\` stay legible.

Ported from `formancehq/connectivity-plugins` `internal/httpx/debug.go`, keeping the comments explaining why each heuristic is shaped the way it is.

## Reviewer notes

- **Scope call worth a look:** request and response bodies also go through the same secret-name vocabulary (`kvSecretRe` / `bearerRe` / `headerSecretRe`), which is beyond the three items above. An OAuth token exchange carries its credential in the body rather than a header, and the vocabulary was needed for headers and query params anyway. Easy to drop if you'd rather bodies dumped raw-but-bounded.
- **Behaviour change:** dumping no longer fails the request. A body that cannot be read is recorded inline in the dump instead of being returned as a `RoundTrip` error.
- `pkg/transport/httpclient` stays Layer 2; no new dependency beyond stdlib.

## Not fixed here

Two more copies of the same three problems exist elsewhere and are left alone as out of scope:

- `pkg/observe/http_client.go` — near-identical dump code on the tracing transport, with all three problems. It is **Layer 1**, so per \`docs/ARCHITECTURE.md\` it cannot import these new Layer 2 helpers; fixing it means moving the redactor down a layer or duplicating it, which is a call worth making deliberately.
- `pkg/transport/httpserver/otlp_middleware.go:164` — the same four-literal sensitive set. Layer 2, so it can call \`httpclient.IsSensitiveHeader\` directly.

Also unrelated but worth knowing: `golangci-lint --fix` deterministically corrupts `pkg/storage/bun/paginate/pagination_column.go`, rewriting \`reflect.Ptr\` into \`reflect.Pointernternter\` and breaking \`go build ./...\`. That file is reverted and not part of this PR; reproduce on a clean tree with \`just lint && git diff\`.

## Tests

15 tests, all green under `-race`; the three pre-existing tests pass unmodified.

- `TestDebugHTTPTransportDoesNotLeakAPIKeyInPath` — Alchemy-shaped URL, key absent from the dump, `/v2/[REDACTED]` present and the rest of the dump still legible.
- `TestDebugHTTPTransportTruncatesDumpButKeepsBodyReadable` — body 8× the cap: dump holds exactly `DefaultMaxDumpBody` bytes, caller reads all of it.
- `TestSensitiveHeaderNames` — table of real vendor spellings, including bare `X-Auth` masked and `X-Auth-Timestamp` not.
- `TestDebugHTTPTransportShowsNonSensitiveHeadersInFull` — values in full, no `[present]`.
- `TestRedactURL` — 11 cases covering userinfo, query params, chain hashes, numeric ids and long endpoint names.

`just pre-commit` reports 0 issues.