### PR TITLE
fix(service): reject malformed selected env configuration (EN-1922)

### DIFF
--- a/pkg/service/execute.go
+++ b/pkg/service/execute.go
@@ -4,11 +4,72 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func Execute(cmd *cobra.Command) {
-	BindEnvToCommand(cmd)
+	bindEnvForExecute(cmd)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
+	}
+}
+
+// bindEnvForExecute preserves the existing early environment binding so Cobra
+// initializers can observe valid values. Parse failures are deferred until
+// argument validation, after Cobra has marked explicit CLI flags Changed. A
+// malformed environment value therefore fails only when no higher-precedence
+// CLI value replaced it, and always before pre-run or run hooks start service
+// components.
+func bindEnvForExecute(cmd *cobra.Command) {
+	bindingErrors := make(map[*pflag.Flag]error)
+	bindEnvToCommandWithDeferredErrors(cmd, bindingErrors)
+	rejectSelectedEnvErrorsBeforeRun(cmd, bindingErrors)
+}
+
+func bindEnvToCommandWithDeferredErrors(cmd *cobra.Command, bindingErrors map[*pflag.Flag]error) {
+	bindEnvToFlagSetWithDeferredErrors(cmd.Flags(), bindingErrors)
+	bindEnvToFlagSetWithDeferredErrors(cmd.PersistentFlags(), bindingErrors)
+
+	for _, subCmd := range cmd.Commands() {
+		bindEnvToCommandWithDeferredErrors(subCmd, bindingErrors)
+	}
+}
+
+func bindEnvToFlagSetWithDeferredErrors(set *pflag.FlagSet, bindingErrors map[*pflag.Flag]error) {
+	set.VisitAll(func(flag *pflag.Flag) {
+		if flag.Changed {
+			return
+		}
+		if _, alreadyBound := bindingErrors[flag]; alreadyBound {
+			return
+		}
+		if err := bindEnvToFlag(set, flag); err != nil {
+			bindingErrors[flag] = err
+		}
+	})
+}
+
+func rejectSelectedEnvErrorsBeforeRun(cmd *cobra.Command, bindingErrors map[*pflag.Flag]error) {
+	originalArgs := cmd.Args
+	cmd.Args = func(cmd *cobra.Command, args []string) error {
+		var selectedError error
+		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			if selectedError != nil || flag.Changed {
+				return
+			}
+			selectedError = bindingErrors[flag]
+		})
+		if selectedError != nil {
+			return selectedError
+		}
+		if originalArgs != nil {
+			return originalArgs(cmd, args)
+		}
+
+		return nil
+	}
+
+	for _, subCmd := range cmd.Commands() {
+		rejectSelectedEnvErrorsBeforeRun(subCmd, bindingErrors)
 	}
 }

--- a/pkg/service/execute_test.go
+++ b/pkg/service/execute_test.go
@@ -11,9 +11,17 @@ func TestBindEnvBeforeRunRejectsMalformedSelectedEnvironment(t *testing.T) {
 	t.Setenv("GRPC_PORT", "not-an-integer")
 
 	runCalled := false
+	persistentPreRunCalled := false
+	preRunCalled := false
 	root := &cobra.Command{Use: "service"}
+	root.PersistentPreRun = func(*cobra.Command, []string) {
+		persistentPreRunCalled = true
+	}
 	run := &cobra.Command{
 		Use: "run",
+		PreRun: func(*cobra.Command, []string) {
+			preRunCalled = true
+		},
 		Run: func(*cobra.Command, []string) {
 			runCalled = true
 		},
@@ -30,6 +38,8 @@ func TestBindEnvBeforeRunRejectsMalformedSelectedEnvironment(t *testing.T) {
 	require.ErrorContains(t, err, "GRPC_PORT")
 	require.ErrorContains(t, err, "--grpc-port")
 	require.False(t, runCalled)
+	require.False(t, persistentPreRunCalled)
+	require.False(t, preRunCalled)
 }
 
 func TestBindEnvBeforeRunPreservesExplicitFlagPrecedence(t *testing.T) {

--- a/pkg/service/execute_test.go
+++ b/pkg/service/execute_test.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindEnvBeforeRunRejectsMalformedSelectedEnvironment(t *testing.T) {
+	t.Setenv("GRPC_PORT", "not-an-integer")
+
+	runCalled := false
+	root := &cobra.Command{Use: "service"}
+	run := &cobra.Command{
+		Use: "run",
+		Run: func(*cobra.Command, []string) {
+			runCalled = true
+		},
+	}
+	run.Flags().Int("grpc-port", 8888, "")
+	root.AddCommand(run)
+	root.SetArgs([]string{"run"})
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	bindEnvForExecute(root)
+	err := root.Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "GRPC_PORT")
+	require.ErrorContains(t, err, "--grpc-port")
+	require.False(t, runCalled)
+}
+
+func TestBindEnvBeforeRunPreservesExplicitFlagPrecedence(t *testing.T) {
+	t.Setenv("GRPC_PORT", "not-an-integer")
+
+	var effectivePort int
+	root := &cobra.Command{Use: "service"}
+	run := &cobra.Command{
+		Use: "run",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var err error
+			effectivePort, err = cmd.Flags().GetInt("grpc-port")
+
+			return err
+		},
+	}
+	run.Flags().Int("grpc-port", 8888, "")
+	root.AddCommand(run)
+	root.SetArgs([]string{"run", "--grpc-port", "9999"})
+
+	bindEnvForExecute(root)
+	require.NoError(t, root.Execute())
+	require.Equal(t, 9999, effectivePort)
+}
+
+func TestBindEnvForExecuteBindsValidEnvironmentBeforeExecution(t *testing.T) {
+	t.Setenv("GRPC_PORT", "9999")
+
+	root := &cobra.Command{Use: "service"}
+	run := &cobra.Command{Use: "run", Run: func(*cobra.Command, []string) {}}
+	run.Flags().Int("grpc-port", 8888, "")
+	root.AddCommand(run)
+
+	bindEnvForExecute(root)
+	port, err := run.Flags().GetInt("grpc-port")
+	require.NoError(t, err)
+	require.Equal(t, 9999, port)
+}
+
+func TestBindEnvBeforeRunIgnoresMalformedEnvironmentForUnselectedCommand(t *testing.T) {
+	t.Setenv("GRPC_PORT", "not-an-integer")
+
+	root := &cobra.Command{Use: "service"}
+	run := &cobra.Command{Use: "run", Run: func(*cobra.Command, []string) {}}
+	run.Flags().Int("grpc-port", 8888, "")
+	versionCalled := false
+	version := &cobra.Command{
+		Use: "version",
+		Run: func(*cobra.Command, []string) {
+			versionCalled = true
+		},
+	}
+	root.AddCommand(run, version)
+	root.SetArgs([]string{"version"})
+
+	bindEnvForExecute(root)
+	require.NoError(t, root.Execute())
+	require.True(t, versionCalled)
+}

--- a/pkg/service/flags.go
+++ b/pkg/service/flags.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -8,6 +9,11 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// BindEnvToCommand binds environment variables to every flag registered on cmd
+// and its descendants.
+//
+// Deprecated: use BindEnvToCommandWithError so malformed typed values can be
+// reported instead of ignored.
 func BindEnvToCommand(cmd *cobra.Command) {
 	BindEnvToFlagSet(cmd.Flags())
 	BindEnvToFlagSet(cmd.PersistentFlags())
@@ -17,28 +23,81 @@ func BindEnvToCommand(cmd *cobra.Command) {
 	}
 }
 
-func BindEnvToFlagSet(set *pflag.FlagSet) {
-	set.VisitAll(func(flag *pflag.Flag) {
-		envVar := strings.ToUpper(flag.Name)
-		envVar = strings.Replace(envVar, "-", "_", -1)
-		// DEBUG is commonly set by tooling and shells; keep debug mode explicit.
-		if flag.Name == DebugFlag && envVar == "DEBUG" {
-			return
-		}
-		value := os.Getenv(envVar)
-		if value == "" {
-			return
-		}
-		value = strings.Trim(value, " ")
-		switch flag.Value.Type() {
-		case "stringSlice":
-			if strings.Contains(value, " ") {
-				value = strings.Replace(value, " ", ",", -1)
-			}
-		}
+// BindEnvToCommandWithError binds environment variables to every flag
+// registered on cmd and its descendants. Explicitly changed flags are left
+// untouched so command-line values retain precedence over environment values.
+func BindEnvToCommandWithError(cmd *cobra.Command) error {
+	if err := BindEnvToFlagSetWithError(cmd.Flags()); err != nil {
+		return err
+	}
+	if err := BindEnvToFlagSetWithError(cmd.PersistentFlags()); err != nil {
+		return err
+	}
 
-		if err := set.Set(flag.Name, value); err != nil {
+	for _, subCmd := range cmd.Commands() {
+		if err := BindEnvToCommandWithError(subCmd); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BindEnvToFlagSet binds environment variables to flags in set.
+//
+// Deprecated: use BindEnvToFlagSetWithError so malformed typed values can be
+// reported instead of ignored.
+func BindEnvToFlagSet(set *pflag.FlagSet) {
+	_ = bindEnvToFlagSet(set, false)
+}
+
+// BindEnvToFlagSetWithError binds environment variables to flags in set.
+// Explicitly changed flags are left untouched so command-line values retain
+// precedence over environment values.
+func BindEnvToFlagSetWithError(set *pflag.FlagSet) error {
+	return bindEnvToFlagSet(set, true)
+}
+
+func bindEnvToFlagSet(set *pflag.FlagSet, failFast bool) error {
+	var bindingErr error
+	set.VisitAll(func(flag *pflag.Flag) {
+		if bindingErr != nil || flag.Changed {
+			return
+		}
+		if err := bindEnvToFlag(set, flag); err != nil {
+			if failFast {
+				bindingErr = err
+			}
+
 			return
 		}
 	})
+
+	return bindingErr
+}
+
+func bindEnvToFlag(set *pflag.FlagSet, flag *pflag.Flag) error {
+	envVar := strings.ToUpper(flag.Name)
+	envVar = strings.Replace(envVar, "-", "_", -1)
+	// DEBUG is commonly set by tooling and shells; keep debug mode explicit.
+	if flag.Name == DebugFlag && envVar == "DEBUG" {
+		return nil
+	}
+	value := os.Getenv(envVar)
+	if value == "" {
+		return nil
+	}
+	value = strings.Trim(value, " ")
+	switch flag.Value.Type() {
+	case "stringSlice":
+		if strings.Contains(value, " ") {
+			value = strings.Replace(value, " ", ",", -1)
+		}
+	}
+
+	if err := set.Set(flag.Name, value); err != nil {
+		return fmt.Errorf("binding environment variable %s to flag --%s: %w", envVar, flag.Name, err)
+	}
+
+	return nil
 }

--- a/pkg/service/flags.go
+++ b/pkg/service/flags.go
@@ -24,8 +24,12 @@ func BindEnvToCommand(cmd *cobra.Command) {
 }
 
 // BindEnvToCommandWithError binds environment variables to every flag
-// registered on cmd and its descendants. Explicitly changed flags are left
-// untouched so command-line values retain precedence over environment values.
+// registered on cmd and its descendants. Call it after Cobra has parsed
+// command-line arguments; explicitly changed flags are then left untouched so
+// command-line values retain precedence over environment values. Callers using
+// service.Execute should use Execute's integrated binding instead, which keeps
+// environment values available during command initialization while deferring
+// malformed-value rejection until after CLI parsing.
 func BindEnvToCommandWithError(cmd *cobra.Command) error {
 	if err := BindEnvToFlagSetWithError(cmd.Flags()); err != nil {
 		return err
@@ -51,9 +55,11 @@ func BindEnvToFlagSet(set *pflag.FlagSet) {
 	_ = bindEnvToFlagSet(set, false)
 }
 
-// BindEnvToFlagSetWithError binds environment variables to flags in set.
-// Explicitly changed flags are left untouched so command-line values retain
-// precedence over environment values.
+// BindEnvToFlagSetWithError binds environment variables to flags in set. Call
+// it after parsing command-line arguments; explicitly changed flags are then
+// left untouched so command-line values retain precedence over environment
+// values. Callers using service.Execute should use Execute's integrated
+// binding instead.
 func BindEnvToFlagSetWithError(set *pflag.FlagSet) error {
 	return bindEnvToFlagSet(set, true)
 }

--- a/pkg/service/flags_test.go
+++ b/pkg/service/flags_test.go
@@ -74,9 +74,11 @@ func TestBindEnvToFlagSetStillBindsNonDebugEnv(t *testing.T) {
 
 func TestBindEnvToFlagSetIgnoresInvalidEnvValue(t *testing.T) {
 	t.Setenv("ENABLED", "not-a-bool")
+	t.Setenv("ROOT1", "changed")
 
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	flags.Bool("enabled", false, "")
+	flags.String("root1", "default", "")
 
 	require.NotPanics(t, func() {
 		BindEnvToFlagSet(flags)
@@ -85,4 +87,90 @@ func TestBindEnvToFlagSetIgnoresInvalidEnvValue(t *testing.T) {
 	enabled, err := flags.GetBool("enabled")
 	require.NoError(t, err)
 	require.False(t, enabled)
+	root1, err := flags.GetString("root1")
+	require.NoError(t, err)
+	require.Equal(t, "changed", root1)
+}
+
+func TestBindEnvToFlagSetWithErrorRejectsMalformedTypedValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		envVar     string
+		value      string
+		flagName   string
+		register   func(*pflag.FlagSet)
+		errorMatch string
+	}{
+		{
+			name:     "integer",
+			envVar:   "GRPC_PORT",
+			value:    "not-an-integer",
+			flagName: "grpc-port",
+			register: func(flags *pflag.FlagSet) {
+				flags.Int("grpc-port", 8888, "")
+			},
+			errorMatch: "invalid syntax",
+		},
+		{
+			name:     "boolean",
+			envVar:   "ENABLED",
+			value:    "not-a-boolean",
+			flagName: "enabled",
+			register: func(flags *pflag.FlagSet) {
+				flags.Bool("enabled", false, "")
+			},
+			errorMatch: "invalid syntax",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(tt.envVar, tt.value)
+
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			tt.register(flags)
+
+			err := BindEnvToFlagSetWithError(flags)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.envVar)
+			require.ErrorContains(t, err, "--"+tt.flagName)
+			require.ErrorContains(t, err, tt.value)
+			require.ErrorContains(t, err, tt.errorMatch)
+		})
+	}
+}
+
+func TestBindEnvToFlagSetWithErrorAppliesValidValue(t *testing.T) {
+	t.Setenv("GRPC_PORT", "9999")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Int("grpc-port", 8888, "")
+
+	require.NoError(t, BindEnvToFlagSetWithError(flags))
+	value, err := flags.GetInt("grpc-port")
+	require.NoError(t, err)
+	require.Equal(t, 9999, value)
+}
+
+func TestBindEnvToFlagSetWithErrorRetainsDefaultWhenUnset(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Int("grpc-port", 8888, "")
+
+	require.NoError(t, BindEnvToFlagSetWithError(flags))
+	value, err := flags.GetInt("grpc-port")
+	require.NoError(t, err)
+	require.Equal(t, 8888, value)
+}
+
+func TestBindEnvToFlagSetWithErrorPrefersExplicitFlag(t *testing.T) {
+	t.Setenv("GRPC_PORT", "not-an-integer")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Int("grpc-port", 8888, "")
+	require.NoError(t, flags.Parse([]string{"--grpc-port", "9999"}))
+
+	require.NoError(t, BindEnvToFlagSetWithError(flags))
+	value, err := flags.GetInt("grpc-port")
+	require.NoError(t, err)
+	require.Equal(t, 9999, value)
 }


### PR DESCRIPTION
## Traceability

- Jira: EN-1922
- Native audit finding: `process-boundary-recovery/malformed-env-falls-back-to-default`
- Challenge status: CONFIRMED
- Ledger target base: `23b4f498138b3ca222b52533fb683830fac38149`

## Product / operational motivation

Need: documented typed environment configuration must fail clearly before service readiness when the selected value is malformed.

Current limitation: `BindEnvToFlagSet` discards `pflag.Set` errors. In the untouched Ledger production process, `GRPC_PORT=not-an-integer` continued through listener startup; with pflag v1.0.10 the effective value became `0` and Ledger opened an ephemeral gRPC listener. A malformed boolean likewise retained its valid `false` default and startup continued.

Requirement: selected malformed environment values return an actionable error before pre-run/run hooks. Existing precedence remains explicit CLI flag > environment > default, so a malformed lower-precedence environment value is ignored when the same flag has an explicit valid CLI value.

Durable evidence: strict binder API comments and process-order contract in `pkg/service/execute.go`; permanent unit coverage in `pkg/service/flags_test.go` and `pkg/service/execute_test.go`.

## Technical decision

Decision: add narrow error-returning binder variants while retaining the existing void wrappers for source compatibility. `service.Execute` keeps valid environment binding at its existing early point, records typed parse failures, and rejects failures for the selected command after Cobra has parsed explicit CLI flags but before pre-run/run hooks.

Why proportionate: the defect is in the shared service binder and all `service.Execute` consumers need the same fail-closed boundary. This avoids a breaking signature change to exported v5 APIs.

Alternatives considered:

- Ledger-only validation was rejected because it would duplicate a shared parser defect.
- Changing the existing exported void signatures was rejected as an unnecessary source-compatibility break.
- Binding only after CLI parsing was rejected because it would make valid environment values unavailable to Cobra initializers.

## Validation

- `go test -race ./pkg/service -count=1`
- `just pre-commit`
- `just tests` (full race-enabled go-libs suite)
- Ledger production-boundary regression passes through `main -> service.Execute -> server.NewRootCommand`
- Real fixed Ledger process exits 1 with `binding environment variable GRPC_PORT to flag --grpc-port`, emits no startup markers, and creates no WAL/data directories
- Mutation sensitivity: restoring the discarded error makes the Ledger regression fail

## Dependency ordering

This PR is the shared prerequisite for the focused Ledger EN-1922 dependency update. It is based on the v5.7.0 code Ledger currently consumes, and its PR diff contains no pyroscope implementation or Ledger PR #1798 work.

Risk: MEDIUM — shared startup behavior changes only for malformed selected typed environment values; explicit CLI precedence, valid environment values, unset defaults, and the compatibility wrappers are covered.

Do not merge automatically.